### PR TITLE
feat(validation): add customizable schema locations for kubeconform

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ Optional flags:
 
 - `--kubeconform-path <path>` — Override the kubeconform binary location (defaults to `kubeconform` resolved via `PATH`).
 - `--skip-validation-kinds <Kind1,Kind2>` — Comma-separated list of resource kinds to skip (useful for custom resources without published schemas, e.g. `ServiceMonitor,ArgoApplication`).
+- `--schema-location <value>` — Extra kubeconform [`-schema-location`](https://github.com/yannh/kubeconform#overriding-schemas-location---air-gapped-environment) values appended after the built-in `default` registry. Repeat the flag (or pass a comma-separated list) to extend validation to Custom Resources. The most common case is pointing at the community [`datreeio/CRDs-catalog`](https://github.com/datreeio/CRDs-catalog) which ships JSON schemas for KEDA, Kyverno, and many other operators:
+  ```
+  --schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
+  ```
 
 Equivalent environment variables (CLI flags take precedence when both are set):
 
@@ -116,6 +120,7 @@ Equivalent environment variables (CLI flags take precedence when both are set):
 ARGO_COMPARE_VALIDATE_MANIFESTS=true \
 ARGO_COMPARE_KUBECONFORM_PATH=/usr/local/bin/kubeconform \
 ARGO_COMPARE_SKIP_VALIDATION_KINDS=ServiceMonitor,ArgoApplication \
+ARGO_COMPARE_KUBECONFORM_SCHEMA_LOCATIONS='https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
 argo-compare branch <target-branch>
 ```
 

--- a/cmd/argo-compare/command/root.go
+++ b/cmd/argo-compare/command/root.go
@@ -144,25 +144,27 @@ func newBranchCommand(opts Options, dropCache func() bool, debug func() bool) *c
 	cmd.Flags().BoolVar(&flags.validateManifests, "validate-manifests", flags.validateManifests, "Validate rendered manifests against Kubernetes schemas")
 	cmd.Flags().StringVar(&flags.kubeconformPath, "kubeconform-path", flags.kubeconformPath, "Path to kubeconform binary")
 	cmd.Flags().StringSliceVar(&flags.validateSkipKinds, "skip-validation-kinds", flags.validateSkipKinds, "Resource kinds to skip during validation (comma-separated)")
+	cmd.Flags().StringSliceVar(&flags.validateSchemaLocations, "schema-location", flags.validateSchemaLocations, "Additional kubeconform -schema-location values (can be repeated or comma-separated)")
 
 	return cmd
 }
 
 type branchFlags struct {
-	file                string
-	ignore              []string
-	preserveHelmLabels  bool
-	printAdded          bool
-	printRemoved        bool
-	fullOutput          bool
-	commentProvider     string
-	gitlabURL           string
-	gitlabToken         string
-	gitlabProjectID     string
-	gitlabMergeIID      int
-	validateManifests   bool
-	kubeconformPath     string
-	validateSkipKinds   []string
+	file                    string
+	ignore                  []string
+	preserveHelmLabels      bool
+	printAdded              bool
+	printRemoved            bool
+	fullOutput              bool
+	commentProvider         string
+	gitlabURL               string
+	gitlabToken             string
+	gitlabProjectID         string
+	gitlabMergeIID          int
+	validateManifests       bool
+	kubeconformPath         string
+	validateSkipKinds       []string
+	validateSchemaLocations []string
 }
 
 // loadBranchDefaults gathers branch flag defaults from the environment.
@@ -223,6 +225,13 @@ func loadBranchDefaults() branchFlags {
 		}
 	}
 
+	schemaLocationsStr := helpers.GetEnv("ARGO_COMPARE_KUBECONFORM_SCHEMA_LOCATIONS", "")
+	for _, loc := range strings.Split(schemaLocationsStr, ",") {
+		if loc = strings.TrimSpace(loc); loc != "" {
+			defaults.validateSchemaLocations = append(defaults.validateSchemaLocations, loc)
+		}
+	}
+
 	return defaults
 }
 
@@ -250,6 +259,7 @@ func (b branchFlags) configOptions(opts Options, debugEnabled bool) ([]app.Confi
 		app.WithValidateManifests(b.validateManifests),
 		app.WithKubeconformPath(b.kubeconformPath),
 		app.WithValidateSkipKinds(b.validateSkipKinds),
+		app.WithValidateSchemaLocations(b.validateSchemaLocations),
 	}
 
 	commentOption, err := b.commentOption()

--- a/cmd/argo-compare/command/root_test.go
+++ b/cmd/argo-compare/command/root_test.go
@@ -222,6 +222,8 @@ func TestExecuteValidationFlags(t *testing.T) {
 		"--validate-manifests",
 		"--kubeconform-path", "/usr/local/bin/kubeconform",
 		"--skip-validation-kinds", "ServiceMonitor,ArgoApplication",
+		"--schema-location", "https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json",
+		"--schema-location", "schemas/{{.ResourceKind}}{{.KindSuffix}}.json",
 	}
 
 	err := Execute(opts, args)
@@ -230,6 +232,13 @@ func TestExecuteValidationFlags(t *testing.T) {
 	assert.True(t, receivedConfig.ValidateManifests)
 	assert.Equal(t, "/usr/local/bin/kubeconform", receivedConfig.KubeconformPath)
 	assert.Equal(t, []string{"ServiceMonitor", "ArgoApplication"}, receivedConfig.ValidateSkipKinds)
+	assert.Equal(t,
+		[]string{
+			"https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json",
+			"schemas/{{.ResourceKind}}{{.KindSuffix}}.json",
+		},
+		receivedConfig.ValidateSchemaLocations,
+	)
 }
 
 func TestExecuteValidationDisabledByDefault(t *testing.T) {
@@ -253,6 +262,7 @@ func TestExecuteValidationDisabledByDefault(t *testing.T) {
 	assert.False(t, receivedConfig.ValidateManifests)
 	assert.Empty(t, receivedConfig.KubeconformPath)
 	assert.Empty(t, receivedConfig.ValidateSkipKinds)
+	assert.Empty(t, receivedConfig.ValidateSchemaLocations)
 }
 
 func TestExecuteValidationEnvVars(t *testing.T) {
@@ -273,6 +283,8 @@ func TestExecuteValidationEnvVars(t *testing.T) {
 	t.Setenv("ARGO_COMPARE_VALIDATE_MANIFESTS", "true")
 	t.Setenv("ARGO_COMPARE_KUBECONFORM_PATH", "/opt/kubeconform")
 	t.Setenv("ARGO_COMPARE_SKIP_VALIDATION_KINDS", "CustomResource,AnotherKind")
+	t.Setenv("ARGO_COMPARE_KUBECONFORM_SCHEMA_LOCATIONS",
+		"https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json, schemas/{{.ResourceKind}}{{.KindSuffix}}.json")
 
 	err := Execute(opts, []string{"branch", "main"})
 	require.NoError(t, err)
@@ -280,6 +292,13 @@ func TestExecuteValidationEnvVars(t *testing.T) {
 	assert.True(t, receivedConfig.ValidateManifests)
 	assert.Equal(t, "/opt/kubeconform", receivedConfig.KubeconformPath)
 	assert.Equal(t, []string{"CustomResource", "AnotherKind"}, receivedConfig.ValidateSkipKinds)
+	assert.Equal(t,
+		[]string{
+			"https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json",
+			"schemas/{{.ResourceKind}}{{.KindSuffix}}.json",
+		},
+		receivedConfig.ValidateSchemaLocations,
+	)
 }
 
 func TestExecuteValidationEnvVarFalsyValues(t *testing.T) {
@@ -339,6 +358,7 @@ func TestExecuteValidationCLIFlagsBeatEnvVars(t *testing.T) {
 	t.Setenv("ARGO_COMPARE_VALIDATE_MANIFESTS", "false")
 	t.Setenv("ARGO_COMPARE_KUBECONFORM_PATH", "/from/env/kubeconform")
 	t.Setenv("ARGO_COMPARE_SKIP_VALIDATION_KINDS", "FromEnvKind")
+	t.Setenv("ARGO_COMPARE_KUBECONFORM_SCHEMA_LOCATIONS", "schemas/from-env/{{.ResourceKind}}.json")
 
 	// ...CLI flags pass distinct, conflicting values.
 	args := []string{
@@ -346,6 +366,7 @@ func TestExecuteValidationCLIFlagsBeatEnvVars(t *testing.T) {
 		"--validate-manifests",
 		"--kubeconform-path", "/from/cli/kubeconform",
 		"--skip-validation-kinds", "FromCliKind,SecondCliKind",
+		"--schema-location", "schemas/from-cli/{{.ResourceKind}}.json",
 	}
 
 	require.NoError(t, Execute(opts, args))
@@ -353,4 +374,6 @@ func TestExecuteValidationCLIFlagsBeatEnvVars(t *testing.T) {
 	assert.True(t, receivedConfig.ValidateManifests, "CLI --validate-manifests should override env=false")
 	assert.Equal(t, "/from/cli/kubeconform", receivedConfig.KubeconformPath, "CLI path should win")
 	assert.Equal(t, []string{"FromCliKind", "SecondCliKind"}, receivedConfig.ValidateSkipKinds, "CLI kinds should win")
+	assert.Equal(t, []string{"schemas/from-cli/{{.ResourceKind}}.json"}, receivedConfig.ValidateSchemaLocations,
+		"CLI schema locations should win")
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -115,9 +115,10 @@ func New(cfg Config, deps Dependencies) (*App, error) {
 			kubeconformPath = "kubeconform"
 		}
 		validator = &KubeconformValidator{
-			CmdRunner: deps.CmdRunner,
-			Path:      kubeconformPath,
-			SkipKinds: cfg.ValidateSkipKinds,
+			CmdRunner:       deps.CmdRunner,
+			Path:            kubeconformPath,
+			SkipKinds:       cfg.ValidateSkipKinds,
+			SchemaLocations: cfg.ValidateSchemaLocations,
 		}
 	}
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -384,6 +384,32 @@ func TestNewWithCustomKubeconformPath(t *testing.T) {
 	assert.Equal(t, []string{"ServiceMonitor", "ArgoApplication"}, kubeconformValidator.SkipKinds)
 }
 
+func TestNewPropagatesSchemaLocationsToValidator(t *testing.T) {
+	locations := []string{
+		"https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json",
+		"schemas/{{.ResourceKind}}{{.KindSuffix}}.json",
+	}
+
+	cfg, err := NewConfig("main",
+		WithCacheDir("/tmp/cache"),
+		WithValidateManifests(true),
+		WithValidateSchemaLocations(locations),
+	)
+	require.NoError(t, err)
+
+	logger := setupTestLogger(t, "app-validator-schema-locations")
+
+	appInstance, err := New(cfg, Dependencies{
+		FS:     afero.NewMemMapFs(),
+		Logger: logger,
+	})
+	require.NoError(t, err)
+
+	kubeconformValidator, ok := appInstance.validator.(*KubeconformValidator)
+	require.True(t, ok)
+	assert.Equal(t, locations, kubeconformValidator.SchemaLocations)
+}
+
 func TestNewWithInjectedValidator(t *testing.T) {
 	cfg, err := NewConfig("main",
 		WithCacheDir("/tmp/cache"),

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -8,21 +8,22 @@ import (
 
 // Config captures runtime parameters for a comparison run.
 type Config struct {
-	TargetBranch          string
-	FileToCompare         string
-	FilesToIgnore         []string
-	PreserveHelmLabels    bool
-	PrintAddedManifests   bool
-	PrintRemovedManifests bool
-	CacheDir              string
-	TempDirBase           string
-	ExternalDiffTool      string
-	Debug                 bool
-	Version               string
-	Comment               *CommentConfig
-	ValidateManifests     bool
-	KubeconformPath       string
-	ValidateSkipKinds     []string
+	TargetBranch            string
+	FileToCompare           string
+	FilesToIgnore           []string
+	PreserveHelmLabels      bool
+	PrintAddedManifests     bool
+	PrintRemovedManifests   bool
+	CacheDir                string
+	TempDirBase             string
+	ExternalDiffTool        string
+	Debug                   bool
+	Version                 string
+	Comment                 *CommentConfig
+	ValidateManifests       bool
+	KubeconformPath         string
+	ValidateSkipKinds       []string
+	ValidateSchemaLocations []string
 }
 
 // ConfigOption mutates a Config during construction.
@@ -190,5 +191,16 @@ func WithKubeconformPath(path string) ConfigOption {
 func WithValidateSkipKinds(kinds []string) ConfigOption {
 	return func(cfg *Config) {
 		cfg.ValidateSkipKinds = append([]string{}, kinds...)
+	}
+}
+
+// WithValidateSchemaLocations configures additional kubeconform `-schema-location`
+// values appended after the hardcoded `default` registry. Each entry is a
+// kubeconform-recognised registry name, local path, or URL template (see the
+// project README for the datreeio/CRDs-catalog example used to validate KEDA
+// and Kyverno custom resources).
+func WithValidateSchemaLocations(locations []string) ConfigOption {
+	return func(cfg *Config) {
+		cfg.ValidateSchemaLocations = append([]string{}, locations...)
 	}
 }

--- a/internal/app/validator.go
+++ b/internal/app/validator.go
@@ -28,6 +28,12 @@ type KubeconformValidator struct {
 	// SkipKinds is an optional list of resource kinds to skip during validation
 	// (passed through as `-skip Kind1,Kind2`).
 	SkipKinds []string
+	// SchemaLocations holds additional `-schema-location` values appended after the
+	// hardcoded `default` registry. Each entry is a registry name, local path, or
+	// URL template understood by kubeconform (e.g. the datreeio/CRDs-catalog URL
+	// with `{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json`). Order is
+	// preserved because kubeconform tries locations in the order they appear.
+	SchemaLocations []string
 }
 
 // kubeconformOutput mirrors the JSON structure produced by `kubeconform -output json`.
@@ -69,6 +75,12 @@ func (v *KubeconformValidator) Validate(ctx context.Context, target, manifestDir
 		"-strict",
 		"-summary",
 		"-schema-location", "default",
+	}
+	for _, loc := range v.SchemaLocations {
+		if strings.TrimSpace(loc) == "" {
+			return ports.ValidationResult{}, fmt.Errorf("empty schema location in SchemaLocations")
+		}
+		args = append(args, "-schema-location", loc)
 	}
 	if len(v.SkipKinds) > 0 {
 		for _, kind := range v.SkipKinds {

--- a/internal/app/validator_test.go
+++ b/internal/app/validator_test.go
@@ -208,6 +208,62 @@ func TestKubeconformValidator_PassesSkipKindsFlag(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestKubeconformValidator_PassesSchemaLocationFlags(t *testing.T) {
+	// Verifies that each SchemaLocations entry is rendered as its own
+	// `-schema-location <value>` pair, in order, after the hardcoded
+	// `-schema-location default`. kubeconform tries locations in the order
+	// they are given, so preserving order matters.
+	ctrl := gomock.NewController(t)
+	mockCmdRunner := mocks.NewMockCmdRunner(ctrl)
+	const manifestDir = "/tmp/templates/src"
+
+	crdsCatalog := "https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
+	localSchemas := "schemas/{{.ResourceKind}}{{.KindSuffix}}.json"
+
+	mockCmdRunner.EXPECT().
+		Run(gomock.Any(), "kubeconform", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, args ...string) (string, string, error) {
+			var locations []string
+			for i := 0; i < len(args); i++ {
+				if args[i] == "-schema-location" {
+					require.Less(t, i+1, len(args), "-schema-location has no value")
+					locations = append(locations, args[i+1])
+				}
+			}
+			assert.Equal(t, []string{"default", crdsCatalog, localSchemas}, locations,
+				"expected default + configured locations in order")
+			return validResourcesJSON, "", nil
+		})
+
+	v := &KubeconformValidator{
+		CmdRunner:       mockCmdRunner,
+		Path:            "kubeconform",
+		SchemaLocations: []string{crdsCatalog, localSchemas},
+	}
+
+	_, err := v.Validate(context.Background(), "src", manifestDir)
+	require.NoError(t, err)
+}
+
+func TestKubeconformValidator_RejectsEmptySchemaLocation(t *testing.T) {
+	// An empty entry would render as `-schema-location ""`, which kubeconform
+	// rejects with an opaque error. Catch it at the boundary instead.
+	ctrl := gomock.NewController(t)
+	mockCmdRunner := mocks.NewMockCmdRunner(ctrl)
+	// No EXPECT() — any call to Run must not happen.
+
+	v := &KubeconformValidator{
+		CmdRunner:       mockCmdRunner,
+		Path:            "kubeconform",
+		SchemaLocations: []string{"schemas/{{.ResourceKind}}.json", ""},
+	}
+
+	_, err := v.Validate(context.Background(), "src", "/tmp/templates/src")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "schema location")
+}
+
 func TestKubeconformValidator_RejectsInvalidSkipKind(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockCmdRunner := mocks.NewMockCmdRunner(ctrl)


### PR DESCRIPTION
This enables users to extend kubeconform validation to custom resources like KEDA and Kyverno by providing additional schema registries via the --schema-location flag or ARGO_COMPARE_KUBECONFORM_SCHEMA_LOCATIONS environment variable.

The implementation adds:
- CLI flag --schema-location (repeatable or comma-separated)
- Environment variable ARGO_COMPARE_KUBECONFORM_SCHEMA_LOCATIONS (comma-separated)
- Support for kubeconform's -schema-location flag with custom URL templates
- Documentation and examples using datreeio/CRDs-catalog

Example usage:
  argo-compare branch main --validate-manifests --schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'