### PR TITLE
test: consolidate noop port fakes and dedupe shared fixtures

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,3 +2,4 @@ ignore:
   - "**/*_test.go"
   - "cmd/argo-compare/mocks/**"
   - "internal/ports/portstest/**"
+  - "internal/testfixtures/**"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,4 @@
 ignore:
   - "**/*_test.go"
   - "cmd/argo-compare/mocks/**"
+  - "internal/ports/portstest/**"

--- a/internal/app/app_integration_test.go
+++ b/internal/app/app_integration_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/shini4i/argo-compare/cmd/argo-compare/utils"
 	"github.com/shini4i/argo-compare/internal/ports"
+	"github.com/shini4i/argo-compare/internal/ports/portstest"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -102,7 +103,6 @@ func TestAppRunIntegration(t *testing.T) {
 	appLogger := logger.New("app-test")
 
 	helmStub := newStubHelmProcessor(t)
-	cmdStub := &stubCmdRunner{}
 
 	cfg := Config{
 		TargetBranch:          "main",
@@ -115,7 +115,7 @@ func TestAppRunIntegration(t *testing.T) {
 
 	appInstance, err := New(cfg, Dependencies{
 		FS:            afero.NewOsFs(),
-		CmdRunner:     cmdStub,
+		CmdRunner:     portstest.NoopCmdRunner{},
 		FileReader:    utils.OsFileReader{},
 		HelmProcessor: helmStub,
 		Globber:       utils.CustomGlobber{},
@@ -173,12 +173,6 @@ func defaultSignature() *object.Signature {
 		Email: "ci@example.com",
 		When:  time.Now(),
 	}
-}
-
-type stubCmdRunner struct{}
-
-func (s *stubCmdRunner) Run(_ context.Context, _ string, _ ...string) (string, string, error) {
-	return "", "", nil
 }
 
 type stubHelmProcessor struct {
@@ -351,7 +345,7 @@ func TestAppRunReturnsValidationErrorWhenValidatorFails(t *testing.T) {
 
 	appInstance, err := New(cfg, Dependencies{
 		FS:                afero.NewOsFs(),
-		CmdRunner:         &stubCmdRunner{},
+		CmdRunner:         portstest.NoopCmdRunner{},
 		FileReader:        utils.OsFileReader{},
 		HelmProcessor:     newStubHelmProcessor(t),
 		Globber:           utils.CustomGlobber{},
@@ -435,7 +429,7 @@ func TestAppRunSucceedsWhenValidatorReportsValid(t *testing.T) {
 
 	appInstance, err := New(cfg, Dependencies{
 		FS:                afero.NewOsFs(),
-		CmdRunner:         &stubCmdRunner{},
+		CmdRunner:         portstest.NoopCmdRunner{},
 		FileReader:        utils.OsFileReader{},
 		HelmProcessor:     newStubHelmProcessor(t),
 		Globber:           utils.CustomGlobber{},

--- a/internal/app/compare_test.go
+++ b/internal/app/compare_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/shini4i/argo-compare/cmd/argo-compare/utils"
 	"github.com/shini4i/argo-compare/internal/sanitizer"
+	"github.com/shini4i/argo-compare/internal/testfixtures"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,30 +29,6 @@ func (f failingMasker) Mask([]byte) ([]byte, bool, error) {
 }
 
 const (
-	helmDeploymentWithManagedLabels = `# for testing purpose we need only limited fields
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app.kubernetes.io/instance: traefik-web
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: traefik
-    argocd.argoproj.io/instance: traefik
-    helm.sh/chart: traefik-23.0.1
-  name: traefik
-  namespace: web
-`
-	expectedStrippedDeployment = `# for testing purpose we need only limited fields
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app.kubernetes.io/instance: traefik-web
-    app.kubernetes.io/name: traefik
-    argocd.argoproj.io/instance: traefik
-  name: traefik
-  namespace: web
-`
 	appManifestYAML = `apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -107,7 +84,7 @@ func TestCompareGenerateFilesStatus(t *testing.T) {
 func TestCompareFindAndStripHelmLabels(t *testing.T) {
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "deployment.yaml")
-	require.NoError(t, os.WriteFile(testFile, []byte(helmDeploymentWithManagedLabels), 0o644))
+	require.NoError(t, os.WriteFile(testFile, []byte(testfixtures.HelmDeploymentWithManagedLabels), 0o644))
 
 	c := &Compare{
 		Fs:      afero.NewOsFs(),
@@ -120,7 +97,7 @@ func TestCompareFindAndStripHelmLabels(t *testing.T) {
 	modified, err := os.ReadFile(testFile)
 	require.NoError(t, err)
 
-	assert.Equal(t, expectedStrippedDeployment, string(modified))
+	assert.Equal(t, testfixtures.HelmDeploymentStripped, string(modified))
 }
 
 func TestCompareProcessFiles(t *testing.T) {

--- a/internal/app/git_test.go
+++ b/internal/app/git_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/shini4i/argo-compare/cmd/argo-compare/utils"
+	"github.com/shini4i/argo-compare/internal/ports/portstest"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 )
@@ -77,7 +78,7 @@ func TestGitRepoGetChangedFilesRespectsIgnore(t *testing.T) {
 	})
 
 	log := logger.New("git-test")
-	repoInstance, err := NewGitRepo(afero.NewOsFs(), noopCmdRunner{}, utils.OsFileReader{}, log)
+	repoInstance, err := NewGitRepo(afero.NewOsFs(), portstest.NoopCmdRunner{}, utils.OsFileReader{}, log)
 	require.NoError(t, err)
 
 	result, err := repoInstance.GetChangedFiles("main", []string{"apps/secondary.yaml"})
@@ -153,7 +154,7 @@ func TestGitRepoGetChangedFilesExcludesDstOnlyChanges(t *testing.T) {
 	})
 
 	log := logger.New("git-test-dst-only")
-	repoInstance, err := NewGitRepo(afero.NewOsFs(), noopCmdRunner{}, utils.OsFileReader{}, log)
+	repoInstance, err := NewGitRepo(afero.NewOsFs(), portstest.NoopCmdRunner{}, utils.OsFileReader{}, log)
 	require.NoError(t, err)
 
 	result, err := repoInstance.GetChangedFiles("main", nil)
@@ -204,7 +205,7 @@ func TestGitRepoGetChangedFilesUnrelatedHistories(t *testing.T) {
 	})
 
 	log := logger.New("git-test-unrelated")
-	repoInstance, err := NewGitRepo(afero.NewOsFs(), noopCmdRunner{}, utils.OsFileReader{}, log)
+	repoInstance, err := NewGitRepo(afero.NewOsFs(), portstest.NoopCmdRunner{}, utils.OsFileReader{}, log)
 	require.NoError(t, err)
 
 	_, err = repoInstance.GetChangedFiles("main", nil)
@@ -257,7 +258,7 @@ func TestGitRepoGetChangedFilesAmbiguousMergeBase(t *testing.T) {
 	})
 
 	log := logger.New("git-test-ambiguous")
-	repoInstance, err := NewGitRepo(afero.NewOsFs(), noopCmdRunner{}, utils.OsFileReader{}, log)
+	repoInstance, err := NewGitRepo(afero.NewOsFs(), portstest.NoopCmdRunner{}, utils.OsFileReader{}, log)
 	require.NoError(t, err)
 
 	_, err = repoInstance.GetChangedFiles("main", nil)
@@ -422,7 +423,7 @@ func buildGitRepo(t *testing.T, includeRemote bool) (*GitRepo, *git.Repository) 
 	})
 
 	log := logger.New(fmt.Sprintf("git-test-%s", t.Name()))
-	repoInstance, err := NewGitRepo(afero.NewOsFs(), noopCmdRunner{}, utils.OsFileReader{}, log)
+	repoInstance, err := NewGitRepo(afero.NewOsFs(), portstest.NoopCmdRunner{}, utils.OsFileReader{}, log)
 	require.NoError(t, err)
 
 	return repoInstance, repo

--- a/internal/app/target_test.go
+++ b/internal/app/target_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/shini4i/argo-compare/cmd/argo-compare/utils/logger"
 
 	"github.com/shini4i/argo-compare/internal/ports"
+	"github.com/shini4i/argo-compare/internal/ports/portstest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -41,31 +42,12 @@ func (r *recordingHelmProcessor) RenderAppSource(_ context.Context, _ ports.CmdR
 	return nil
 }
 
-type noopCmdRunner struct{}
-
-func (noopCmdRunner) Run(_ context.Context, _ string, _ ...string) (string, string, error) {
-	return "", "", nil
-}
-
-type noopFileReader struct{}
-
-func (noopFileReader) ReadFile(string) ([]byte, error) { return nil, nil }
-
-// errFileReader always returns the configured error from ReadFile.
-type errFileReader struct{ err error }
-
-func (r errFileReader) ReadFile(string) ([]byte, error) { return nil, r.err }
-
-type noopGlobber struct{}
-
-func (noopGlobber) Glob(string) ([]string, error) { return nil, nil }
-
 func TestTargetParseReturnsErrorFromFileReader(t *testing.T) {
 	sentinel := errors.New("permission denied")
 
 	target := Target{
-		CmdRunner:  noopCmdRunner{},
-		FileReader: errFileReader{err: sentinel},
+		CmdRunner:  portstest.NoopCmdRunner{},
+		FileReader: portstest.ErrFileReader{Err: sentinel},
 		Log:        logger.New("target-test"),
 		File:       "/some/app.yaml",
 		Type:       TargetTypeSource,
@@ -81,10 +63,10 @@ func TestTargetMultiSourceInvokesHelmPerSource(t *testing.T) {
 	processor := &recordingHelmProcessor{}
 
 	target := Target{
-		CmdRunner:           noopCmdRunner{},
-		FileReader:          noopFileReader{},
+		CmdRunner:           portstest.NoopCmdRunner{},
+		FileReader:          portstest.NoopFileReader{},
 		HelmProcessor:       processor,
-		Globber:             noopGlobber{},
+		Globber:             portstest.NoopGlobber{},
 		CacheDir:            "cache",
 		TmpDir:              "tmp",
 		CredentialProviders: nil,

--- a/internal/helpers/helpers_test.go
+++ b/internal/helpers/helpers_test.go
@@ -8,36 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/shini4i/argo-compare/internal/testfixtures"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-)
-
-const (
-	expectedStrippedOutput = `# for testing purpose we need only limited fields
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app.kubernetes.io/instance: traefik-web
-    app.kubernetes.io/name: traefik
-    argocd.argoproj.io/instance: traefik
-  name: traefik
-  namespace: web
-`
-	helmDeploymentWithManagedLabels = `# for testing purpose we need only limited fields
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app.kubernetes.io/instance: traefik-web
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: traefik
-    argocd.argoproj.io/instance: traefik
-    helm.sh/chart: traefik-23.0.1
-  name: traefik
-  namespace: web
-`
 )
 
 func TestGetEnv(t *testing.T) {
@@ -57,12 +31,12 @@ func TestGetEnv(t *testing.T) {
 func TestStripHelmLabels(t *testing.T) {
 	tmpDir := t.TempDir()
 	sourcePath := filepath.Join(tmpDir, "deployment.yaml")
-	require.NoError(t, os.WriteFile(sourcePath, []byte(helmDeploymentWithManagedLabels), 0o644))
+	require.NoError(t, os.WriteFile(sourcePath, []byte(testfixtures.HelmDeploymentWithManagedLabels), 0o644))
 
 	fileContent, err := StripHelmLabels(sourcePath)
 
 	assert.NoError(t, err)
-	assert.Equal(t, expectedStrippedOutput, string(fileContent))
+	assert.Equal(t, testfixtures.HelmDeploymentStripped, string(fileContent))
 
 	// We want to be sure that the function returns an error if the file cannot be read
 	_, err = StripHelmLabels(filepath.Join(tmpDir, "missing.yaml"))
@@ -76,7 +50,7 @@ func TestWriteToFile(t *testing.T) {
 	filePath := "output.txt"
 
 	// Call the function to write data to file
-	err := WriteToFile(fs, filePath, []byte(expectedStrippedOutput))
+	err := WriteToFile(fs, filePath, []byte(testfixtures.HelmDeploymentStripped))
 	assert.NoError(t, err)
 
 	// Read the written file
@@ -84,7 +58,7 @@ func TestWriteToFile(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Compare the written data with the test data
-	assert.Equal(t, expectedStrippedOutput, string(writtenData))
+	assert.Equal(t, testfixtures.HelmDeploymentStripped, string(writtenData))
 
 	// Cleanup: Remove the written file
 	err = fs.Remove(filePath)
@@ -94,7 +68,7 @@ func TestWriteToFile(t *testing.T) {
 	fs = afero.NewReadOnlyFs(fs)
 
 	filePath = "invalid/output.txt"
-	err = WriteToFile(fs, filePath, []byte(expectedStrippedOutput))
+	err = WriteToFile(fs, filePath, []byte(testfixtures.HelmDeploymentStripped))
 	assert.Error(t, err)
 }
 

--- a/internal/ports/portstest/portstest.go
+++ b/internal/ports/portstest/portstest.go
@@ -1,0 +1,42 @@
+// Package portstest provides minimal hand-rolled fakes for the interfaces
+// defined in internal/ports. They are intentionally small: each one satisfies
+// a port with a no-op (or a single configurable error) so tests that need a
+// "this dependency exists but does nothing" stand-in don't have to redeclare
+// the same trivial type per file.
+//
+// For tests that need to assert call arguments or call counts, prefer the
+// gomock-generated mocks in cmd/argo-compare/mocks. These helpers are only
+// for cases where the test does not care what the dependency was called with.
+package portstest
+
+import (
+	"context"
+)
+
+// NoopCmdRunner satisfies ports.CmdRunner by returning empty output and no error.
+type NoopCmdRunner struct{}
+
+// Run returns ("", "", nil) regardless of arguments.
+func (NoopCmdRunner) Run(_ context.Context, _ string, _ ...string) (string, string, error) {
+	return "", "", nil
+}
+
+// NoopFileReader satisfies ports.FileReader by returning (nil, nil), which the
+// port contract treats as "file absent" (see ports.FileReader docstring).
+type NoopFileReader struct{}
+
+// ReadFile returns (nil, nil) regardless of the path.
+func (NoopFileReader) ReadFile(string) ([]byte, error) { return nil, nil }
+
+// ErrFileReader satisfies ports.FileReader by always returning the configured
+// error. Useful for verifying that callers propagate I/O failures correctly.
+type ErrFileReader struct{ Err error }
+
+// ReadFile returns (nil, r.Err) regardless of the path.
+func (r ErrFileReader) ReadFile(string) ([]byte, error) { return nil, r.Err }
+
+// NoopGlobber satisfies ports.Globber by returning no matches and no error.
+type NoopGlobber struct{}
+
+// Glob returns (nil, nil) regardless of the pattern.
+func (NoopGlobber) Glob(string) ([]string, error) { return nil, nil }

--- a/internal/testfixtures/manifests.go
+++ b/internal/testfixtures/manifests.go
@@ -1,0 +1,40 @@
+// Package testfixtures holds small Kubernetes manifest snippets that more
+// than one test package needs to share. The goal is to avoid silent drift
+// between identical-but-copy-pasted YAML blobs across test files.
+//
+// Only put fixtures here when the *same* fixture is used by tests in two or
+// more packages. Single-package fixtures should stay inline in their _test.go
+// file — moving them here costs locality without any dedup benefit.
+package testfixtures
+
+// HelmDeploymentWithManagedLabels is a minimal Helm-rendered Deployment that
+// includes the standard `app.kubernetes.io/managed-by: Helm` and `helm.sh/chart`
+// labels which helpers.StripHelmLabels is expected to remove.
+const HelmDeploymentWithManagedLabels = `# for testing purpose we need only limited fields
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: traefik-web
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: traefik
+    argocd.argoproj.io/instance: traefik
+    helm.sh/chart: traefik-23.0.1
+  name: traefik
+  namespace: web
+`
+
+// HelmDeploymentStripped is the expected result of running
+// helpers.StripHelmLabels on HelmDeploymentWithManagedLabels: the
+// Helm-specific labels are gone, all other content is byte-identical.
+const HelmDeploymentStripped = `# for testing purpose we need only limited fields
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: traefik-web
+    app.kubernetes.io/name: traefik
+    argocd.argoproj.io/instance: traefik
+  name: traefik
+  namespace: web
+`


### PR DESCRIPTION
  ## Summary

  Two small, atomic test-suite refactors that remove genuine duplication without
  touching production code or coverage. Driven by an audit that flagged
  hand-rolled noop fakes for the same `internal/ports` interfaces being
  redeclared across three test files, plus two byte-identical YAML manifest
  strings copy-pasted between `internal/helpers` and `internal/app`.

  **a4aafe9 — `test(ports): consolidate noop port fakes into portstest package`**
  - New `internal/ports/portstest` package exporting `NoopCmdRunner`,
    `NoopFileReader`, `ErrFileReader`, `NoopGlobber`.
  - Removed duplicated noop type declarations from `internal/app/target_test.go`
    and `internal/app/app_integration_test.go` (the latter had `stubCmdRunner`,
    an exact duplicate of `noopCmdRunner` in the same package).
  - Updated call sites in `target_test.go`, `git_test.go`,
    `app_integration_test.go`.
  - `codecov.yml`: added `internal/ports/portstest/**` to the ignore block
    (matches the existing `cmd/argo-compare/mocks/**` precedent).

  **b9cc7d4 — `test(fixtures): dedupe Helm Deployment YAML across helpers and app tests`**
  - New `internal/testfixtures` package exporting `HelmDeploymentWithManagedLabels`
    and `HelmDeploymentStripped`. Package doc states the threshold: only add
    fixtures here when used by 2+ packages.
  - Removed the byte-identical local consts from `internal/helpers/helpers_test.go`
    (`helmDeploymentWithManagedLabels`, `expectedStrippedOutput`) and
    `internal/app/compare_test.go` (`helmDeploymentWithManagedLabels`,
    `expectedStrippedDeployment`).
  - Single-package fixtures (validator JSON constants, `appYAML`,
    `appManifestYAML`, `appValuesYAML`) were intentionally left inline —
    moving them costs locality without dedup benefit.
  - `codecov.yml`: added `internal/testfixtures/**` to the ignore block.

  ### Intentionally untouched
  - `recordingHelmProcessor`, `stubPoster`, `stubHelmProcessor`, `stubValidator`,
    `roundTripperFunc`, `mockECRClient` — these are stateful stubs, HTTP idioms,
    or AWS-SDK mocks, not noop port fakes.
  - Existing gomock usage in `helm_chart_processor_test.go`, `validator_test.go`,
    `app_test.go` — gomock is the right tool where argument matching matters.