### PR TITLE
fix(validation): show correct manifest counts and validate src only 

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ When running inside GitLab CI, most settings are detected automatically:
 
 `argo-compare` can validate rendered manifests against Kubernetes OpenAPI schemas using [kubeconform](https://github.com/yannh/kubeconform). Validation runs after rendering, helping catch schema violations before deployment. Results are included in stdout output and (when configured) GitLab MR comments.
 
+**Scope:** validation runs only against the source branch (the post-merge state — what will land on the target branch if the change is merged). All rendered manifests are validated, not just the ones that differ between branches — a value change can break a manifest the diff doesn't touch, and the validator's job is to confirm the whole result is deployable. The target branch is not validated; pre-existing breakage there is not the responsibility of the current change.
+
 Validation is **opt-in**. The comparison always runs to completion (diff is printed and any configured MR comment is posted) — but if any resource fails schema validation, or the validator itself cannot run, `argo-compare` exits with a non-zero status so CI can gate the merge.
 
 ```bash
@@ -175,7 +177,7 @@ If AWS credentials are not available (e.g., running locally without AWS access),
 2) It will get the content of the changed Application files from the target branch.
 3) It will render manifests using the helm template using source and target branch values.
 4) It will get rid of helm related labels as they are not important for the comparison. (It can be skipped by providing `--preserve-helm-labels` flag)
-5) Optionally, when `--validate-manifests` is enabled, rendered manifests are validated against Kubernetes schemas via `kubeconform`.
+5) Optionally, when `--validate-manifests` is enabled, all source-branch rendered manifests (not just changed ones) are validated against Kubernetes schemas via `kubeconform`.
 6) As the last step, it will compare rendered manifest from the source and destination branches and print the
    difference.
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -332,12 +332,15 @@ func (a *App) processFile(ctx context.Context, fileName, fileType string, applic
 		return err
 	}
 
-	if a.validator != nil {
+	// Only validate source manifests: src represents the post-merge state (what will land
+	// on the target branch). Validating dst (current target branch state) would surface
+	// pre-existing breakage unrelated to the PR, which is noise for a merge gate.
+	if a.validator != nil && fileType == TargetTypeSource {
 		// Rendered manifests land at <tmpDir>/templates/<src|dst> (set by RenderAppSource).
 		manifests := filepath.Join(tmpDir, "templates", fileType)
 		result, err := a.validator.Validate(ctx, fileType, manifests)
 		if err != nil {
-			a.logger.Warningf("Manifest validation failed for %s: %v", fileType, err)
+			a.logger.Warningf("Manifest validation failed: %v", err)
 			// Record a synthetic result so the failure surfaces in presenters.
 			validationResults[fileType] = ports.ValidationResult{
 				Target:          fileType,
@@ -346,7 +349,7 @@ func (a *App) processFile(ctx context.Context, fileName, fileType string, applic
 		} else {
 			validationResults[fileType] = result
 			if !result.Valid {
-				a.logger.Warningf("Validation errors in %s: %d issues found", fileType, result.ErrorCount)
+				a.logger.Warningf("Validation errors found: %d issues", result.ErrorCount)
 			}
 		}
 	}

--- a/internal/app/app_integration_test.go
+++ b/internal/app/app_integration_test.go
@@ -372,7 +372,7 @@ func TestAppRunReturnsValidationErrorWhenValidatorFails(t *testing.T) {
 	require.True(t, errors.Is(err, ErrManifestValidationFailed), "error must wrap ErrManifestValidationFailed, got: %v", err)
 
 	// Validator was actually invoked (sanity check the test exercises the path).
-	assert.Greater(t, validator.calls, 0, "validator must have been called")
+	assert.Equal(t, 1, validator.calls, "validator must be called exactly once per application (src only)")
 	// Diff still ran end-to-end before the failure was returned.
 	assert.Contains(t, logBuffer.String(), "Manifest Validation Results")
 }
@@ -457,5 +457,5 @@ func TestAppRunSucceedsWhenValidatorReportsValid(t *testing.T) {
 
 	err = appInstance.Run(context.Background())
 	require.NoError(t, err, "Run must not return an error when validation passes")
-	assert.Greater(t, validator.calls, 0, "validator must have been called")
+	assert.Equal(t, 1, validator.calls, "validator must be called exactly once per application (src only)")
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -19,6 +19,25 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+// appYAML is a minimal valid Application manifest shared by tests that need to
+// exercise the source-path parse() step without touching the real filesystem.
+var appYAML = []byte(`apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: test-app
+  namespace: argocd
+spec:
+  source:
+    repoURL: https://charts.example.com
+    chart: my-chart
+    targetRevision: 1.0.0
+    helm:
+      releaseName: test-app
+  destination:
+    namespace: default
+    server: https://kubernetes.default.svc
+`)
+
 func TestFilterIgnored(t *testing.T) {
 	files := []string{"a.yaml", "b.yaml", "c.yaml"}
 	ignored := []string{"b.yaml"}
@@ -402,6 +421,7 @@ func TestProcessFileRecordsValidatorInvocationError(t *testing.T) {
 
 	appInstance, err := New(cfg, Dependencies{
 		FS:                afero.NewMemMapFs(),
+		FileReader:        stubFileReader{content: appYAML},
 		Logger:            logger,
 		ManifestValidator: mockValidator,
 		HelmProcessor:     mockHelmProcessor,
@@ -416,20 +436,18 @@ func TestProcessFileRecordsValidatorInvocationError(t *testing.T) {
 	mockHelmProcessor.EXPECT().RenderAppSource(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	mockValidator.EXPECT().
-		Validate(gomock.Any(), TargetTypeDestination, gomock.Any()).
+		Validate(gomock.Any(), TargetTypeSource, gomock.Any()).
 		Return(ports.ValidationResult{}, errors.New("kubeconform binary not found"))
 
-	testApp := models.Application{}
-	testApp.Spec.Source = &models.Source{Chart: "my-chart", RepoURL: "https://charts.example.com"}
-	testApp.Spec.Destination = &models.Destination{Server: "https://kubernetes.default.svc", Namespace: "default"}
+	appFile := filepath.Join(t.TempDir(), "test-app.yaml")
 
 	validationResults := make(map[string]ports.ValidationResult)
-	err = appInstance.processFile(context.Background(), "apps/test.yaml", TargetTypeDestination, testApp, tmpDir, validationResults)
+	err = appInstance.processFile(context.Background(), appFile, TargetTypeSource, models.Application{}, tmpDir, validationResults)
 	require.NoError(t, err, "validator invocation failure should not propagate from processFile")
 
-	require.Contains(t, validationResults, TargetTypeDestination)
-	stored := validationResults[TargetTypeDestination]
-	assert.Equal(t, TargetTypeDestination, stored.Target)
+	require.Contains(t, validationResults, TargetTypeSource)
+	stored := validationResults[TargetTypeSource]
+	assert.Equal(t, TargetTypeSource, stored.Target)
 	assert.Contains(t, stored.InvocationError, "kubeconform binary not found")
 	assert.False(t, stored.Valid, "synthetic result for invocation error should be Valid=false")
 }
@@ -448,6 +466,7 @@ func TestProcessFileRecordsInvalidValidationResult(t *testing.T) {
 
 	appInstance, err := New(cfg, Dependencies{
 		FS:                afero.NewMemMapFs(),
+		FileReader:        stubFileReader{content: appYAML},
 		Logger:            logger,
 		ManifestValidator: mockValidator,
 		HelmProcessor:     mockHelmProcessor,
@@ -462,7 +481,7 @@ func TestProcessFileRecordsInvalidValidationResult(t *testing.T) {
 	mockHelmProcessor.EXPECT().RenderAppSource(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	invalidResult := ports.ValidationResult{
-		Target:        TargetTypeDestination,
+		Target:        TargetTypeSource,
 		Valid:         false,
 		ResourceCount: 2,
 		ErrorCount:    1,
@@ -471,19 +490,17 @@ func TestProcessFileRecordsInvalidValidationResult(t *testing.T) {
 		},
 	}
 	mockValidator.EXPECT().
-		Validate(gomock.Any(), TargetTypeDestination, gomock.Any()).
+		Validate(gomock.Any(), TargetTypeSource, gomock.Any()).
 		Return(invalidResult, nil)
 
-	testApp := models.Application{}
-	testApp.Spec.Source = &models.Source{Chart: "my-chart", RepoURL: "https://charts.example.com"}
-	testApp.Spec.Destination = &models.Destination{Server: "https://kubernetes.default.svc", Namespace: "default"}
+	appFile := filepath.Join(t.TempDir(), "test-app.yaml")
 
 	validationResults := make(map[string]ports.ValidationResult)
-	err = appInstance.processFile(context.Background(), "apps/test.yaml", TargetTypeDestination, testApp, tmpDir, validationResults)
+	err = appInstance.processFile(context.Background(), appFile, TargetTypeSource, models.Application{}, tmpDir, validationResults)
 	require.NoError(t, err, "schema-invalid manifests must not cause processFile to fail")
 
-	require.Contains(t, validationResults, TargetTypeDestination)
-	assert.Equal(t, invalidResult, validationResults[TargetTypeDestination])
+	require.Contains(t, validationResults, TargetTypeSource)
+	assert.Equal(t, invalidResult, validationResults[TargetTypeSource])
 }
 
 func TestProcessFileSkipsValidationWhenValidatorNil(t *testing.T) {
@@ -499,6 +516,7 @@ func TestProcessFileSkipsValidationWhenValidatorNil(t *testing.T) {
 
 	appInstance, err := New(cfg, Dependencies{
 		FS:            afero.NewMemMapFs(),
+		FileReader:    stubFileReader{content: appYAML},
 		Logger:        logger,
 		HelmProcessor: mockHelmProcessor,
 	})
@@ -512,21 +530,27 @@ func TestProcessFileSkipsValidationWhenValidatorNil(t *testing.T) {
 	mockHelmProcessor.EXPECT().ExtractHelmChart(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	mockHelmProcessor.EXPECT().RenderAppSource(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
-	testApp := models.Application{}
-	testApp.Spec.Source = &models.Source{Chart: "my-chart", RepoURL: "https://charts.example.com"}
-	testApp.Spec.Destination = &models.Destination{Server: "https://kubernetes.default.svc", Namespace: "default"}
+	appFile := filepath.Join(t.TempDir(), "test-app.yaml")
 
 	validationResults := make(map[string]ports.ValidationResult)
-	err = appInstance.processFile(context.Background(), "apps/test.yaml", TargetTypeDestination, testApp, tmpDir, validationResults)
+	// Use TargetTypeSource so parse() is exercised and the nil-validator guard is
+	// reached on the same code path that production code takes.
+	err = appInstance.processFile(context.Background(), appFile, TargetTypeSource, models.Application{}, tmpDir, validationResults)
 	require.NoError(t, err)
 
 	assert.Empty(t, validationResults, "validationResults must remain empty when no validator is configured")
 }
 
-func TestProcessFileCallsValidatorWithCorrectPath(t *testing.T) {
-	// Verifies the validator is invoked with <tmpDir>/templates/<fileType> and that
-	// the result is stored in the caller-supplied validationResults map.
-	// Uses TargetTypeDestination to skip the parse() step (which reads from the filesystem).
+// stubFileReader returns a fixed byte payload for any ReadFile call.
+type stubFileReader struct {
+	content []byte
+}
+
+func (s stubFileReader) ReadFile(string) []byte { return s.content }
+
+func TestProcessFileCallsValidatorForSource(t *testing.T) {
+	// Verifies validator is invoked with <tmpDir>/templates/src for source manifests
+	// (the post-merge state) and the result is stored in validationResults.
 	ctrl := gomock.NewController(t)
 	mockValidator := mocks.NewMockManifestValidator(ctrl)
 	mockHelmProcessor := mocks.NewMockHelmChartsProcessor(ctrl)
@@ -534,10 +558,11 @@ func TestProcessFileCallsValidatorWithCorrectPath(t *testing.T) {
 	cfg, err := NewConfig("main", WithCacheDir("/tmp/cache"), WithValidateManifests(true))
 	require.NoError(t, err)
 
-	logger := setupTestLogger(t, "app-processfile-validator")
+	logger := setupTestLogger(t, "app-processfile-validator-src")
 
 	appInstance, err := New(cfg, Dependencies{
 		FS:                afero.NewMemMapFs(),
+		FileReader:        stubFileReader{content: appYAML},
 		Logger:            logger,
 		ManifestValidator: mockValidator,
 		HelmProcessor:     mockHelmProcessor,
@@ -553,16 +578,59 @@ func TestProcessFileCallsValidatorWithCorrectPath(t *testing.T) {
 	mockHelmProcessor.EXPECT().RenderAppSource(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	// Match the path layout that processFile uses (filepath.Join, not string concat).
-	expectedManifestDir := filepath.Join(tmpDir, "templates", TargetTypeDestination)
+	expectedManifestDir := filepath.Join(tmpDir, "templates", TargetTypeSource)
 	expectedResult := ports.ValidationResult{
-		Target:        TargetTypeDestination,
+		Target:        TargetTypeSource,
 		Valid:         true,
 		ResourceCount: 3,
 	}
 
 	mockValidator.EXPECT().
-		Validate(gomock.Any(), TargetTypeDestination, expectedManifestDir).
+		Validate(gomock.Any(), TargetTypeSource, expectedManifestDir).
 		Return(expectedResult, nil)
+
+	// Absolute path skips GetGitRepoRoot() inside Target.parse() so the test does
+	// not depend on running inside a git repository.
+	appFile := filepath.Join(t.TempDir(), "test-app.yaml")
+
+	validationResults := make(map[string]ports.ValidationResult)
+	err = appInstance.processFile(context.Background(), appFile, TargetTypeSource, models.Application{}, tmpDir, validationResults)
+	require.NoError(t, err)
+
+	require.Contains(t, validationResults, TargetTypeSource)
+	assert.Equal(t, expectedResult, validationResults[TargetTypeSource])
+}
+
+func TestProcessFileSkipsValidationForDestination(t *testing.T) {
+	// Destination represents the current state of the target branch (already deployed).
+	// We only validate src (the post-merge state), so dst processing must NOT call
+	// the validator and must NOT add an entry to validationResults.
+	ctrl := gomock.NewController(t)
+	mockValidator := mocks.NewMockManifestValidator(ctrl)
+	mockHelmProcessor := mocks.NewMockHelmChartsProcessor(ctrl)
+
+	cfg, err := NewConfig("main", WithCacheDir("/tmp/cache"), WithValidateManifests(true))
+	require.NoError(t, err)
+
+	logger := setupTestLogger(t, "app-processfile-validator-dst")
+
+	appInstance, err := New(cfg, Dependencies{
+		FS:                afero.NewMemMapFs(),
+		Logger:            logger,
+		ManifestValidator: mockValidator,
+		HelmProcessor:     mockHelmProcessor,
+	})
+	require.NoError(t, err)
+
+	tmpDir := t.TempDir()
+
+	mockHelmProcessor.EXPECT().GenerateValuesFile(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockHelmProcessor.EXPECT().DownloadHelmChart(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockHelmProcessor.EXPECT().ExtractHelmChart(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockHelmProcessor.EXPECT().RenderAppSource(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	// No EXPECT on mockValidator: gomock.NewController(t) will fail the test if
+	// Validate is called.
 
 	// Provide a minimal Application with non-nil Source and Destination to avoid
 	// nil dereferences in generateValuesFiles and renderAppSources.
@@ -574,6 +642,5 @@ func TestProcessFileCallsValidatorWithCorrectPath(t *testing.T) {
 	err = appInstance.processFile(context.Background(), "apps/test.yaml", TargetTypeDestination, testApp, tmpDir, validationResults)
 	require.NoError(t, err)
 
-	require.Contains(t, validationResults, TargetTypeDestination)
-	assert.Equal(t, expectedResult, validationResults[TargetTypeDestination])
+	assert.Empty(t, validationResults, "validation must be skipped for destination manifests")
 }

--- a/internal/app/comment_strategy.go
+++ b/internal/app/comment_strategy.go
@@ -162,14 +162,14 @@ func buildValidationSummary(results map[string]ports.ValidationResult) string {
 	for _, target := range keys {
 		result := results[target]
 		if result.InvocationError != "" {
-			lines = append(lines, fmt.Sprintf("- ✗ %s: validator could not run: %s", target, escapeInlineMarkdown(result.InvocationError)))
+			lines = append(lines, fmt.Sprintf("- ✗ validator could not run: %s", escapeInlineMarkdown(result.InvocationError)))
 			continue
 		}
 		status := "✓"
 		if !result.Valid {
 			status = "✗"
 		}
-		lines = append(lines, fmt.Sprintf("- %s %s: %d/%d valid", status, target, result.ResourceCount-result.ErrorCount, result.ResourceCount))
+		lines = append(lines, fmt.Sprintf("- %s %d/%d valid", status, result.ResourceCount-result.ErrorCount, result.ResourceCount))
 		for _, err := range result.Errors {
 			lines = append(lines, fmt.Sprintf("  - `%s.%s`: %s",
 				escapeInlineMarkdown(err.Kind),

--- a/internal/app/comment_strategy_test.go
+++ b/internal/app/comment_strategy_test.go
@@ -255,7 +255,7 @@ func TestBuildValidationSummaryAllValid(t *testing.T) {
 
 	assert.Contains(t, summary, "**Validation**")
 	assert.Contains(t, summary, "✓")
-	assert.Contains(t, summary, "src: 5/5 valid")
+	assert.Contains(t, summary, "5/5 valid")
 }
 
 func TestBuildValidationSummaryWithErrors(t *testing.T) {
@@ -276,7 +276,7 @@ func TestBuildValidationSummaryWithErrors(t *testing.T) {
 
 	assert.Contains(t, summary, "**Validation**")
 	assert.Contains(t, summary, "✗")
-	assert.Contains(t, summary, "dst: 1/3 valid")
+	assert.Contains(t, summary, "1/3 valid")
 	assert.Contains(t, summary, "`Deployment.broken`")
 	assert.Contains(t, summary, "missing field spec.selector")
 	assert.Contains(t, summary, "`Service.svc`")
@@ -347,5 +347,5 @@ func TestCommentStrategyIncludesValidationResults(t *testing.T) {
 	require.Len(t, poster.bodies, 1)
 	body := poster.bodies[0]
 	assert.Contains(t, body, "**Validation**")
-	assert.Contains(t, body, "src: 3/3 valid")
+	assert.Contains(t, body, "3/3 valid")
 }

--- a/internal/app/diff_strategy.go
+++ b/internal/app/diff_strategy.go
@@ -74,14 +74,14 @@ func (s StdoutStrategy) printValidationResults(results map[string]ports.Validati
 	for _, target := range keys {
 		result := results[target]
 		if result.InvocationError != "" {
-			s.Log.Warningf("  %s: validator could not run: %s", target, result.InvocationError)
+			s.Log.Warningf("  validator could not run: %s", result.InvocationError)
 			continue
 		}
 		status := "✓"
 		if !result.Valid {
 			status = "✗"
 		}
-		s.Log.Infof("%s %s: %d/%d valid", status, target, result.ResourceCount-result.ErrorCount, result.ResourceCount)
+		s.Log.Infof("%s %d/%d valid", status, result.ResourceCount-result.ErrorCount, result.ResourceCount)
 		for _, err := range result.Errors {
 			s.Log.Warningf("  - %s.%s: %s", err.Kind, err.Name, err.Message)
 		}

--- a/internal/app/diff_strategy.go
+++ b/internal/app/diff_strategy.go
@@ -81,7 +81,7 @@ func (s StdoutStrategy) printValidationResults(results map[string]ports.Validati
 		if !result.Valid {
 			status = "✗"
 		}
-		s.Log.Infof("%s %s: %d resources validated", status, target, result.ResourceCount)
+		s.Log.Infof("%s %s: %d/%d valid", status, target, result.ResourceCount-result.ErrorCount, result.ResourceCount)
 		for _, err := range result.Errors {
 			s.Log.Warningf("  - %s.%s: %s", err.Kind, err.Name, err.Message)
 		}

--- a/internal/app/diff_strategy_test.go
+++ b/internal/app/diff_strategy_test.go
@@ -359,8 +359,8 @@ func TestStdoutStrategyPresentNoValidationResults(t *testing.T) {
 }
 
 func TestStdoutStrategyValidationResultsFormat(t *testing.T) {
-	// Locks in the "<status> <target>: <valid>/<total> valid" output format and
-	// guards against regressions where ResourceCount-ErrorCount is miscomputed.
+	// Locks in the "<status> <valid>/<total> valid" output format and guards
+	// against regressions where ResourceCount-ErrorCount is miscomputed.
 	var buf bytes.Buffer
 	backend := logging.NewLogBackend(&buf, "", 0)
 	logging.SetBackend(logging.NewBackendFormatter(backend, logging.MustStringFormatter(`%{message}`)))
@@ -368,33 +368,40 @@ func TestStdoutStrategyValidationResultsFormat(t *testing.T) {
 		logging.SetBackend(logging.NewBackendFormatter(logging.NewLogBackend(os.Stdout, "", 0), logging.MustStringFormatter(`%{message}`)))
 	})
 
-	strategy := StdoutStrategy{Log: logging.MustGetLogger("test-stdout-format")}
-	result := ComparisonResult{
-		ValidationResults: map[string]ports.ValidationResult{
-			"src": {
-				Target:        "src",
-				Valid:         true,
-				ResourceCount: 4,
+	t.Run("all valid", func(t *testing.T) {
+		buf.Reset()
+		strategy := StdoutStrategy{Log: logging.MustGetLogger("test-stdout-format-ok")}
+		result := ComparisonResult{
+			ValidationResults: map[string]ports.ValidationResult{
+				"src": {Target: "src", Valid: true, ResourceCount: 4},
 			},
-			"dst": {
-				Target:        "dst",
-				Valid:         false,
-				ResourceCount: 4,
-				ErrorCount:    1,
-				Errors: []ports.ValidationError{
-					{Kind: "Deployment", Name: "broken", Message: "schema mismatch"},
+		}
+		require.NoError(t, strategy.Present(context.Background(), result))
+		assert.Contains(t, buf.String(), "✓ 4/4 valid")
+		// Old wording must be gone so a regression to "%d resources validated" is caught.
+		assert.NotContains(t, buf.String(), "resources validated")
+	})
+
+	t.Run("with errors", func(t *testing.T) {
+		buf.Reset()
+		strategy := StdoutStrategy{Log: logging.MustGetLogger("test-stdout-format-fail")}
+		result := ComparisonResult{
+			ValidationResults: map[string]ports.ValidationResult{
+				"src": {
+					Target:        "src",
+					Valid:         false,
+					ResourceCount: 4,
+					ErrorCount:    1,
+					Errors: []ports.ValidationError{
+						{Kind: "Deployment", Name: "broken", Message: "schema mismatch"},
+					},
 				},
 			},
-		},
-	}
-
-	require.NoError(t, strategy.Present(context.Background(), result))
-
-	output := buf.String()
-	assert.Contains(t, output, "✓ src: 4/4 valid")
-	assert.Contains(t, output, "✗ dst: 3/4 valid")
-	// Old wording must be gone so a regression to "%d resources validated" is caught.
-	assert.NotContains(t, output, "resources validated")
+		}
+		require.NoError(t, strategy.Present(context.Background(), result))
+		assert.Contains(t, buf.String(), "✗ 3/4 valid")
+		assert.Contains(t, buf.String(), "Deployment.broken")
+	})
 }
 
 func TestValidateToolName(t *testing.T) {

--- a/internal/app/diff_strategy_test.go
+++ b/internal/app/diff_strategy_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"os"
@@ -355,6 +356,45 @@ func TestStdoutStrategyPresentNoValidationResults(t *testing.T) {
 
 	err := strategy.Present(context.Background(), result)
 	require.NoError(t, err)
+}
+
+func TestStdoutStrategyValidationResultsFormat(t *testing.T) {
+	// Locks in the "<status> <target>: <valid>/<total> valid" output format and
+	// guards against regressions where ResourceCount-ErrorCount is miscomputed.
+	var buf bytes.Buffer
+	backend := logging.NewLogBackend(&buf, "", 0)
+	logging.SetBackend(logging.NewBackendFormatter(backend, logging.MustStringFormatter(`%{message}`)))
+	t.Cleanup(func() {
+		logging.SetBackend(logging.NewBackendFormatter(logging.NewLogBackend(os.Stdout, "", 0), logging.MustStringFormatter(`%{message}`)))
+	})
+
+	strategy := StdoutStrategy{Log: logging.MustGetLogger("test-stdout-format")}
+	result := ComparisonResult{
+		ValidationResults: map[string]ports.ValidationResult{
+			"src": {
+				Target:        "src",
+				Valid:         true,
+				ResourceCount: 4,
+			},
+			"dst": {
+				Target:        "dst",
+				Valid:         false,
+				ResourceCount: 4,
+				ErrorCount:    1,
+				Errors: []ports.ValidationError{
+					{Kind: "Deployment", Name: "broken", Message: "schema mismatch"},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, strategy.Present(context.Background(), result))
+
+	output := buf.String()
+	assert.Contains(t, output, "✓ src: 4/4 valid")
+	assert.Contains(t, output, "✗ dst: 3/4 valid")
+	// Old wording must be gone so a regression to "%d resources validated" is caught.
+	assert.NotContains(t, output, "resources validated")
 }
 
 func TestValidateToolName(t *testing.T) {

--- a/internal/app/validator.go
+++ b/internal/app/validator.go
@@ -127,10 +127,12 @@ func isValidKindName(s string) bool {
 }
 
 // buildValidationResult converts kubeconform JSON output into a ValidationResult.
+// kubeconform's non-verbose JSON output only lists failed resources in the resources array;
+// the total count of processed resources is only available via the Summary fields.
 func buildValidationResult(target string, parsed kubeconformOutput) ports.ValidationResult {
 	result := ports.ValidationResult{
 		Target:        target,
-		ResourceCount: len(parsed.Resources),
+		ResourceCount: parsed.Summary.Valid + parsed.Summary.Invalid + parsed.Summary.Errors + parsed.Summary.Skipped,
 		ErrorCount:    parsed.Summary.Invalid + parsed.Summary.Errors,
 	}
 	result.Valid = result.ErrorCount == 0

--- a/internal/app/validator_test.go
+++ b/internal/app/validator_test.go
@@ -42,6 +42,14 @@ const errorResourceJSON = `{
   "summary": {"valid": 0, "invalid": 0, "errors": 1, "skipped": 0}
 }`
 
+// allValidEmptyResourcesJSON reproduces kubeconform's non-verbose JSON output when every
+// resource is valid: the resources array is empty and only the summary carries counts.
+// Reading the count from len(resources) would incorrectly report 0 resources validated.
+const allValidEmptyResourcesJSON = `{
+  "resources": [],
+  "summary": {"valid": 3, "invalid": 0, "errors": 0, "skipped": 0}
+}`
+
 func TestKubeconformValidator_ValidManifests(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockCmdRunner := mocks.NewMockCmdRunner(ctrl)
@@ -61,6 +69,32 @@ func TestKubeconformValidator_ValidManifests(t *testing.T) {
 	assert.Equal(t, "src", result.Target)
 	assert.True(t, result.Valid)
 	assert.Equal(t, 2, result.ResourceCount)
+	assert.Equal(t, 0, result.ErrorCount)
+	assert.Empty(t, result.Errors)
+}
+
+func TestKubeconformValidator_AllValidWithEmptyResourcesArray(t *testing.T) {
+	// Regression test: kubeconform's non-verbose JSON output omits valid resources
+	// from the resources array. Before the fix, ResourceCount was derived from
+	// len(parsed.Resources) and incorrectly reported 0 even when every resource passed.
+	// ResourceCount must now come from the summary fields (valid+invalid+errors+skipped).
+	ctrl := gomock.NewController(t)
+	mockCmdRunner := mocks.NewMockCmdRunner(ctrl)
+
+	mockCmdRunner.EXPECT().
+		Run(gomock.Any(), "kubeconform", gomock.Any()).
+		Return(allValidEmptyResourcesJSON, "", nil)
+
+	v := &KubeconformValidator{
+		CmdRunner: mockCmdRunner,
+		Path:      "kubeconform",
+	}
+
+	result, err := v.Validate(context.Background(), "src", "/tmp/templates/src")
+
+	require.NoError(t, err)
+	assert.True(t, result.Valid)
+	assert.Equal(t, 3, result.ResourceCount, "ResourceCount must come from summary, not len(resources)")
 	assert.Equal(t, 0, result.ErrorCount)
 	assert.Empty(t, result.Errors)
 }


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                            
  Two related fixes for the kubeconform validation feature.                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                            
  ### Bug: validation reported "0/0 valid" for valid manifests                          
                                                                                    
  `kubeconform -output json` (without `-verbose`) omits valid resources from
  the `resources` array — only failed/error resources appear there. The                                                                                                                                                                                                                     
  validator was using `len(parsed.Resources)` for `ResourceCount`, so a
  fully-valid run always reported `0/0 valid`. Fix: derive the total from                                                                                                                                                                                                                   
  `Summary.Valid + Summary.Invalid + Summary.Errors + Summary.Skipped`.                 
                                                                                                                                                                                                                                                                                            
  ### Scope: validate only the post-merge state                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                            
  Validation previously ran for both src (your branch) and dst (current target                                                                                                                                                                                                              
  branch). Validating dst surfaces pre-existing breakage that isn't introduced                                                                                                                                                                                                              
  by the PR — noise for a merge gate. With this change, validation runs only            
  against src. All rendered manifests are validated, not just the ones that                                                                                                                                                                                                                 
  differ between branches: a value change can break a manifest the diff                 
  doesn't touch, and the validator's job is to confirm the whole result is                                                                                                                                                                                                                  
  deployable.                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                            
  ### UX: drop confusing target label from output                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                            
  With only one validation result, the `src:` prefix added no information.                                                                                                                                                                                                                  
  Output simplified from `"✓ src: 4/4 valid"` to `"✓ 4/4 valid"`.                                                                                                                                                                                                                           
                                                                                        
  ## Changes                                                                                                                                                                                                                                                                                
                                         
  - `internal/app/validator.go` — `ResourceCount` from `Summary` totals                                                                                                                                                                                                                     
  - `internal/app/app.go` — skip validator when `fileType != TargetTypeSource`          
  - `internal/app/comment_strategy.go` + `diff_strategy.go` — drop target prefix                                                                                                                                                                                                            
  - `README.md` — document validation scope (src-only, all manifests)                                                                                                                                                                                                                       
  - Tests: regression test for the count bug, dst-skip assertion, format            
    assertion, integration test call count tightened to `Equal(1)`       

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated manifest validation documentation to clarify that validation runs only against source-branch rendered manifests, and all resources are validated (not just changed ones), causing non-zero exit on schema failures.

* **Bug Fixes**
  * Fixed resource count calculation in validation results.

* **Changes**
  * Simplified validation output by removing target identifiers from status messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shini4i/argo-compare/pull/131?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->