### PR TITLE
fix(git): compare against merge-base instead of target tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ If AWS credentials are not available (e.g., running locally without AWS access),
 
 ## How it works
 
-1) First, this tool will check which files are changed compared to the files in the target branch.
+1) First, this tool checks which Application files the source branch has modified since it diverged from the target branch (the merge-base is the baseline, so commits made only on the target branch after divergence are ignored).
 2) It will get the content of the changed Application files from the target branch.
 3) It will render manifests using the helm template using source and target branch values.
 4) It will get rid of helm related labels as they are not important for the comparison. (It can be skipped by providing `--preserve-helm-labels` flag)

--- a/internal/app/git.go
+++ b/internal/app/git.go
@@ -32,7 +32,18 @@ type ChangedFilesResult struct {
 	Invalid      []string
 }
 
-var errGitFileDoesNotExist = errors.New("file does not exist in target branch")
+var (
+	errGitFileDoesNotExist = errors.New("file does not exist in target branch")
+	// ErrNoCommonAncestor is returned when HEAD and the target branch share no
+	// history, meaning the "what did src change since branching off" question
+	// has no meaningful answer.
+	ErrNoCommonAncestor = errors.New("no common ancestor")
+	// ErrAmbiguousMergeBase is returned when the history between HEAD and the
+	// target branch has multiple equally-valid merge bases (criss-cross merges).
+	// Picking one arbitrarily would produce non-deterministic results, so we
+	// surface the ambiguity to the user instead.
+	ErrAmbiguousMergeBase = errors.New("ambiguous merge-base")
+)
 
 // NewGitRepo opens the Git repository rooted at the current working directory and returns a GitRepo configured with the provided filesystem, command runner, file reader, and logger.
 // It locates the repository root and opens the repository; an error is returned if root discovery or repository opening fails.
@@ -56,7 +67,10 @@ func NewGitRepo(fs afero.Fs, cmdRunner ports.CmdRunner, fileReader ports.FileRea
 	}, nil
 }
 
-// GetChangedFiles compares HEAD against targetBranch and returns changed application files.
+// GetChangedFiles returns application files that the current branch (HEAD)
+// has modified since it diverged from targetBranch. Files modified only on
+// targetBranch after the divergence point are intentionally excluded — those
+// are not changes the source branch is proposing.
 func (g *GitRepo) GetChangedFiles(targetBranch string, filesToIgnore []string) (ChangedFilesResult, error) {
 	targetRef, err := g.repo.Reference(plumbing.ReferenceName(fmt.Sprintf("refs/remotes/origin/%s", targetBranch)), true)
 	if err != nil {
@@ -78,9 +92,9 @@ func (g *GitRepo) GetChangedFiles(targetBranch string, filesToIgnore []string) (
 		return ChangedFilesResult{}, fmt.Errorf("failed to get commit object for current branch: %w", err)
 	}
 
-	targetTree, err := targetCommit.Tree()
+	baseTree, err := g.mergeBaseTree(headCommit, targetCommit)
 	if err != nil {
-		return ChangedFilesResult{}, fmt.Errorf("failed to get tree for target commit: %w", err)
+		return ChangedFilesResult{}, fmt.Errorf("failed to resolve merge-base with %s: %w", targetBranch, err)
 	}
 
 	headTree, err := headCommit.Tree()
@@ -88,7 +102,7 @@ func (g *GitRepo) GetChangedFiles(targetBranch string, filesToIgnore []string) (
 		return ChangedFilesResult{}, fmt.Errorf("failed to get tree for head commit: %w", err)
 	}
 
-	changes, err := object.DiffTree(targetTree, headTree)
+	changes, err := object.DiffTree(baseTree, headTree)
 	if err != nil {
 		return ChangedFilesResult{}, fmt.Errorf("failed to get diff between trees: %w", err)
 	}
@@ -109,6 +123,36 @@ func (g *GitRepo) GetChangedFiles(targetBranch string, filesToIgnore []string) (
 	filtered := filterIgnored(applications, filesToIgnore)
 
 	return ChangedFilesResult{Applications: filtered, Invalid: invalid}, nil
+}
+
+// mergeBaseTree returns the tree of the merge-base commit between headCommit
+// and targetCommit — the snapshot from which the source branch diverged.
+// Diffing against this snapshot yields only the changes the source branch
+// actually introduced, ignoring commits made on the target branch since
+// divergence.
+//
+// Returns ErrNoCommonAncestor if the histories are unrelated, or
+// ErrAmbiguousMergeBase if multiple equally-valid merge bases exist
+// (criss-cross merges) — go-git does not perform recursive merge-base
+// resolution, so picking one silently would be non-deterministic.
+func (g *GitRepo) mergeBaseTree(headCommit, targetCommit *object.Commit) (*object.Tree, error) {
+	bases, err := headCommit.MergeBase(targetCommit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find merge-base: %w", err)
+	}
+	switch len(bases) {
+	case 0:
+		return nil, ErrNoCommonAncestor
+	case 1:
+	default:
+		return nil, fmt.Errorf("%w: %d candidates (history contains criss-cross merges)", ErrAmbiguousMergeBase, len(bases))
+	}
+
+	tree, err := bases[0].Tree()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get tree for merge-base commit: %w", err)
+	}
+	return tree, nil
 }
 
 // GetChangedFileContent fetches and parses targetFile from targetBranch.

--- a/internal/app/git_test.go
+++ b/internal/app/git_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/op/go-logging"
 	"github.com/shini4i/argo-compare/cmd/argo-compare/utils"
 	"github.com/spf13/afero"
@@ -83,6 +84,144 @@ func TestGitRepoGetChangedFilesRespectsIgnore(t *testing.T) {
 
 	require.ElementsMatch(t, []string{"apps/demo.yaml"}, result.Applications)
 	require.Empty(t, result.Invalid)
+}
+
+// TestGitRepoGetChangedFilesExcludesDstOnlyChanges verifies that files modified
+// only on the destination branch (after src branched off) are NOT reported as
+// changed. We want "what src changed since branching off", not the symmetric
+// difference between src and dst tips.
+func TestGitRepoGetChangedFilesExcludesDstOnlyChanges(t *testing.T) {
+	tempDir := t.TempDir()
+	workDir := filepath.Join(tempDir, "repo")
+	require.NoError(t, os.MkdirAll(workDir, 0o755))
+
+	repo, err := git.PlainInit(workDir, false)
+	require.NoError(t, err)
+
+	err = repo.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.NewBranchReferenceName("main")))
+	require.NoError(t, err)
+
+	// Base commit on main: both apps at v1.0.0 — this is the merge base.
+	writeApplication(t, workDir, `1.0.0`, 1)
+	writeExtraApplication(t, workDir, "secondary", `1.0.0`, 1)
+
+	worktree, err := repo.Worktree()
+	require.NoError(t, err)
+
+	_, err = worktree.Add("apps/demo.yaml")
+	require.NoError(t, err)
+	_, err = worktree.Add("apps/secondary.yaml")
+	require.NoError(t, err)
+
+	_, err = worktree.Commit("initial", &git.CommitOptions{Author: defaultSignature()})
+	require.NoError(t, err)
+
+	// Branch off "feature" from the base commit and modify ONLY demo.yaml.
+	err = worktree.Checkout(&git.CheckoutOptions{Branch: plumbing.NewBranchReferenceName("feature"), Create: true})
+	require.NoError(t, err)
+
+	writeApplication(t, workDir, `1.1.0`, 2)
+	_, err = worktree.Add("apps/demo.yaml")
+	require.NoError(t, err)
+	_, err = worktree.Commit("src changes demo", &git.CommitOptions{Author: defaultSignature()})
+	require.NoError(t, err)
+
+	// Switch back to main and modify ONLY secondary.yaml (dst-only change).
+	err = worktree.Checkout(&git.CheckoutOptions{Branch: plumbing.NewBranchReferenceName("main")})
+	require.NoError(t, err)
+
+	writeExtraApplication(t, workDir, "secondary", `2.0.0`, 3)
+	_, err = worktree.Add("apps/secondary.yaml")
+	require.NoError(t, err)
+	mainHash, err := worktree.Commit("dst changes secondary", &git.CommitOptions{Author: defaultSignature()})
+	require.NoError(t, err)
+
+	// origin/main points at the new main tip — which has the dst-only change.
+	err = repo.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName("refs/remotes/origin/main"), mainHash))
+	require.NoError(t, err)
+
+	// Switch back to feature so HEAD reflects src.
+	err = worktree.Checkout(&git.CheckoutOptions{Branch: plumbing.NewBranchReferenceName("feature")})
+	require.NoError(t, err)
+
+	originalWD, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(workDir))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(originalWD))
+	})
+
+	logger := logging.MustGetLogger("git-test-dst-only")
+	repoInstance, err := NewGitRepo(afero.NewOsFs(), noopCmdRunner{}, utils.OsFileReader{}, logger)
+	require.NoError(t, err)
+
+	result, err := repoInstance.GetChangedFiles("main", nil)
+	require.NoError(t, err)
+
+	// Only the file src actually touched should be reported.
+	require.ElementsMatch(t, []string{"apps/demo.yaml"}, result.Applications)
+	require.Empty(t, result.Invalid)
+}
+
+// TestGitRepoGetChangedFilesUnrelatedHistories verifies that an unrelated
+// target branch (no shared history with HEAD) produces ErrNoCommonAncestor
+// rather than silently treating every file as changed.
+func TestGitRepoGetChangedFilesUnrelatedHistories(t *testing.T) {
+	tempDir := t.TempDir()
+	workDir := filepath.Join(tempDir, "repo")
+	require.NoError(t, os.MkdirAll(workDir, 0o755))
+
+	repo, err := git.PlainInit(workDir, false)
+	require.NoError(t, err)
+
+	err = repo.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.NewBranchReferenceName("main")))
+	require.NoError(t, err)
+
+	writeApplication(t, workDir, `1.0.0`, 1)
+
+	worktree, err := repo.Worktree()
+	require.NoError(t, err)
+
+	_, err = worktree.Add("apps/demo.yaml")
+	require.NoError(t, err)
+	_, err = worktree.Commit("initial", &git.CommitOptions{Author: defaultSignature()})
+	require.NoError(t, err)
+
+	// Construct an orphan commit (no parents, empty tree) and point
+	// origin/main at it — HEAD and origin/main now share no history.
+	emptyTree := &object.Tree{}
+	treeObj := repo.Storer.NewEncodedObject()
+	require.NoError(t, emptyTree.Encode(treeObj))
+	treeHash, err := repo.Storer.SetEncodedObject(treeObj)
+	require.NoError(t, err)
+
+	orphan := &object.Commit{
+		Author:    *defaultSignature(),
+		Committer: *defaultSignature(),
+		Message:   "orphan",
+		TreeHash:  treeHash,
+	}
+	commitObj := repo.Storer.NewEncodedObject()
+	require.NoError(t, orphan.Encode(commitObj))
+	orphanHash, err := repo.Storer.SetEncodedObject(commitObj)
+	require.NoError(t, err)
+
+	err = repo.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName("refs/remotes/origin/main"), orphanHash))
+	require.NoError(t, err)
+
+	originalWD, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(workDir))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(originalWD))
+	})
+
+	logger := logging.MustGetLogger("git-test-unrelated")
+	repoInstance, err := NewGitRepo(afero.NewOsFs(), noopCmdRunner{}, utils.OsFileReader{}, logger)
+	require.NoError(t, err)
+
+	_, err = repoInstance.GetChangedFiles("main", nil)
+	require.ErrorIs(t, err, ErrNoCommonAncestor)
 }
 
 func TestGitRepoTreeForBranchReturnsTree(t *testing.T) {

--- a/internal/app/git_test.go
+++ b/internal/app/git_test.go
@@ -189,22 +189,8 @@ func TestGitRepoGetChangedFilesUnrelatedHistories(t *testing.T) {
 
 	// Construct an orphan commit (no parents, empty tree) and point
 	// origin/main at it — HEAD and origin/main now share no history.
-	emptyTree := &object.Tree{}
-	treeObj := repo.Storer.NewEncodedObject()
-	require.NoError(t, emptyTree.Encode(treeObj))
-	treeHash, err := repo.Storer.SetEncodedObject(treeObj)
-	require.NoError(t, err)
-
-	orphan := &object.Commit{
-		Author:    *defaultSignature(),
-		Committer: *defaultSignature(),
-		Message:   "orphan",
-		TreeHash:  treeHash,
-	}
-	commitObj := repo.Storer.NewEncodedObject()
-	require.NoError(t, orphan.Encode(commitObj))
-	orphanHash, err := repo.Storer.SetEncodedObject(commitObj)
-	require.NoError(t, err)
+	treeHash := storeEmptyTree(t, repo)
+	orphanHash := storeRawCommit(t, repo, treeHash, nil, "orphan")
 
 	err = repo.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName("refs/remotes/origin/main"), orphanHash))
 	require.NoError(t, err)
@@ -222,6 +208,92 @@ func TestGitRepoGetChangedFilesUnrelatedHistories(t *testing.T) {
 
 	_, err = repoInstance.GetChangedFiles("main", nil)
 	require.ErrorIs(t, err, ErrNoCommonAncestor)
+}
+
+// TestGitRepoGetChangedFilesAmbiguousMergeBase verifies that a criss-cross
+// merge topology — where HEAD and the target branch have two equally-valid
+// best common ancestors — returns ErrAmbiguousMergeBase rather than silently
+// picking one.
+//
+// The topology built here:
+//
+//	    A---C   (HEAD, "feature": merges B into A's line)
+//	   / \ /
+//	  O   X
+//	   \ / \
+//	    B---D  (origin/main: merges A into B's line)
+//
+// Merge bases of C and D are {A, B} — neither is reachable from the other.
+func TestGitRepoGetChangedFilesAmbiguousMergeBase(t *testing.T) {
+	tempDir := t.TempDir()
+	workDir := filepath.Join(tempDir, "repo")
+	require.NoError(t, os.MkdirAll(workDir, 0o755))
+
+	repo, err := git.PlainInit(workDir, false)
+	require.NoError(t, err)
+
+	treeHash := storeEmptyTree(t, repo)
+	oHash := storeRawCommit(t, repo, treeHash, nil, "O")
+	aHash := storeRawCommit(t, repo, treeHash, []plumbing.Hash{oHash}, "A")
+	bHash := storeRawCommit(t, repo, treeHash, []plumbing.Hash{oHash}, "B")
+	cHash := storeRawCommit(t, repo, treeHash, []plumbing.Hash{aHash, bHash}, "C: merge B into A")
+	dHash := storeRawCommit(t, repo, treeHash, []plumbing.Hash{bHash, aHash}, "D: merge A into B")
+
+	// HEAD → feature → C
+	err = repo.Storer.SetReference(plumbing.NewHashReference(plumbing.NewBranchReferenceName("feature"), cHash))
+	require.NoError(t, err)
+	err = repo.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.NewBranchReferenceName("feature")))
+	require.NoError(t, err)
+	// origin/main → D
+	err = repo.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName("refs/remotes/origin/main"), dHash))
+	require.NoError(t, err)
+
+	originalWD, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(workDir))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(originalWD))
+	})
+
+	logger := logging.MustGetLogger("git-test-ambiguous")
+	repoInstance, err := NewGitRepo(afero.NewOsFs(), noopCmdRunner{}, utils.OsFileReader{}, logger)
+	require.NoError(t, err)
+
+	_, err = repoInstance.GetChangedFiles("main", nil)
+	require.ErrorIs(t, err, ErrAmbiguousMergeBase)
+}
+
+// storeEmptyTree writes an empty Git tree to the repository's object store
+// and returns its hash. Used by tests that construct commits directly via the
+// storer rather than through a worktree.
+func storeEmptyTree(t *testing.T, repo *git.Repository) plumbing.Hash {
+	t.Helper()
+	tree := &object.Tree{}
+	obj := repo.Storer.NewEncodedObject()
+	require.NoError(t, tree.Encode(obj))
+	hash, err := repo.Storer.SetEncodedObject(obj)
+	require.NoError(t, err)
+	return hash
+}
+
+// storeRawCommit writes a commit object with the given tree, parents, and
+// message directly to the repository's object store and returns its hash.
+// Lets tests assemble arbitrary commit topologies (orphans, criss-cross
+// merges) that the worktree-based API cannot express.
+func storeRawCommit(t *testing.T, repo *git.Repository, tree plumbing.Hash, parents []plumbing.Hash, msg string) plumbing.Hash {
+	t.Helper()
+	commit := &object.Commit{
+		Author:       *defaultSignature(),
+		Committer:    *defaultSignature(),
+		Message:      msg,
+		TreeHash:     tree,
+		ParentHashes: parents,
+	}
+	obj := repo.Storer.NewEncodedObject()
+	require.NoError(t, commit.Encode(obj))
+	hash, err := repo.Storer.SetEncodedObject(obj)
+	require.NoError(t, err)
+	return hash
 }
 
 func TestGitRepoTreeForBranchReturnsTree(t *testing.T) {


### PR DESCRIPTION
GetChangedFiles previously used a symmetric two-tree diff between HEAD and origin/<target>, so files modified only on the target branch after the source branch diverged were wrongly reported as "changed". The diff now uses the merge-base of HEAD and the target as the baseline, so only files the source branch actually modified are compared.

Return ErrAmbiguousMergeBase when go-git reports multiple equally-valid merge bases (criss-cross merges) rather than silently picking one, and ErrNoCommonAncestor for unrelated histories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how the tool identifies changed application files by comparing against the merge-base between source and target branches.

* **Bug Fixes**
  * Improved file change detection to exclude modifications made on the target branch after the branches diverged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shini4i/argo-compare/pull/134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->