### PR TITLE
feat: add support for multiple sources in Application manifest

### DIFF
--- a/cmd/argo-compare/cli.go
+++ b/cmd/argo-compare/cli.go
@@ -33,10 +33,11 @@ type DropCache bool
 
 func (d *DropCache) BeforeApply(app *kong.Kong) error {
 	fmt.Printf("===> Purging cache directory: %s\n", cacheDir)
-	err := os.RemoveAll(cacheDir)
-	if err != nil {
+
+	if err := os.RemoveAll(cacheDir); err != nil {
 		return err
 	}
+
 	app.Exit(0)
 	return nil
 }

--- a/cmd/argo-compare/compare.go
+++ b/cmd/argo-compare/compare.go
@@ -16,8 +16,8 @@ import (
 )
 
 type File struct {
-	Name string `diff:"name"`
-	Sha  string `diff:"sha"`
+	Name string
+	Sha  string
 }
 
 type Compare struct {

--- a/cmd/argo-compare/main.go
+++ b/cmd/argo-compare/main.go
@@ -71,17 +71,13 @@ func processFiles(fileName string, fileType string, application m.Application) e
 		}
 	}
 
-	if len(target.App.Spec.Source.Chart) == 0 {
-		return unsupportedAppConfiguration
-	}
-
-	target.writeValuesYaml()
+	target.generateValuesFiles()
 	if err := target.collectHelmChart(); err != nil {
 		return err
 	}
 
 	target.extractChart()
-	target.renderTemplate()
+	target.renderAppSources()
 
 	return nil
 }

--- a/cmd/argo-compare/main.go
+++ b/cmd/argo-compare/main.go
@@ -102,10 +102,7 @@ func compareFiles(changedFiles []string) {
 				}
 			}(tmpDir)
 
-			if err = processFiles(file, "src", m.Application{}); err == unsupportedAppConfiguration {
-				color.Yellow("Skipping unsupported application configuration")
-				return
-			} else if err != nil {
+			if err = processFiles(file, "src", m.Application{}); err != nil {
 				log.Panicf("Could not process the source Application: %s", err)
 			}
 

--- a/cmd/argo-compare/main.go
+++ b/cmd/argo-compare/main.go
@@ -72,11 +72,11 @@ func processFiles(fileName string, fileType string, application m.Application) e
 	}
 
 	target.generateValuesFiles()
-	if err := target.collectHelmChart(); err != nil {
+	if err := target.ensureHelmCharts(); err != nil {
 		return err
 	}
 
-	target.extractChart()
+	target.extractCharts()
 	target.renderAppSources()
 
 	return nil

--- a/cmd/argo-compare/target.go
+++ b/cmd/argo-compare/target.go
@@ -56,101 +56,30 @@ func (t *Target) generateValuesFiles() {
 	}
 }
 
-func (t *Target) collectHelmChart() error {
-	t.chartLocation = fmt.Sprintf("%s/%s", cacheDir, t.App.Spec.Source.RepoURL)
-
-	if err := os.MkdirAll(t.chartLocation, os.ModePerm); err != nil {
-		log.Fatal(err)
-	}
-
-	// A bit hacky, but we need to support cases when helm chart tgz filename does not follow the standard naming convention
-	// For example, sonarqube-4.0.0+315.tgz
-	chartFileName, err := zglob.Glob(fmt.Sprintf("%s/%s-%s*.tgz", t.chartLocation, t.App.Spec.Source.Chart, t.App.Spec.Source.TargetRevision))
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	if len(chartFileName) == 0 {
-		var username, password string
-
-		for _, repoCred := range repoCredentials {
-			if repoCred.Url == t.App.Spec.Source.RepoURL {
-				username = repoCred.Username
-				password = repoCred.Password
-				break
+func (t *Target) ensureHelmCharts() error {
+	if t.App.Spec.MultiSource {
+		for _, source := range t.App.Spec.Sources {
+			if err := downloadHelmChart(cacheDir, source.RepoURL, source.Chart, source.TargetRevision); err != nil {
+				return err
 			}
 		}
-
-		log.Debugf("Downloading version [%s] of [%s] chart...",
-			cyan(t.App.Spec.Source.TargetRevision),
-			cyan(t.App.Spec.Source.Chart))
-
-		cmd := exec.Command(
-			"helm",
-			"pull",
-			"--destination", t.chartLocation,
-			"--username", username,
-			"--password", password,
-			"--repo", t.App.Spec.Source.RepoURL,
-			t.App.Spec.Source.Chart,
-			"--version", t.App.Spec.Source.TargetRevision)
-
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-
-		if err := cmd.Run(); err != nil {
-			return failedToDownloadChart
-		}
 	} else {
-		log.Debugf("Version [%s] of [%s] chart is present in the cache...",
-			cyan(t.App.Spec.Source.TargetRevision),
-			cyan(t.App.Spec.Source.Chart))
+		if err := downloadHelmChart(cacheDir, t.App.Spec.Source.RepoURL, t.App.Spec.Source.Chart, t.App.Spec.Source.TargetRevision); err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
-func (t *Target) extractChart() {
+func (t *Target) extractCharts() {
 	// We have a separate function for this and not using helm to extract the content of the chart
 	// because we don't want to re-download the chart if the TargetRevision is the same
-	log.Debugf("Extracting [%s] chart version [%s] to %s/charts/%s...",
-		cyan(t.App.Spec.Source.Chart),
-		cyan(t.App.Spec.Source.TargetRevision),
-		tmpDir, t.Type)
-
-	path := fmt.Sprintf("%s/charts/%s/%s", tmpDir, t.Type, t.App.Spec.Source.Chart)
-	if err := os.MkdirAll(path, os.ModePerm); err != nil {
-		log.Fatal(err)
-	}
-
-	searchPattern := fmt.Sprintf("%s/%s-%s*.tgz",
-		t.chartLocation,
-		t.App.Spec.Source.Chart,
-		t.App.Spec.Source.TargetRevision)
-
-	chartFileName, err := zglob.Glob(searchPattern)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	// It's highly unlikely that we will have more than one file matching the pattern
-	// Nevertheless we need to handle this case, please submit an issue if you encounter this
-	if len(chartFileName) > 1 {
-		log.Fatal("More than one chart file found, please check your cache directory")
-	}
-
-	cmd := exec.Command(
-		"tar",
-		"xf",
-		chartFileName[0],
-		"-C", fmt.Sprintf("%s/charts/%s", tmpDir, t.Type),
-	)
-
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	if err = cmd.Run(); err != nil {
-		log.Fatal(err)
+	if t.App.Spec.MultiSource {
+		for _, source := range t.App.Spec.Sources {
+			extractHelmChart(source.Chart, source.TargetRevision, fmt.Sprintf("%s/%s", cacheDir, source.RepoURL), tmpDir, t.Type)
+		}
+	} else {
 	}
 }
 
@@ -159,14 +88,21 @@ func (t *Target) renderAppSources() {
 
 	// We are providing release name to the helm template command to cover some corner cases
 	// when the chart is using the release name in the templates
-	if t.App.Spec.Source.Helm.ReleaseName != "" {
-		releaseName = t.App.Spec.Source.Helm.ReleaseName
-	} else {
-		releaseName = t.App.Metadata.Name
+	if !t.App.Spec.MultiSource {
+		if t.App.Spec.Source.Helm.ReleaseName != "" {
+			releaseName = t.App.Spec.Source.Helm.ReleaseName
+		} else {
+			releaseName = t.App.Metadata.Name
+		}
 	}
 
 	if t.App.Spec.MultiSource {
 		for _, source := range t.App.Spec.Sources {
+			if source.Helm.ReleaseName != "" {
+				releaseName = source.Helm.ReleaseName
+			} else {
+				releaseName = t.App.Metadata.Name
+			}
 			if err := renderAppSource(releaseName, source.Chart, source.TargetRevision, tmpDir, t.Type); err != nil {
 				log.Fatal(err)
 			}
@@ -192,7 +128,7 @@ func renderAppSource(releaseName, chartName, chartVersion, tmpDir, targetType st
 		fmt.Sprintf("%s/charts/%s/%s", tmpDir, targetType, chartName),
 		"--output-dir", fmt.Sprintf("%s/templates/%s", tmpDir, targetType),
 		"--values", fmt.Sprintf("%s/charts/%s/%s/values.yaml", tmpDir, targetType, chartName),
-		"--values", fmt.Sprintf("%s/%s-values-%s.yaml", chartName, tmpDir, targetType),
+		"--values", fmt.Sprintf("%s/%s-values-%s.yaml", tmpDir, chartName, targetType),
 	)
 
 	cmd.Stderr = os.Stderr
@@ -210,6 +146,102 @@ func generateValuesFile(chartName, tmpDir, targetType, values string) {
 	}
 
 	if _, err := yamlFile.WriteString(values); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func downloadHelmChart(cacheDir, repoUrl, chartName, targetRevision string) error {
+	chartLocation := fmt.Sprintf("%s/%s", cacheDir, repoUrl)
+
+	if err := os.MkdirAll(chartLocation, os.ModePerm); err != nil {
+		log.Fatal(err)
+	}
+
+	// A bit hacky, but we need to support cases when helm chart tgz filename does not follow the standard naming convention
+	// For example, sonarqube-4.0.0+315.tgz
+	chartFileName, err := zglob.Glob(fmt.Sprintf("%s/%s-%s*.tgz", chartLocation, chartName, targetRevision))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if len(chartFileName) == 0 {
+		var username, password string
+
+		for _, repoCred := range repoCredentials {
+			if repoCred.Url == repoUrl {
+				username = repoCred.Username
+				password = repoCred.Password
+				break
+			}
+		}
+
+		log.Debugf("Downloading version [%s] of [%s] chart...",
+			cyan(targetRevision),
+			cyan(chartName))
+
+		cmd := exec.Command(
+			"helm",
+			"pull",
+			"--destination", chartLocation,
+			"--username", username,
+			"--password", password,
+			"--repo", repoUrl,
+			chartName,
+			"--version", targetRevision)
+
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+
+		if err := cmd.Run(); err != nil {
+			return failedToDownloadChart
+		}
+	} else {
+		log.Debugf("Version [%s] of [%s] chart is present in the cache...",
+			cyan(targetRevision),
+			cyan(chartName))
+	}
+
+	return nil
+}
+
+func extractHelmChart(chartName, chartVersion, chartLocation, tmpDir, targetType string) {
+	log.Debugf("Extracting [%s] chart version [%s] to %s/charts/%s...",
+		cyan(chartName),
+		cyan(chartVersion),
+		tmpDir, targetType)
+
+	path := fmt.Sprintf("%s/charts/%s/%s", tmpDir, targetType, chartName)
+	if err := os.MkdirAll(path, os.ModePerm); err != nil {
+		log.Fatal(err)
+	}
+
+	searchPattern := fmt.Sprintf("%s/%s-%s*.tgz",
+		chartLocation,
+		chartName,
+		chartVersion)
+
+	chartFileName, err := zglob.Glob(searchPattern)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// It's highly unlikely that we will have more than one file matching the pattern
+	// Nevertheless we need to handle this case, please submit an issue if you encounter this
+	if len(chartFileName) > 1 {
+		log.Fatal("More than one chart file found, please check your cache directory")
+	}
+
+	cmd := exec.Command(
+		"tar",
+		"xf",
+		chartFileName[0],
+		"-C", fmt.Sprintf("%s/charts/%s", tmpDir, targetType),
+	)
+
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err = cmd.Run(); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/cmd/argo-compare/target.go
+++ b/cmd/argo-compare/target.go
@@ -80,6 +80,7 @@ func (t *Target) extractCharts() {
 			extractHelmChart(source.Chart, source.TargetRevision, fmt.Sprintf("%s/%s", cacheDir, source.RepoURL), tmpDir, t.Type)
 		}
 	} else {
+		extractHelmChart(t.App.Spec.Source.Chart, t.App.Spec.Source.TargetRevision, fmt.Sprintf("%s/%s", cacheDir, t.App.Spec.Source.RepoURL), tmpDir, t.Type)
 	}
 }
 

--- a/internal/models/application.go
+++ b/internal/models/application.go
@@ -1,6 +1,14 @@
 package models
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	NotApplicationError              = errors.New("file is not an Application")
+	UnsupportedAppConfigurationError = errors.New("unsupported Application configuration")
+)
 
 type Application struct {
 	Kind     string `yaml:"kind"`
@@ -32,16 +40,20 @@ func (app *Application) Validate() error {
 		return fmt.Errorf("both 'source' and 'sources' fields cannot be set at the same time")
 	}
 
+	if app.Kind != "Application" {
+		return NotApplicationError
+	}
+
 	// currently we support only helm repository based charts as a source
 	if len(app.Spec.Sources) != 0 {
 		for _, source := range app.Spec.Sources {
 			if len(source.Chart) == 0 {
-				return fmt.Errorf("unsupported configuration")
+				return UnsupportedAppConfigurationError
 			}
 		}
 	} else {
 		if len(app.Spec.Source.Chart) == 0 {
-			return fmt.Errorf("unsupported configuration")
+			return UnsupportedAppConfigurationError
 		}
 	}
 

--- a/internal/models/application.go
+++ b/internal/models/application.go
@@ -1,5 +1,7 @@
 package models
 
+import "fmt"
+
 type Application struct {
 	Kind     string `yaml:"kind"`
 	Metadata struct {
@@ -7,16 +9,45 @@ type Application struct {
 		Namespace string `yaml:"namespace"`
 	} `yaml:"metadata"`
 	Spec struct {
-		Source struct {
-			RepoURL        string `yaml:"repoURL"`
-			Chart          string `yaml:"chart,omitempty"`
-			TargetRevision string `yaml:"targetRevision"`
-			Path           string `yaml:"path,omitempty"`
-			Helm           struct {
-				ReleaseName string   `yaml:"releaseName,omitempty"`
-				Values      string   `yaml:"values,omitempty"`
-				ValueFiles  []string `yaml:"valueFiles,omitempty"`
-			} `yaml:"helm"`
-		} `yaml:"source"`
+		Source      *Source   `yaml:"source"`
+		Sources     []*Source `yaml:"sources"`
+		MultiSource bool      `yaml:"-"`
 	} `yaml:"spec"`
+}
+
+type Source struct {
+	RepoURL        string `yaml:"repoURL"`
+	Chart          string `yaml:"chart,omitempty"`
+	TargetRevision string `yaml:"targetRevision"`
+	Path           string `yaml:"path,omitempty"`
+	Helm           struct {
+		ReleaseName string   `yaml:"releaseName,omitempty"`
+		Values      string   `yaml:"values,omitempty"`
+		ValueFiles  []string `yaml:"valueFiles,omitempty"`
+	} `yaml:"helm"`
+}
+
+func (app *Application) Validate() error {
+	if app.Spec.Source != nil && len(app.Spec.Sources) > 0 {
+		return fmt.Errorf("both 'source' and 'sources' fields cannot be set at the same time")
+	}
+
+	// currently we support only helm repository based charts as a source
+	if len(app.Spec.Sources) != 0 {
+		for _, source := range app.Spec.Sources {
+			if len(source.Chart) == 0 {
+				return fmt.Errorf("unsupported configuration")
+			}
+		}
+	} else {
+		if len(app.Spec.Source.Chart) == 0 {
+			return fmt.Errorf("unsupported configuration")
+		}
+	}
+
+	if app.Spec.Sources != nil {
+		app.Spec.MultiSource = true
+	}
+
+	return nil
 }


### PR DESCRIPTION
Adds fast and dirty support for processing Applications that are using `sources` instead of `source`.