### PR TITLE
ci(release): add nixpkgs-updater integration to automate package updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,3 +37,12 @@ jobs:
         run: nix develop --command goreleaser release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update nixpkgs
+        if: success()
+        uses: shini4i/nixpkgs-updater@v1
+        with:
+          package-name: argo-compare
+          version: ${{ github.ref_name }}
+          target-repo: shini4i/nixpkgs
+          github-token: ${{ secrets.NIXPKGS_UPDATER_TOKEN }}


### PR DESCRIPTION
Adds a step to the release workflow that triggers nixpkgs-updater to create/update PRs in shini4i/nixpkgs whenever a new version is released.

This automates the synchronization of the argo-compare Nix package with releases, using the NIXPKGS_UPDATER_TOKEN secret for repository access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the release workflow to automatically sync package updates with the nixpkgs repository upon successful releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shini4i/argo-compare/pull/130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->