### PR TITLE
fix(validation): nested formatting for kubeconform errors

### DIFF
--- a/internal/app/comment_strategy.go
+++ b/internal/app/comment_strategy.go
@@ -136,8 +136,14 @@ func buildCommentBodies(result ComparisonResult, showAdded, showRemoved bool, ap
 }
 
 // escapeInlineMarkdown sanitizes a string for safe interpolation into Markdown.
-// Backticks would break inline-code spans; newlines/carriage returns would break the bullet structure.
+// Backslashes are escaped first so that subsequent backtick escaping cannot
+// accidentally create a CommonMark backslash-escape sequence that leaves the
+// backtick unescaped (e.g. a trailing `\` before a `` ` `` would otherwise
+// produce `\\`` which the renderer interprets as literal `\` + open code-span).
+// Newlines and carriage returns are collapsed to spaces to keep each bullet on
+// a single line.
 func escapeInlineMarkdown(s string) string {
+	s = strings.ReplaceAll(s, "\\", "\\\\")
 	s = strings.ReplaceAll(s, "`", "\\`")
 	s = strings.ReplaceAll(s, "\r", " ")
 	s = strings.ReplaceAll(s, "\n", " ")
@@ -145,6 +151,9 @@ func escapeInlineMarkdown(s string) string {
 }
 
 // buildValidationSummary formats validation results for a GitLab comment in a stable order.
+// Each failing resource renders as a parent bullet (with cleaned filename when available)
+// followed by one nested sub-bullet per non-empty line of the kubeconform message — keeping
+// individual schema failures visually distinct instead of squashing them onto one line.
 func buildValidationSummary(results map[string]ports.ValidationResult) string {
 	if len(results) == 0 {
 		return ""
@@ -171,14 +180,55 @@ func buildValidationSummary(results map[string]ports.ValidationResult) string {
 		}
 		lines = append(lines, fmt.Sprintf("- %s %d/%d valid", status, result.ResourceCount-result.ErrorCount, result.ResourceCount))
 		for _, err := range result.Errors {
-			lines = append(lines, fmt.Sprintf("  - `%s.%s`: %s",
-				escapeInlineMarkdown(err.Kind),
-				escapeInlineMarkdown(err.Name),
-				escapeInlineMarkdown(err.Message)))
+			issues := formatValidationIssues(err.Message)
+			lines = append(lines, buildResourceHeader(err, len(issues) > 0))
+			for _, issue := range issues {
+				lines = append(lines, "    - "+escapeInlineMarkdown(issue))
+			}
 		}
 	}
 
 	return strings.Join(lines, "\n") + "\n\n"
+}
+
+// buildResourceHeader formats the parent bullet for a single failing resource.
+// hasIssues controls the trailing punctuation: a colon when sub-bullets will
+// follow, or a "(no message)" sentinel so an empty message doesn't render as a
+// dangling colon.
+func buildResourceHeader(err ports.ValidationError, hasIssues bool) string {
+	kindName := fmt.Sprintf("`%s.%s`",
+		escapeInlineMarkdown(err.Kind),
+		escapeInlineMarkdown(err.Name))
+
+	if err.Filename == "" {
+		if hasIssues {
+			return "  - " + kindName + ":"
+		}
+		return "  - " + kindName + " (no message)"
+	}
+
+	fname := fmt.Sprintf("`%s`", escapeInlineMarkdown(err.Filename))
+	if hasIssues {
+		return "  - " + kindName + " — " + fname + ":"
+	}
+	return "  - " + kindName + " — " + fname + " (no message)"
+}
+
+// formatValidationIssues splits a kubeconform message into one entry per
+// non-empty line. Kubeconform packs multiple schema failures for a single
+// resource into one msg field separated by newlines; rendering them as
+// sub-bullets keeps each issue individually scannable in the MR comment.
+// Returns nil when message is empty or contains only whitespace lines.
+func formatValidationIssues(message string) []string {
+	var out []string
+	for _, line := range strings.Split(message, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		out = append(out, trimmed)
+	}
+	return out
 }
 
 func buildSummaryLines(result ComparisonResult, showAdded, showRemoved bool) string {

--- a/internal/app/comment_strategy_test.go
+++ b/internal/app/comment_strategy_test.go
@@ -259,6 +259,9 @@ func TestBuildValidationSummaryAllValid(t *testing.T) {
 }
 
 func TestBuildValidationSummaryWithErrors(t *testing.T) {
+	// Locks in the exact rendered block so accidental format drift is caught.
+	// Each resource is a parent bullet with filename; each issue from the
+	// kubeconform message becomes a nested sub-bullet.
 	results := map[string]ports.ValidationResult{
 		"dst": {
 			Target:        "dst",
@@ -266,21 +269,190 @@ func TestBuildValidationSummaryWithErrors(t *testing.T) {
 			ResourceCount: 3,
 			ErrorCount:    2,
 			Errors: []ports.ValidationError{
-				{Kind: "Deployment", Name: "broken", Message: "missing field spec.selector"},
-				{Kind: "Service", Name: "svc", Message: "invalid port"},
+				{Kind: "Deployment", Name: "broken", Filename: "templates/deployment.yaml", Message: "missing field spec.selector"},
+				{Kind: "Service", Name: "svc", Filename: "templates/service.yaml", Message: "invalid port"},
 			},
 		},
 	}
 
 	summary := buildValidationSummary(results)
 
-	assert.Contains(t, summary, "**Validation**")
-	assert.Contains(t, summary, "✗")
-	assert.Contains(t, summary, "1/3 valid")
-	assert.Contains(t, summary, "`Deployment.broken`")
-	assert.Contains(t, summary, "missing field spec.selector")
-	assert.Contains(t, summary, "`Service.svc`")
-	assert.Contains(t, summary, "invalid port")
+	expected := "**Validation**\n" +
+		"- ✗ 1/3 valid\n" +
+		"  - `Deployment.broken` — `templates/deployment.yaml`:\n" +
+		"    - missing field spec.selector\n" +
+		"  - `Service.svc` — `templates/service.yaml`:\n" +
+		"    - invalid port\n\n"
+	assert.Equal(t, expected, summary)
+}
+
+func TestBuildValidationSummaryMultiIssueMessage(t *testing.T) {
+	// Kubeconform packs multiple schema failures for a single resource into one
+	// msg field separated by newlines. Each non-empty line must render as its
+	// own sub-bullet so issues stay individually scannable.
+	results := map[string]ports.ValidationResult{
+		"src": {
+			Target:        "src",
+			Valid:         false,
+			ResourceCount: 1,
+			ErrorCount:    1,
+			Errors: []ports.ValidationError{
+				{
+					Kind:     "Deployment",
+					Name:     "api",
+					Filename: "templates/deployment.yaml",
+					Message:  "/spec/replicas: expected integer, got string\n/spec/containers/0/image: required field missing\n\n/spec/strategy/type: invalid value",
+				},
+			},
+		},
+	}
+
+	summary := buildValidationSummary(results)
+
+	expected := "**Validation**\n" +
+		"- ✗ 0/1 valid\n" +
+		"  - `Deployment.api` — `templates/deployment.yaml`:\n" +
+		"    - /spec/replicas: expected integer, got string\n" +
+		"    - /spec/containers/0/image: required field missing\n" +
+		"    - /spec/strategy/type: invalid value\n\n"
+	assert.Equal(t, expected, summary)
+}
+
+func TestBuildValidationSummaryOmitsFilenameWhenEmpty(t *testing.T) {
+	// Defensive: if the adapter could not produce a meaningful filename, render
+	// the parent bullet without the em-dash filename slot so we don't show
+	// "Kind.Name — `` :" with an empty backtick pair.
+	results := map[string]ports.ValidationResult{
+		"src": {
+			Target:        "src",
+			Valid:         false,
+			ResourceCount: 1,
+			ErrorCount:    1,
+			Errors: []ports.ValidationError{
+				{Kind: "Service", Name: "broken", Message: "port required"},
+			},
+		},
+	}
+
+	summary := buildValidationSummary(results)
+
+	expected := "**Validation**\n" +
+		"- ✗ 0/1 valid\n" +
+		"  - `Service.broken`:\n" +
+		"    - port required\n\n"
+	assert.Equal(t, expected, summary)
+}
+
+func TestBuildValidationSummaryEmptyMessageRendersParentOnly(t *testing.T) {
+	// If the message is empty after splitting/trimming, emit only the parent
+	// bullet with a "(no message)" sentinel rather than a dangling colon.
+	results := map[string]ports.ValidationResult{
+		"src": {
+			Target:        "src",
+			Valid:         false,
+			ResourceCount: 1,
+			ErrorCount:    1,
+			Errors: []ports.ValidationError{
+				{Kind: "Pod", Name: "ghost", Filename: "templates/pod.yaml", Message: ""},
+			},
+		},
+	}
+
+	summary := buildValidationSummary(results)
+
+	expected := "**Validation**\n" +
+		"- ✗ 0/1 valid\n" +
+		"  - `Pod.ghost` — `templates/pod.yaml` (no message)\n\n"
+	assert.Equal(t, expected, summary)
+}
+
+func TestBuildValidationSummaryEmptyFilenameAndEmptyMessage(t *testing.T) {
+	// Covers the buildResourceHeader branch where err.Filename == "" AND the
+	// message produces no issues: emit only "Kind.Name (no message)" without
+	// the em-dash filename slot or a dangling colon.
+	results := map[string]ports.ValidationResult{
+		"src": {
+			Target:        "src",
+			Valid:         false,
+			ResourceCount: 1,
+			ErrorCount:    1,
+			Errors: []ports.ValidationError{
+				{Kind: "Service", Name: "broken", Message: ""},
+			},
+		},
+	}
+
+	summary := buildValidationSummary(results)
+
+	expected := "**Validation**\n" +
+		"- ✗ 0/1 valid\n" +
+		"  - `Service.broken` (no message)\n\n"
+	assert.Equal(t, expected, summary)
+}
+
+func TestBuildValidationSummaryWhitespaceOnlyMessage(t *testing.T) {
+	// A message containing only whitespace lines must be treated the same as
+	// an empty message: no sub-bullets, parent rendered with "(no message)".
+	results := map[string]ports.ValidationResult{
+		"src": {
+			Target:        "src",
+			Valid:         false,
+			ResourceCount: 1,
+			ErrorCount:    1,
+			Errors: []ports.ValidationError{
+				{Kind: "Pod", Name: "ghost", Filename: "pod.yaml", Message: "   \n\t\n  "},
+			},
+		},
+	}
+
+	summary := buildValidationSummary(results)
+
+	expected := "**Validation**\n" +
+		"- ✗ 0/1 valid\n" +
+		"  - `Pod.ghost` — `pod.yaml` (no message)\n\n"
+	assert.Equal(t, expected, summary)
+}
+
+func TestBuildValidationSummaryWindowsLineEndings(t *testing.T) {
+	// kubeconform messages may arrive with CRLF line endings depending on the
+	// environment. Each non-empty line must still render as its own sub-bullet
+	// and the trailing CR must not leak into the rendered output.
+	results := map[string]ports.ValidationResult{
+		"src": {
+			Target:        "src",
+			Valid:         false,
+			ResourceCount: 1,
+			ErrorCount:    1,
+			Errors: []ports.ValidationError{
+				{
+					Kind:     "Deployment",
+					Name:     "api",
+					Filename: "deployment.yaml",
+					Message:  "first failure\r\nsecond failure\r\n",
+				},
+			},
+		},
+	}
+
+	summary := buildValidationSummary(results)
+
+	expected := "**Validation**\n" +
+		"- ✗ 0/1 valid\n" +
+		"  - `Deployment.api` — `deployment.yaml`:\n" +
+		"    - first failure\n" +
+		"    - second failure\n\n"
+	assert.Equal(t, expected, summary)
+}
+
+func TestEscapeInlineMarkdownBackslashOnly(t *testing.T) {
+	// A bare backslash must become a doubled backslash so a downstream backtick
+	// escape cannot accidentally form a CommonMark backslash-escape sequence.
+	assert.Equal(t, `\\`, escapeInlineMarkdown(`\`))
+	// Pre-existing double backslash must remain balanced after escaping.
+	assert.Equal(t, `\\\\`, escapeInlineMarkdown(`\\`))
+	// Backslash followed by backtick: backslash must be escaped first so the
+	// backtick is still escaped independently.
+	assert.Equal(t, "\\\\\\`", escapeInlineMarkdown("\\`"))
 }
 
 func TestBuildValidationSummaryInvocationError(t *testing.T) {
@@ -297,8 +469,12 @@ func TestBuildValidationSummaryInvocationError(t *testing.T) {
 }
 
 func TestBuildValidationSummaryEscapesMarkdownInjection(t *testing.T) {
-	// Crafted manifest fields could otherwise break out of the inline-code span or
-	// inject newlines that disrupt the bullet structure of the comment.
+	// Crafted manifest fields could otherwise break out of the inline-code span
+	// or inject control characters that disrupt the bullet layout. Backticks
+	// must be escaped in every slot (Kind, Name, Filename, issue text), and CR
+	// must be normalized so a single message line stays on a single sub-bullet.
+	// Backslashes must be escaped before backticks so a trailing `\` does not
+	// create a CommonMark escape sequence that leaves the backtick unescaped.
 	results := map[string]ports.ValidationResult{
 		"src": {
 			Target:        "src",
@@ -307,9 +483,10 @@ func TestBuildValidationSummaryEscapesMarkdownInjection(t *testing.T) {
 			ErrorCount:    1,
 			Errors: []ports.ValidationError{
 				{
-					Kind:    "Deployment`hax",
-					Name:    "evil`name",
-					Message: "line1\nline2\rwith CR",
+					Kind:     "Deployment`hax",
+					Name:     "evil`name",
+					Filename: "evil`file.yaml",
+					Message:  "line1\nline2\rwith CR\nline3`hax",
 				},
 			},
 		},
@@ -317,13 +494,43 @@ func TestBuildValidationSummaryEscapesMarkdownInjection(t *testing.T) {
 
 	summary := buildValidationSummary(results)
 
-	assert.NotContains(t, summary, "Deployment`hax", "raw backtick must be escaped")
-	assert.NotContains(t, summary, "evil`name", "raw backtick must be escaped")
-	assert.Contains(t, summary, "Deployment\\`hax")
-	assert.Contains(t, summary, "evil\\`name")
-	// Newlines/CR must be normalized so they don't break the bullet layout.
-	assert.NotContains(t, summary, "line1\nline2", "newlines in Message must be normalized")
-	assert.NotContains(t, summary, "line2\rwith", "carriage returns in Message must be normalized")
+	expected := "**Validation**\n" +
+		"- ✗ 0/1 valid\n" +
+		"  - `Deployment\\`hax.evil\\`name` — `evil\\`file.yaml`:\n" +
+		"    - line1\n" +
+		"    - line2 with CR\n" +
+		"    - line3\\`hax\n\n"
+	assert.Equal(t, expected, summary)
+}
+
+func TestBuildValidationSummaryEscapesBackslash(t *testing.T) {
+	// A trailing backslash before a backtick must not leave the backtick
+	// unescaped: `\\`` in CommonMark renders as literal `\` + open code-span.
+	// escapeInlineMarkdown must escape backslashes first.
+	results := map[string]ports.ValidationResult{
+		"src": {
+			Target:        "src",
+			Valid:         false,
+			ResourceCount: 1,
+			ErrorCount:    1,
+			Errors: []ports.ValidationError{
+				{
+					Kind:     "Service",
+					Name:     "broken",
+					Filename: "path\\with\\backslash.yaml",
+					Message:  "field\\value: unexpected",
+				},
+			},
+		},
+	}
+
+	summary := buildValidationSummary(results)
+
+	expected := "**Validation**\n" +
+		"- ✗ 0/1 valid\n" +
+		"  - `Service.broken` — `path\\\\with\\\\backslash.yaml`:\n" +
+		"    - field\\\\value: unexpected\n\n"
+	assert.Equal(t, expected, summary)
 }
 
 func TestCommentStrategyIncludesValidationResults(t *testing.T) {

--- a/internal/app/validator.go
+++ b/internal/app/validator.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/shini4i/argo-compare/internal/ports"
@@ -101,7 +102,7 @@ func (v *KubeconformValidator) Validate(ctx context.Context, target, manifestDir
 		return ports.ValidationResult{}, fmt.Errorf("could not parse kubeconform output: %w (stderr: %s)", jsonErr, strings.TrimSpace(stderr))
 	}
 
-	return buildValidationResult(target, parsed), nil
+	return buildValidationResult(target, manifestDir, parsed), nil
 }
 
 // isValidKindName reports whether s is a valid Kubernetes resource kind identifier.
@@ -131,7 +132,9 @@ func isValidKindName(s string) bool {
 // kubeconform's JSON output only lists failed resources in the resources array;
 // the total count of processed resources comes from the Summary fields, which
 // are only emitted when -summary is passed (we add it in Validate above).
-func buildValidationResult(target string, parsed kubeconformOutput) ports.ValidationResult {
+// manifestDir is the path passed to kubeconform; it is used to convert the
+// absolute filenames kubeconform emits into paths relative to that directory.
+func buildValidationResult(target, manifestDir string, parsed kubeconformOutput) ports.ValidationResult {
 	result := ports.ValidationResult{
 		Target:        target,
 		ResourceCount: parsed.Summary.Valid + parsed.Summary.Invalid + parsed.Summary.Errors + parsed.Summary.Skipped,
@@ -144,7 +147,7 @@ func buildValidationResult(target string, parsed kubeconformOutput) ports.Valida
 			continue
 		}
 		result.Errors = append(result.Errors, ports.ValidationError{
-			Filename: r.Filename,
+			Filename: cleanFilename(manifestDir, r.Filename),
 			Kind:     r.Kind,
 			Name:     r.Name,
 			Message:  r.Msg,
@@ -152,4 +155,27 @@ func buildValidationResult(target string, parsed kubeconformOutput) ports.Valida
 	}
 
 	return result
+}
+
+// cleanFilename normalizes a filename emitted by kubeconform into a path
+// relative to manifestDir. kubeconform reports absolute paths under a
+// per-invocation tmpdir; surfacing them raw would make the MR comment churn
+// across runs (defeating GitLab's note dedup) and bury the useful name inside
+// noise. When the file lies outside manifestDir, or the relative result is
+// ambiguous ("." when raw equals manifestDir), fall back to the base name so
+// the bullet has a meaningful identifier. When manifestDir is empty, the base
+// name is returned directly.
+func cleanFilename(manifestDir, raw string) string {
+	if raw == "" {
+		return ""
+	}
+	if manifestDir != "" {
+		if rel, err := filepath.Rel(manifestDir, raw); err == nil &&
+			rel != "." &&
+			rel != ".." &&
+			!strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return rel
+		}
+	}
+	return filepath.Base(raw)
 }

--- a/internal/app/validator_test.go
+++ b/internal/app/validator_test.go
@@ -381,6 +381,160 @@ func TestKubeconformValidator_RejectsDigitFirstSkipKind(t *testing.T) {
 	assert.Contains(t, err.Error(), "1BadKind")
 }
 
+func TestKubeconformValidator_FilenameIsRelativeToManifestDir(t *testing.T) {
+	// kubeconform reports absolute paths under the per-invocation tmpdir.
+	// Surfacing them raw would make MR comments non-deterministic across runs
+	// (defeating GitLab's note dedup) and bury the useful path inside noise.
+	// The adapter must strip the manifestDir prefix at the boundary.
+	const manifestDir = "/tmp/argo-compare-12345/templates/src"
+	const rawJSON = `{
+	  "resources": [
+	    {"filename": "/tmp/argo-compare-12345/templates/src/templates/deployment.yaml", "kind": "Deployment", "name": "broken", "status": "statusInvalid", "msg": "field required"}
+	  ],
+	  "summary": {"valid": 0, "invalid": 1, "errors": 0, "skipped": 0}
+	}`
+
+	ctrl := gomock.NewController(t)
+	mockCmdRunner := mocks.NewMockCmdRunner(ctrl)
+	mockCmdRunner.EXPECT().
+		Run(gomock.Any(), "kubeconform", gomock.Any()).
+		Return(rawJSON, "", &exec.ExitError{})
+
+	v := &KubeconformValidator{
+		CmdRunner: mockCmdRunner,
+		Path:      "kubeconform",
+	}
+
+	result, err := v.Validate(context.Background(), "src", manifestDir)
+
+	require.NoError(t, err)
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "templates/deployment.yaml", result.Errors[0].Filename)
+}
+
+func TestKubeconformValidator_FilenameFallsBackToBase(t *testing.T) {
+	// When kubeconform reports a filename outside the manifestDir (filepath.Rel
+	// returns a ".."-prefixed path) the adapter must fall back to filepath.Base
+	// so the bullet still has a meaningful identifier rather than ../../foo.yaml.
+	const manifestDir = "/tmp/argo-compare-12345/templates/src"
+	const rawJSON = `{
+	  "resources": [
+	    {"filename": "/some/other/path/file.yaml", "kind": "Service", "name": "broken", "status": "statusInvalid", "msg": "port required"}
+	  ],
+	  "summary": {"valid": 0, "invalid": 1, "errors": 0, "skipped": 0}
+	}`
+
+	ctrl := gomock.NewController(t)
+	mockCmdRunner := mocks.NewMockCmdRunner(ctrl)
+	mockCmdRunner.EXPECT().
+		Run(gomock.Any(), "kubeconform", gomock.Any()).
+		Return(rawJSON, "", &exec.ExitError{})
+
+	v := &KubeconformValidator{
+		CmdRunner: mockCmdRunner,
+		Path:      "kubeconform",
+	}
+
+	result, err := v.Validate(context.Background(), "src", manifestDir)
+
+	require.NoError(t, err)
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "file.yaml", result.Errors[0].Filename)
+}
+
+func TestKubeconformValidator_FilenameRelativePathStartingWithDotDotName(t *testing.T) {
+	// Regression: `strings.HasPrefix(rel, "..")` matched valid directory names like
+	// "..hidden/file.yaml". Only the path-traversal sequences ".." and "../" should
+	// trigger the fallback; a name that merely starts with ".." as a substring must
+	// not be treated as an escape.
+	const manifestDir = "/srv/templates"
+	const rawJSON = `{
+	  "resources": [
+	    {"filename": "/srv/templates/..hidden/file.yaml", "kind": "Deployment", "name": "ok", "status": "statusInvalid", "msg": "error"}
+	  ],
+	  "summary": {"valid": 0, "invalid": 1, "errors": 0, "skipped": 0}
+	}`
+
+	ctrl := gomock.NewController(t)
+	mockCmdRunner := mocks.NewMockCmdRunner(ctrl)
+	mockCmdRunner.EXPECT().
+		Run(gomock.Any(), "kubeconform", gomock.Any()).
+		Return(rawJSON, "", &exec.ExitError{})
+
+	v := &KubeconformValidator{CmdRunner: mockCmdRunner, Path: "kubeconform"}
+
+	result, err := v.Validate(context.Background(), "src", manifestDir)
+
+	require.NoError(t, err)
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "..hidden/file.yaml", result.Errors[0].Filename)
+}
+
+func TestKubeconformValidator_FilenameIsManifestDirItselfFallsBackToBase(t *testing.T) {
+	// filepath.Rel returns "." when raw == manifestDir. Emitting "." as a filename
+	// bullet would be confusing; fall back to the base name (which is the last
+	// segment of the directory path).
+	const manifestDir = "/srv/templates"
+	const rawJSON = `{
+	  "resources": [
+	    {"filename": "/srv/templates", "kind": "Service", "name": "broken", "status": "statusInvalid", "msg": "error"}
+	  ],
+	  "summary": {"valid": 0, "invalid": 1, "errors": 0, "skipped": 0}
+	}`
+
+	ctrl := gomock.NewController(t)
+	mockCmdRunner := mocks.NewMockCmdRunner(ctrl)
+	mockCmdRunner.EXPECT().
+		Run(gomock.Any(), "kubeconform", gomock.Any()).
+		Return(rawJSON, "", &exec.ExitError{})
+
+	v := &KubeconformValidator{CmdRunner: mockCmdRunner, Path: "kubeconform"}
+
+	result, err := v.Validate(context.Background(), "src", manifestDir)
+
+	require.NoError(t, err)
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "templates", result.Errors[0].Filename)
+}
+
+func TestKubeconformValidator_FilenameEmptyStaysEmpty(t *testing.T) {
+	// Defensive: if kubeconform reports an empty filename, the adapter must
+	// preserve it rather than emit "." (the filepath.Rel result for empty input).
+	const manifestDir = "/tmp/argo-compare-12345/templates/src"
+	const rawJSON = `{
+	  "resources": [
+	    {"filename": "", "kind": "Service", "name": "broken", "status": "statusInvalid", "msg": "port required"}
+	  ],
+	  "summary": {"valid": 0, "invalid": 1, "errors": 0, "skipped": 0}
+	}`
+
+	ctrl := gomock.NewController(t)
+	mockCmdRunner := mocks.NewMockCmdRunner(ctrl)
+	mockCmdRunner.EXPECT().
+		Run(gomock.Any(), "kubeconform", gomock.Any()).
+		Return(rawJSON, "", &exec.ExitError{})
+
+	v := &KubeconformValidator{
+		CmdRunner: mockCmdRunner,
+		Path:      "kubeconform",
+	}
+
+	result, err := v.Validate(context.Background(), "src", manifestDir)
+
+	require.NoError(t, err)
+	require.Len(t, result.Errors, 1)
+	assert.Empty(t, result.Errors[0].Filename)
+}
+
+func TestCleanFilenameEmptyManifestDir(t *testing.T) {
+	// Defensive: when manifestDir is empty the Rel branch is skipped and
+	// cleanFilename must fall straight through to filepath.Base so the
+	// caller still gets a meaningful identifier.
+	assert.Equal(t, "file.yaml", cleanFilename("", "/tmp/deep/path/file.yaml"))
+	// Empty raw with empty manifestDir must remain empty (no spurious ".").
+	assert.Equal(t, "", cleanFilename("", ""))
+}
+
 func TestKubeconformValidator_ExitErrorWithEmptyStdout(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockCmdRunner := mocks.NewMockCmdRunner(ctrl)


### PR DESCRIPTION
Restructure kubeconform validation errors in MR comments to improve readability. Each resource error is now a parent bullet showing Kind.Name and relative filename, with each schema violation as a nested sub-bullet.

Changes:
- Add cleanFilename() helper to convert absolute tmpdir paths to relative paths (manifestDir-relative) with fallback to basename
- Add formatValidationIssues() helper to split multi-issue messages on newlines for individually scannable sub-bullets
- Fix escapeInlineMarkdown() to escape backslashes before backticks, preventing broken markdown when input contains backslash+backtick
- Add buildResourceHeader() helper to format parent bullet with filename and message status
- Pass manifestDir through buildValidationResult for filename cleaning
- Add comprehensive test coverage for path handling edge cases and markdown injection across all slots

Resolves kubeconform comment presentation issues:
✓ Multi-issue messages no longer squashed into single line ✓ Filenames visible (previously captured but never rendered) ✓ Tmpdir paths stripped for deterministic MR comment dedup ✓ Robust markdown escaping for edge cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Validation messages now display per-resource issues as parent bullets with nested sub-issues and filenames.
  * Enhanced markdown escaping to prevent unintended escape sequences in validation output.
  * Improved handling of special characters, newlines, and Windows line endings in messages.

* **Tests**
  * Expanded test coverage for validation message formatting, escaping behavior, and filename normalization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shini4i/argo-compare/pull/133?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->