### PR TITLE
fix(validation): pass -summary to kubeconform

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -118,6 +118,7 @@ func New(cfg Config, deps Dependencies) (*App, error) {
 			CmdRunner: deps.CmdRunner,
 			Path:      kubeconformPath,
 			SkipKinds: cfg.ValidateSkipKinds,
+			Log:       deps.Logger,
 		}
 	}
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -118,7 +118,6 @@ func New(cfg Config, deps Dependencies) (*App, error) {
 			CmdRunner: deps.CmdRunner,
 			Path:      kubeconformPath,
 			SkipKinds: cfg.ValidateSkipKinds,
-			Log:       deps.Logger,
 		}
 	}
 

--- a/internal/app/validator.go
+++ b/internal/app/validator.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/op/go-logging"
 	"github.com/shini4i/argo-compare/internal/ports"
 )
 
@@ -27,6 +28,9 @@ type KubeconformValidator struct {
 	// SkipKinds is an optional list of resource kinds to skip during validation
 	// (passed through as `-skip Kind1,Kind2`).
 	SkipKinds []string
+	// Log surfaces kubeconform's stderr and command line so failures (e.g. schema
+	// download issues, "no files found" warnings) are visible in CI logs. Optional.
+	Log *logging.Logger
 }
 
 // kubeconformOutput mirrors the JSON structure produced by `kubeconform -output json`.
@@ -79,7 +83,19 @@ func (v *KubeconformValidator) Validate(ctx context.Context, target, manifestDir
 	// "--" terminates options so manifestDir cannot be interpreted as a flag.
 	args = append(args, "--", manifestDir)
 
+	if v.Log != nil {
+		v.Log.Debugf("Running kubeconform: %s %s", v.Path, strings.Join(args, " "))
+	}
+
 	stdout, stderr, err := v.CmdRunner.Run(ctx, v.Path, args...)
+
+	// Surface kubeconform's stderr in CI logs so warnings (e.g. schema download
+	// issues, files skipped, "no resources found") are visible. Stderr is empty
+	// on a clean successful run; non-empty stderr always means something worth
+	// seeing happened.
+	if v.Log != nil && strings.TrimSpace(stderr) != "" {
+		v.Log.Warningf("kubeconform stderr: %s", strings.TrimSpace(stderr))
+	}
 
 	// kubeconform exits non-zero when manifests are invalid; that is an expected
 	// outcome, not a validator failure. Treat *exec.ExitError as benign and proceed
@@ -98,6 +114,10 @@ func (v *KubeconformValidator) Validate(ctx context.Context, target, manifestDir
 	var parsed kubeconformOutput
 	if jsonErr := json.Unmarshal([]byte(stdout), &parsed); jsonErr != nil {
 		return ports.ValidationResult{}, fmt.Errorf("could not parse kubeconform output: %w (stderr: %s)", jsonErr, strings.TrimSpace(stderr))
+	}
+
+	if v.Log != nil {
+		v.Log.Debugf("kubeconform stdout: %s", strings.TrimSpace(stdout))
 	}
 
 	return buildValidationResult(target, parsed), nil

--- a/internal/app/validator.go
+++ b/internal/app/validator.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/op/go-logging"
 	"github.com/shini4i/argo-compare/internal/ports"
 )
 
@@ -28,9 +27,6 @@ type KubeconformValidator struct {
 	// SkipKinds is an optional list of resource kinds to skip during validation
 	// (passed through as `-skip Kind1,Kind2`).
 	SkipKinds []string
-	// Log surfaces kubeconform's stderr and command line so failures (e.g. schema
-	// download issues, "no files found" warnings) are visible in CI logs. Optional.
-	Log *logging.Logger
 }
 
 // kubeconformOutput mirrors the JSON structure produced by `kubeconform -output json`.
@@ -70,6 +66,7 @@ func (v *KubeconformValidator) Validate(ctx context.Context, target, manifestDir
 	args := []string{
 		"-output", "json",
 		"-strict",
+		"-summary",
 		"-schema-location", "default",
 	}
 	if len(v.SkipKinds) > 0 {
@@ -83,19 +80,7 @@ func (v *KubeconformValidator) Validate(ctx context.Context, target, manifestDir
 	// "--" terminates options so manifestDir cannot be interpreted as a flag.
 	args = append(args, "--", manifestDir)
 
-	if v.Log != nil {
-		v.Log.Debugf("Running kubeconform: %s %s", v.Path, strings.Join(args, " "))
-	}
-
 	stdout, stderr, err := v.CmdRunner.Run(ctx, v.Path, args...)
-
-	// Surface kubeconform's stderr in CI logs so warnings (e.g. schema download
-	// issues, files skipped, "no resources found") are visible. Stderr is empty
-	// on a clean successful run; non-empty stderr always means something worth
-	// seeing happened.
-	if v.Log != nil && strings.TrimSpace(stderr) != "" {
-		v.Log.Warningf("kubeconform stderr: %s", strings.TrimSpace(stderr))
-	}
 
 	// kubeconform exits non-zero when manifests are invalid; that is an expected
 	// outcome, not a validator failure. Treat *exec.ExitError as benign and proceed
@@ -114,10 +99,6 @@ func (v *KubeconformValidator) Validate(ctx context.Context, target, manifestDir
 	var parsed kubeconformOutput
 	if jsonErr := json.Unmarshal([]byte(stdout), &parsed); jsonErr != nil {
 		return ports.ValidationResult{}, fmt.Errorf("could not parse kubeconform output: %w (stderr: %s)", jsonErr, strings.TrimSpace(stderr))
-	}
-
-	if v.Log != nil {
-		v.Log.Debugf("kubeconform stdout: %s", strings.TrimSpace(stdout))
 	}
 
 	return buildValidationResult(target, parsed), nil
@@ -147,8 +128,9 @@ func isValidKindName(s string) bool {
 }
 
 // buildValidationResult converts kubeconform JSON output into a ValidationResult.
-// kubeconform's non-verbose JSON output only lists failed resources in the resources array;
-// the total count of processed resources is only available via the Summary fields.
+// kubeconform's JSON output only lists failed resources in the resources array;
+// the total count of processed resources comes from the Summary fields, which
+// are only emitted when -summary is passed (we add it in Validate above).
 func buildValidationResult(target string, parsed kubeconformOutput) ports.ValidationResult {
 	result := ports.ValidationResult{
 		Target:        target,


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                            
  Follow-up to #131. After that PR shipped, the MR comment still showed                                                                                                                                                                                                                     
  `✓ 0/0 valid` for runs with valid manifests. Root cause was below the                                                                                                                                                                                                                     
  fix in #131: **kubeconform's JSON output omits the `summary` field                                                                                                                                                                                                                        
  entirely unless `-summary` is passed**, so the validator was always                                                                                                                                                                                                                       
  parsing a zero-valued Summary struct (`0+0+0+0=0`) regardless of how                                                                                                                                                                                                                      
  many resources kubeconform actually processed.                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                            
  Verified locally with `nix-shell -p kubernetes-helm kubeconform`                                                                                                                                                                                                                          
  against the exact helm command pattern in `helm_chart_processor.go`:                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                            
  Without -summary (current behavior)                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                            
  $ kubeconform -output json -strict -schema-location default --                                                                                                                                                                                                                            
  {                                                                                     
    "resources": []                                                                                                                                                                                                                                                                         
  }                                                                                     
                                                                                      
  With -summary (the fix)                

  $ kubeconform -output json -strict -summary -schema-location default --
  {
    "resources": [],                                                                                                                                                                                                                                                                        
    "summary": { "valid": 1, "invalid": 0, "errors": 0, "skipped": 0 }
  }                                                                                                                                                                                                                                                                                         
                                                                                        
  The `resources` array always behaves the same — failed manifests                    
  appear there with full `kind`, `name`, and `msg` detail — so existing                                                                                                                                                                                                                     
  error reporting in both presenters is unaffected. Schema failures                                                                                                                                                                                                                         
  will still surface as `` `Deployment.broken`: ... `` in MR comments                                                                                                                                                                                                                       
  and stdout logs.                                                                                                                                                                                                                                                                          
                                                                                        
  ## Changes                                                                                                                                                                                                                                                                                
                                                                                        
  - `internal/app/validator.go`: add `"-summary"` to the kubeconform                  
    args; update the doc comment on `buildValidationResult` so the
    invariant is documented at the call site.                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                            