### PR TITLE
feat(anchor): support path-based Applications via .argo-compare.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ See [Installation](docs/installation.md) and [Usage](docs/usage.md) for the full
 - [Anchored repositories](docs/anchored-repositories.md) — path-based sources and chart-only repos via `.argo-compare.yml`.
 - [Manifest validation](docs/manifest-validation.md) — schema validation with `kubeconform`.
 - [Repository credentials](docs/repository-credentials.md) — private Helm repos, OCI registries, AWS ECR.
-- [Sensitive data handling](docs/sensitive-data.md) — Secret masking in diff output.
 - [GitLab integration](docs/gitlab-integration.md) — posting the diff as a Merge Request comment.
 
 ## Current limitations

--- a/README.md
+++ b/README.md
@@ -16,217 +16,38 @@ A comparison tool for displaying the differences between applications in differe
 Example output of `argo-compare` with `diff-so-fancy`
 </div>
 
-## General information
+## About
 
-This tool will show what would be changed in the manifests rendered by helm after changes to the specific Application
-are merged into the target branch.
+`argo-compare` shows what would change in the helm-rendered manifests of an ArgoCD Application once a pull request is merged into the target branch. It renders both branches with `helm template`, strips Helm-injected noise, and prints the diff.
 
-### How to install
+Optional features layer on top of the core flow — manifest schema validation, posting the diff as a Merge Request comment, anchored discovery for chart-only repos, and credential handling for private chart sources. See the [Documentation](#documentation) index below.
 
-Download the binary from the [Releases](https://github.com/shini4i/argo-compare/releases) page, or pull the Docker image:
+## Quick start
 
 ```bash
+# Install via Docker
 docker pull ghcr.io/shini4i/argo-compare:<version>
-```
 
-### How to use
-
-The simplest usage scenario is to compare all changed files in the current branch with the target branch:
-
-```bash
+# Or download a binary from the Releases page, then:
 argo-compare branch <target-branch>
 ```
 
-If you want to compare only specific file, you can use the `--file` flag:
+See [Installation](docs/installation.md) and [Usage](docs/usage.md) for the full setup.
 
-```bash
-argo-compare branch <target-branch> --file <file-path>
-```
+## Documentation
 
-By default, argo-compare will print only changed files content, but if this behavior is not desired, you can use one of the following flags:
-```bash
-# In addition to the changed files, it will print all added manifests
-argo-compare branch <target-branch> --print-added-manifests
-# In addition to the changed files, it will print all removed manifests
-argo-compare branch <target-branch> --print-removed-manifests
-# Print all changed, added and removed manifests
-argo-compare branch <target-branch> --full-output
-```
-
-To use an external diff tool, you can set `EXTERNAL_DIFF_TOOL` environment variable. Each file diff will be passed in a pipe to the external tool.
-```bash
-EXTERNAL_DIFF_TOOL=diff-so-fancy argo-compare branch <target-branch>
-```
-
-Additionally, you can try this tool using docker container:
-```bash
-docker run -it --mount type=bind,source="$(pwd)",target=/apps --env EXTERNAL_DIFF_TOOL=diff-so-fancy --workdir /apps ghcr.io/shini4i/argo-compare:<version> branch <target-branch> --full-output
-```
-
-To post the comparison as a comment to a GitLab Merge Request, provide the GitLab provider and credentials either with flags or environment variables:
-
-```bash
-ARGO_COMPARE_COMMENT_PROVIDER=gitlab \
-ARGO_COMPARE_GITLAB_URL=https://gitlab.com \
-ARGO_COMPARE_GITLAB_TOKEN=$GITLAB_TOKEN \
-ARGO_COMPARE_GITLAB_PROJECT_ID=12345 \
-ARGO_COMPARE_GITLAB_MR_IID=10 \
-argo-compare branch <target-branch>
-```
-
-Equivalent CLI flags are available:
-
-```bash
-argo-compare branch <target-branch> \
-  --comment-provider gitlab \
-  --gitlab-url https://gitlab.com \
-  --gitlab-token "$GITLAB_TOKEN" \
-  --gitlab-project-id 12345 \
-  --gitlab-merge-request-iid 10
-```
-
-When running inside GitLab CI, most settings are detected automatically:
-
-- `--comment-provider` defaults to `gitlab` when `GITLAB_CI` and `CI_MERGE_REQUEST_IID` are present.
-- `--gitlab-url` falls back to `CI_SERVER_URL`.
-- `--gitlab-project-id` falls back to `CI_PROJECT_ID`.
-- `--gitlab-merge-request-iid` falls back to `CI_MERGE_REQUEST_IID`.
-- `--gitlab-token` falls back to `CI_JOB_TOKEN` if no explicit token is provided (ensure the token has the necessary scope to post notes).
-
-### Manifest validation
-
-`argo-compare` can validate rendered manifests against Kubernetes OpenAPI schemas using [kubeconform](https://github.com/yannh/kubeconform). Validation runs after rendering, helping catch schema violations before deployment. Results are included in stdout output and (when configured) GitLab MR comments.
-
-**Scope:** validation runs only against the source branch (the post-merge state — what will land on the target branch if the change is merged). All rendered manifests are validated, not just the ones that differ between branches — a value change can break a manifest the diff doesn't touch, and the validator's job is to confirm the whole result is deployable. The target branch is not validated; pre-existing breakage there is not the responsibility of the current change.
-
-Validation is **opt-in**. The comparison always runs to completion (diff is printed and any configured MR comment is posted) — but if any resource fails schema validation, or the validator itself cannot run, `argo-compare` exits with a non-zero status so CI can gate the merge.
-
-```bash
-argo-compare branch <target-branch> --validate-manifests
-```
-
-Optional flags:
-
-- `--kubeconform-path <path>` — Override the kubeconform binary location (defaults to `kubeconform` resolved via `PATH`).
-- `--skip-validation-kinds <Kind1,Kind2>` — Comma-separated list of resource kinds to skip (useful for custom resources without published schemas, e.g. `ServiceMonitor,ArgoApplication`).
-- `--schema-location <value>` — Extra kubeconform [`-schema-location`](https://github.com/yannh/kubeconform#overriding-schemas-location---air-gapped-environment) values appended after the built-in `default` registry. Repeat the flag (or pass a comma-separated list) to extend validation to Custom Resources. The most common case is pointing at the community [`datreeio/CRDs-catalog`](https://github.com/datreeio/CRDs-catalog) which ships JSON schemas for KEDA, Kyverno, and many other operators:
-  ```
-  --schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
-  ```
-
-Equivalent environment variables (CLI flags take precedence when both are set):
-
-```bash
-ARGO_COMPARE_VALIDATE_MANIFESTS=true \
-ARGO_COMPARE_KUBECONFORM_PATH=/usr/local/bin/kubeconform \
-ARGO_COMPARE_SKIP_VALIDATION_KINDS=ServiceMonitor,ArgoApplication \
-ARGO_COMPARE_KUBECONFORM_SCHEMA_LOCATIONS='https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
-argo-compare branch <target-branch>
-```
-
-`kubeconform` must be available in the runtime environment when validation is enabled. The published Docker image (`ghcr.io/shini4i/argo-compare`) bundles it; for standalone binary installs, install [kubeconform](https://github.com/yannh/kubeconform) separately.
-
-### Sensitive data handling
-
-`argo-compare` masks the rendered contents of Kubernetes `Secret` manifests before they reach stdout logs, external diff tools, or merge request comments. Each secret entry is replaced with a deterministic hash placeholder, allowing reviewers to spot that a value changed without exposing the underlying secret material.
-
-#### Password Protected Repositories
-Using password protected repositories is a bit more challenging. To make it work, we need to expose JSON as an environment variable.
-The JSON should contain the following fields:
-
-```json
-{
-  "url": "https://charts.example.com",
-  "username": "username",
-  "password": "password"
-}
-```
-How to properly expose it depends on the specific use case.
-
-A bash example:
-```bash
-export REPO_CREDS_EXAMPLE={\"url\":\"https://charts.example.com\",\"username\":\"username\",\"password\":\"password\"}
-```
-
-Where `EXAMPLE` is an identifier that is not used by the application.
-
-Argo Compare will look for all `REPO_CREDS_*` environment variables and use them if `url` will match the `repoURL` from Application manifest.
-
-#### OCI Registries
-
-Argo Compare supports charts hosted in OCI registries. Following the ArgoCD convention for Helm charts, the `repoURL` field should contain the bare registry hostname without the `oci://` scheme prefix:
-
-```yaml
-source:
-  chart: my-chart
-  repoURL: registry-1.docker.io/randomcharts
-  targetRevision: 15.9.0
-```
-
-For **public OCI registries** (e.g., `ghcr.io`), no additional configuration is required.
-
-For **private OCI registries**, credentials can be provided via `REPO_CREDS_*` environment variables (same format as above), or resolved automatically in the case of AWS ECR.
-
-#### AWS ECR
-
-Charts hosted in AWS ECR are authenticated automatically using the standard AWS credential chain (environment variables, IRSA, instance profiles, shared config). No manual credential configuration is needed — Argo Compare detects ECR registry URLs, extracts the region, and calls `ecr:GetAuthorizationToken` to obtain a short-lived token.
-
-Tokens are cached for the duration of the comparison run to avoid redundant API calls when multiple charts are hosted in the same registry.
-
-If AWS credentials are not available (e.g., running locally without AWS access), ECR authentication is skipped gracefully — public ECR charts will still work, and private charts will produce a clear error from Helm.
-
-
-## How it works
-
-1) First, this tool checks which Application files the source branch has modified since it diverged from the target branch (the merge-base is the baseline, so commits made only on the target branch after divergence are ignored).
-2) It will get the content of the changed Application files from the target branch.
-3) It will render manifests using the helm template using source and target branch values.
-4) It will get rid of helm related labels as they are not important for the comparison. (It can be skipped by providing `--preserve-helm-labels` flag)
-5) Optionally, when `--validate-manifests` is enabled, all source-branch rendered manifests (not just changed ones) are validated against Kubernetes schemas via `kubeconform`.
-6) As the last step, it will compare rendered manifest from the source and destination branches and print the
-   difference.
-
-## Anchored repositories (path-based sources)
-
-The default flow assumes the modified file in a PR _is_ the Application YAML. Some repositories split things up: the ArgoCD Application points at a chart directory inside the same repo (`spec.source.path`), or lives in a different repo that consumes a chart from this one. In both cases a PR typically touches chart values rather than the Application itself, so there is no `kind: Application` in the diff and the default flow finds nothing to compare.
-
-To bridge that gap, drop a `.argo-compare.yml` file into any directory where chart content is changed. Argo Compare walks up from each changed file, picks the nearest enclosing anchor, and uses it to find the Application affected by the change:
-
-```yaml
-# .argo-compare.yml — universal schema
-application:
-  # Optional. Omit when the Application lives in this same repo.
-  repo: ssh://git@example.com/group/apps.git
-  # Required. Path to the Application YAML inside that repo.
-  path: cluster-state/myapp/myapp.yaml
-  # Optional. Defaults to the remote's default branch.
-  branch: main
-```
-
-Two layouts work out of the box:
-
-- **Same-repo / all-in-one** — Application and chart live in the same repo. Drop a `.argo-compare.yml` next to the chart, omit `repo`, and point `path` at the Application YAML inside this repo.
-- **Manifest-only repo** — chart content lives here, Application lives elsewhere. Drop a `.argo-compare.yml` next to the chart, set `repo` to the apps repo, and point `path` at the Application YAML inside it.
-
-A worked example lives under [`examples/anchor/`](./examples/anchor).
-
-### Limits in this version
-
-- Only Helm sources are supported (`spec.source.chart` or `spec.source.path`). Kustomize / plain-YAML sources are not handled.
-- For path-based Applications, `spec.source.repoURL` must identify the local repository — chart sources living in a _third_ repo are out of scope.
-- A multi-source Application must use one kind consistently; mixing `chart` and `path` entries is rejected.
-- The anchored Application is read at the configured branch tip; commit-pinning is not supported.
-- Cross-repo Application reads use your local Git environment (SSH agent, `~/.gitconfig`). The `REPO_CREDS_*` mechanism remains Helm-only.
-- Any failure to fetch, parse, or validate an anchored Application is a hard error — partial output would silently hide a broken configuration.
-
-### Configuration
-
-- `--anchor-file <name>` (or `ARGO_COMPARE_ANCHOR_FILE`) overrides the anchor file name. Default: `.argo-compare.yml`. Pass an empty string to suppress discovery.
+- [Installation](docs/installation.md) — binary downloads and Docker image.
+- [Usage](docs/usage.md) — CLI flags, output modes, external diff tools.
+- [How it works](docs/how-it-works.md) — the comparison pipeline.
+- [Anchored repositories](docs/anchored-repositories.md) — path-based sources and chart-only repos via `.argo-compare.yml`.
+- [Manifest validation](docs/manifest-validation.md) — schema validation with `kubeconform`.
+- [Repository credentials](docs/repository-credentials.md) — private Helm repos, OCI registries, AWS ECR.
+- [Sensitive data handling](docs/sensitive-data.md) — Secret masking in diff output.
+- [GitLab integration](docs/gitlab-integration.md) — posting the diff as a Merge Request comment.
 
 ## Current limitations
 
-- The default change-detection flow looks for Application YAMLs in the diff. Repos that store chart content separately from their Application files should use [Anchored repositories](#anchored-repositories-path-based-sources) above.
-- <s>Does not support password protected repositories.</s>
+- The default change-detection flow looks for Application YAMLs in the diff. Repos that store chart content separately from their Application files should use [Anchored repositories](docs/anchored-repositories.md).
 
 ## Roadmap
 
@@ -238,4 +59,5 @@ A worked example lives under [`examples/anchor/`](./examples/anchor).
 - [x] Add manifest validation via kubeconform
 
 ## Contributing
+
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.

--- a/README.md
+++ b/README.md
@@ -186,14 +186,51 @@ If AWS credentials are not available (e.g., running locally without AWS access),
 6) As the last step, it will compare rendered manifest from the source and destination branches and print the
    difference.
 
+## Anchored repositories (path-based sources)
+
+The default flow assumes the modified file in a PR _is_ the Application YAML. Some repositories split things up: the ArgoCD Application points at a chart directory inside the same repo (`spec.source.path`), or lives in a different repo that consumes a chart from this one. In both cases a PR typically touches chart values rather than the Application itself, so there is no `kind: Application` in the diff and the default flow finds nothing to compare.
+
+To bridge that gap, drop a `.argo-compare.yml` file into any directory where chart content is changed. Argo Compare walks up from each changed file, picks the nearest enclosing anchor, and uses it to find the Application affected by the change:
+
+```yaml
+# .argo-compare.yml — universal schema
+application:
+  # Optional. Omit when the Application lives in this same repo.
+  repo: ssh://git@example.com/group/apps.git
+  # Required. Path to the Application YAML inside that repo.
+  path: cluster-state/myapp/myapp.yaml
+  # Optional. Defaults to the remote's default branch.
+  branch: main
+```
+
+Two layouts work out of the box:
+
+- **Same-repo / all-in-one** — Application and chart live in the same repo. Drop a `.argo-compare.yml` next to the chart, omit `repo`, and point `path` at the Application YAML inside this repo.
+- **Manifest-only repo** — chart content lives here, Application lives elsewhere. Drop a `.argo-compare.yml` next to the chart, set `repo` to the apps repo, and point `path` at the Application YAML inside it.
+
+A worked example lives under [`examples/anchor/`](./examples/anchor).
+
+### Limits in this version
+
+- Only Helm sources are supported (`spec.source.chart` or `spec.source.path`). Kustomize / plain-YAML sources are not handled.
+- For path-based Applications, `spec.source.repoURL` must identify the local repository — chart sources living in a _third_ repo are out of scope.
+- A multi-source Application must use one kind consistently; mixing `chart` and `path` entries is rejected.
+- The anchored Application is read at the configured branch tip; commit-pinning is not supported.
+- Cross-repo Application reads use your local Git environment (SSH agent, `~/.gitconfig`). The `REPO_CREDS_*` mechanism remains Helm-only.
+- Any failure to fetch, parse, or validate an anchored Application is a hard error — partial output would silently hide a broken configuration.
+
+### Configuration
+
+- `--anchor-file <name>` (or `ARGO_COMPARE_ANCHOR_FILE`) overrides the anchor file name. Default: `.argo-compare.yml`. Pass an empty string to suppress discovery.
+
 ## Current limitations
 
-- Works only with Applications that are using helm repositories and helm values present in the Application yaml.
+- The default change-detection flow looks for Application YAMLs in the diff. Repos that store chart content separately from their Application files should use [Anchored repositories](#anchored-repositories-path-based-sources) above.
 - <s>Does not support password protected repositories.</s>
 
 ## Roadmap
 
-- [ ] Add support for Application using git as a source of helm chart
+- [x] Add support for Application using git as a source of helm chart
 - [x] Add support for providing credentials for password protected helm repositories
 - [x] Add support for OCI registries (including AWS ECR with automatic authentication)
 - [x] Add support for posting diff as a comment to MR (GitLab)

--- a/cmd/argo-compare/command/root.go
+++ b/cmd/argo-compare/command/root.go
@@ -145,6 +145,7 @@ func newBranchCommand(opts Options, dropCache func() bool, debug func() bool) *c
 	cmd.Flags().StringVar(&flags.kubeconformPath, "kubeconform-path", flags.kubeconformPath, "Path to kubeconform binary")
 	cmd.Flags().StringSliceVar(&flags.validateSkipKinds, "skip-validation-kinds", flags.validateSkipKinds, "Resource kinds to skip during validation (comma-separated)")
 	cmd.Flags().StringSliceVar(&flags.validateSchemaLocations, "schema-location", flags.validateSchemaLocations, "Additional kubeconform -schema-location values (can be repeated or comma-separated)")
+	cmd.Flags().StringVar(&flags.anchorFileName, "anchor-file", flags.anchorFileName, "Name of the file that marks an anchor directory (default .argo-compare.yml; empty disables discovery)")
 
 	return cmd
 }
@@ -165,6 +166,7 @@ type branchFlags struct {
 	kubeconformPath         string
 	validateSkipKinds       []string
 	validateSchemaLocations []string
+	anchorFileName          string
 }
 
 // loadBranchDefaults gathers branch flag defaults from the environment.
@@ -232,6 +234,8 @@ func loadBranchDefaults() branchFlags {
 		}
 	}
 
+	defaults.anchorFileName = helpers.GetEnv("ARGO_COMPARE_ANCHOR_FILE", app.DefaultAnchorFileName)
+
 	return defaults
 }
 
@@ -260,6 +264,7 @@ func (b branchFlags) configOptions(opts Options, debugEnabled bool) ([]app.Confi
 		app.WithKubeconformPath(b.kubeconformPath),
 		app.WithValidateSkipKinds(b.validateSkipKinds),
 		app.WithValidateSchemaLocations(b.validateSchemaLocations),
+		app.WithAnchorFileName(b.anchorFileName),
 	}
 
 	commentOption, err := b.commentOption()

--- a/docs/anchored-repositories.md
+++ b/docs/anchored-repositories.md
@@ -1,0 +1,38 @@
+# Anchored repositories (path-based sources)
+
+The default flow assumes the modified file in a PR _is_ the Application YAML. Some repositories split things up: the ArgoCD Application points at a chart directory inside the same repo (`spec.source.path`), or lives in a different repo that consumes a chart from this one. In both cases a PR typically touches chart values rather than the Application itself, so there is no `kind: Application` in the diff and the default flow finds nothing to compare.
+
+To bridge that gap, drop a `.argo-compare.yml` file into any directory where chart content is changed. Argo Compare walks up from each changed file, picks the nearest enclosing anchor, and uses it to find the Application affected by the change:
+
+```yaml
+# .argo-compare.yml — universal schema
+application:
+  # Optional. Omit when the Application lives in this same repo.
+  repo: ssh://git@example.com/group/apps.git
+  # Required. Path to the Application YAML inside that repo.
+  path: cluster-state/myapp/myapp.yaml
+  # Optional. Defaults to the remote's default branch.
+  branch: main
+```
+
+## Supported layouts
+
+Two layouts work out of the box:
+
+- **Same-repo / all-in-one** — Application and chart live in the same repo. Drop a `.argo-compare.yml` next to the chart, omit `repo`, and point `path` at the Application YAML inside this repo.
+- **Manifest-only repo** — chart content lives here, Application lives elsewhere. Drop a `.argo-compare.yml` next to the chart, set `repo` to the apps repo, and point `path` at the Application YAML inside it.
+
+A worked example lives under [`examples/anchor/`](../examples/anchor).
+
+## Limits in this version
+
+- Only Helm sources are supported (`spec.source.chart` or `spec.source.path`). Kustomize / plain-YAML sources are not handled.
+- For path-based Applications, `spec.source.repoURL` must identify the local repository — chart sources living in a _third_ repo are out of scope.
+- A multi-source Application must use one kind consistently; mixing `chart` and `path` entries is rejected.
+- The anchored Application is read at the configured branch tip; commit-pinning is not supported.
+- Cross-repo Application reads use your local Git environment (SSH agent, `~/.gitconfig`). The `REPO_CREDS_*` mechanism remains Helm-only.
+- Any failure to fetch, parse, or validate an anchored Application is a hard error — partial output would silently hide a broken configuration.
+
+## Configuration
+
+- `--anchor-file <name>` (or `ARGO_COMPARE_ANCHOR_FILE`) overrides the anchor file name. Default: `.argo-compare.yml`. Pass an empty string to suppress discovery.

--- a/docs/gitlab-integration.md
+++ b/docs/gitlab-integration.md
@@ -1,0 +1,33 @@
+# GitLab integration
+
+`argo-compare` can post the comparison output as a comment on a GitLab Merge Request. Configure it with environment variables:
+
+```bash
+ARGO_COMPARE_COMMENT_PROVIDER=gitlab \
+ARGO_COMPARE_GITLAB_URL=https://gitlab.com \
+ARGO_COMPARE_GITLAB_TOKEN=$GITLAB_TOKEN \
+ARGO_COMPARE_GITLAB_PROJECT_ID=12345 \
+ARGO_COMPARE_GITLAB_MR_IID=10 \
+argo-compare branch <target-branch>
+```
+
+Equivalent CLI flags are available:
+
+```bash
+argo-compare branch <target-branch> \
+  --comment-provider gitlab \
+  --gitlab-url https://gitlab.com \
+  --gitlab-token "$GITLAB_TOKEN" \
+  --gitlab-project-id 12345 \
+  --gitlab-merge-request-iid 10
+```
+
+## GitLab CI auto-detection
+
+When running inside GitLab CI, most settings are detected automatically:
+
+- `--comment-provider` defaults to `gitlab` when `GITLAB_CI` and `CI_MERGE_REQUEST_IID` are present.
+- `--gitlab-url` falls back to `CI_SERVER_URL`.
+- `--gitlab-project-id` falls back to `CI_PROJECT_ID`.
+- `--gitlab-merge-request-iid` falls back to `CI_MERGE_REQUEST_IID`.
+- `--gitlab-token` falls back to `CI_JOB_TOKEN` if no explicit token is provided (ensure the token has the necessary scope to post notes).

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,0 +1,10 @@
+# How it works
+
+1. `argo-compare` checks which Application files the source branch has modified since it diverged from the target branch (the merge-base is the baseline, so commits made only on the target branch after divergence are ignored).
+2. It fetches the content of the changed Application files from the target branch.
+3. It renders manifests using `helm template` against both source and target branch values.
+4. It strips Helm-injected labels since they are not meaningful for the comparison (skip with `--preserve-helm-labels`).
+5. Optionally, when `--validate-manifests` is enabled, all source-branch rendered manifests (not just changed ones) are validated against Kubernetes schemas via `kubeconform`. See [Manifest validation](manifest-validation.md).
+6. Finally, it compares the rendered manifests from the source and target branches and prints the difference.
+
+Repositories where the PR touches chart content instead of the Application YAML follow a different entry path; see [Anchored repositories](anchored-repositories.md).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,25 @@
+# Installation
+
+`argo-compare` ships as a standalone binary and as a Docker image.
+
+## Binary
+
+Download the latest release from the [Releases](https://github.com/shini4i/argo-compare/releases) page for your platform and place the binary somewhere on your `PATH`.
+
+## Docker
+
+```bash
+docker pull ghcr.io/shini4i/argo-compare:<version>
+```
+
+To run the image against your working tree:
+
+```bash
+docker run -it \
+  --mount type=bind,source="$(pwd)",target=/apps \
+  --env EXTERNAL_DIFF_TOOL=diff-so-fancy \
+  --workdir /apps \
+  ghcr.io/shini4i/argo-compare:<version> branch <target-branch> --full-output
+```
+
+The published image bundles [`kubeconform`](https://github.com/yannh/kubeconform), so [manifest validation](manifest-validation.md) works out of the box. For standalone binary installs that need validation, install `kubeconform` separately.

--- a/docs/manifest-validation.md
+++ b/docs/manifest-validation.md
@@ -1,0 +1,41 @@
+# Manifest validation
+
+`argo-compare` can validate rendered manifests against Kubernetes OpenAPI schemas using [kubeconform](https://github.com/yannh/kubeconform). Validation runs after rendering, helping catch schema violations before deployment. Results are included in stdout output and (when configured) GitLab MR comments.
+
+## Scope
+
+Validation runs only against the **source branch** (the post-merge state — what will land on the target branch if the change is merged). All rendered manifests are validated, not just the ones that differ between branches — a value change can break a manifest the diff doesn't touch, and the validator's job is to confirm the whole result is deployable. The target branch is not validated; pre-existing breakage there is not the responsibility of the current change.
+
+## Behavior
+
+Validation is **opt-in**. The comparison always runs to completion (diff is printed and any configured MR comment is posted) — but if any resource fails schema validation, or the validator itself cannot run, `argo-compare` exits with a non-zero status so CI can gate the merge.
+
+```bash
+argo-compare branch <target-branch> --validate-manifests
+```
+
+## Flags
+
+- `--kubeconform-path <path>` — Override the kubeconform binary location (defaults to `kubeconform` resolved via `PATH`).
+- `--skip-validation-kinds <Kind1,Kind2>` — Comma-separated list of resource kinds to skip (useful for custom resources without published schemas, e.g. `ServiceMonitor,ArgoApplication`).
+- `--schema-location <value>` — Extra kubeconform [`-schema-location`](https://github.com/yannh/kubeconform#overriding-schemas-location---air-gapped-environment) values appended after the built-in `default` registry. Repeat the flag (or pass a comma-separated list) to extend validation to Custom Resources. The most common case is pointing at the community [`datreeio/CRDs-catalog`](https://github.com/datreeio/CRDs-catalog) which ships JSON schemas for KEDA, Kyverno, and many other operators:
+
+  ```
+  --schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
+  ```
+
+## Environment variables
+
+CLI flags take precedence when both are set:
+
+```bash
+ARGO_COMPARE_VALIDATE_MANIFESTS=true \
+ARGO_COMPARE_KUBECONFORM_PATH=/usr/local/bin/kubeconform \
+ARGO_COMPARE_SKIP_VALIDATION_KINDS=ServiceMonitor,ArgoApplication \
+ARGO_COMPARE_KUBECONFORM_SCHEMA_LOCATIONS='https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+argo-compare branch <target-branch>
+```
+
+## Requirements
+
+`kubeconform` must be available in the runtime environment when validation is enabled. The published Docker image (`ghcr.io/shini4i/argo-compare`) bundles it; for standalone binary installs, install [kubeconform](https://github.com/yannh/kubeconform) separately.

--- a/docs/repository-credentials.md
+++ b/docs/repository-credentials.md
@@ -1,0 +1,45 @@
+# Repository credentials
+
+Public Helm repositories work with no configuration. For private sources, `argo-compare` reads credentials from environment variables matched against the `repoURL` of each Application.
+
+## Password-protected Helm repositories
+
+Expose credentials as a JSON object in an environment variable named `REPO_CREDS_*`, where the suffix is any identifier you choose:
+
+```json
+{
+  "url": "https://charts.example.com",
+  "username": "username",
+  "password": "password"
+}
+```
+
+Bash example:
+
+```bash
+export REPO_CREDS_EXAMPLE='{"url":"https://charts.example.com","username":"username","password":"password"}'
+```
+
+`argo-compare` scans every `REPO_CREDS_*` variable and applies the entry whose `url` matches the `repoURL` of the Application being rendered.
+
+## OCI registries
+
+`argo-compare` supports charts hosted in OCI registries. Following the ArgoCD convention for Helm charts, the `repoURL` field contains the bare registry hostname without the `oci://` scheme prefix:
+
+```yaml
+source:
+  chart: my-chart
+  repoURL: registry-1.docker.io/randomcharts
+  targetRevision: 15.9.0
+```
+
+- **Public OCI registries** (e.g. `ghcr.io`) — no additional configuration required.
+- **Private OCI registries** — provide credentials via the same `REPO_CREDS_*` mechanism described above, or use the automatic AWS ECR flow below.
+
+## AWS ECR
+
+Charts hosted in AWS ECR are authenticated automatically using the standard AWS credential chain (environment variables, IRSA, instance profiles, shared config). No manual credential configuration is needed — `argo-compare` detects ECR registry URLs, extracts the region, and calls `ecr:GetAuthorizationToken` to obtain a short-lived token.
+
+Tokens are cached for the duration of the comparison run to avoid redundant API calls when multiple charts are hosted in the same registry.
+
+If AWS credentials are not available (e.g. running locally without AWS access), ECR authentication is skipped gracefully — public ECR charts still work, and private charts produce a clear error from Helm.

--- a/docs/sensitive-data.md
+++ b/docs/sensitive-data.md
@@ -1,3 +1,0 @@
-# Sensitive data handling
-
-`argo-compare` masks the rendered contents of Kubernetes `Secret` manifests before they reach stdout logs, external diff tools, or merge request comments. Each secret entry is replaced with a deterministic hash placeholder, allowing reviewers to spot that a value changed without exposing the underlying secret material.

--- a/docs/sensitive-data.md
+++ b/docs/sensitive-data.md
@@ -1,0 +1,3 @@
+# Sensitive data handling
+
+`argo-compare` masks the rendered contents of Kubernetes `Secret` manifests before they reach stdout logs, external diff tools, or merge request comments. Each secret entry is replaced with a deterministic hash placeholder, allowing reviewers to spot that a value changed without exposing the underlying secret material.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,49 @@
+# Usage
+
+## Comparing a branch
+
+The simplest scenario is to compare every changed Application file in the current branch against a target branch:
+
+```bash
+argo-compare branch <target-branch>
+```
+
+To restrict the comparison to a single file:
+
+```bash
+argo-compare branch <target-branch> --file <file-path>
+```
+
+## Output modes
+
+By default, `argo-compare` prints only the diff of changed manifests. To include added or removed manifests in full:
+
+```bash
+# Print added manifests in addition to the diff
+argo-compare branch <target-branch> --print-added-manifests
+
+# Print removed manifests in addition to the diff
+argo-compare branch <target-branch> --print-removed-manifests
+
+# Print added, removed, and changed manifests
+argo-compare branch <target-branch> --full-output
+```
+
+## External diff tool
+
+Set `EXTERNAL_DIFF_TOOL` to pipe each file diff through a third-party tool such as [`diff-so-fancy`](https://github.com/so-fancy/diff-so-fancy):
+
+```bash
+EXTERNAL_DIFF_TOOL=diff-so-fancy argo-compare branch <target-branch>
+```
+
+## Helm labels
+
+Helm-injected labels are stripped from rendered manifests before comparison because they add noise without changing the deployed state. Pass `--preserve-helm-labels` to keep them.
+
+## Where to next
+
+- [Anchored repositories](anchored-repositories.md) — for repos where the PR touches chart content instead of the Application YAML.
+- [Manifest validation](manifest-validation.md) — schema-check rendered manifests with `kubeconform`.
+- [GitLab integration](gitlab-integration.md) — post the diff as an MR comment.
+- [Repository credentials](repository-credentials.md) — authenticate to private chart sources.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -41,6 +41,10 @@ EXTERNAL_DIFF_TOOL=diff-so-fancy argo-compare branch <target-branch>
 
 Helm-injected labels are stripped from rendered manifests before comparison because they add noise without changing the deployed state. Pass `--preserve-helm-labels` to keep them.
 
+## Sensitive data
+
+`argo-compare` masks the rendered contents of Kubernetes `Secret` manifests before they reach stdout logs, external diff tools, or merge request comments. Each secret entry is replaced with a deterministic hash placeholder, allowing reviewers to spot that a value changed without exposing the underlying secret material.
+
 ## Where to next
 
 - [Anchored repositories](anchored-repositories.md) — for repos where the PR touches chart content instead of the Application YAML.

--- a/examples/anchor/README.md
+++ b/examples/anchor/README.md
@@ -1,0 +1,56 @@
+# `.argo-compare.yml` anchor examples
+
+These fixtures illustrate the two layouts that the anchor flow supports.
+Replace `example.com` and `group/repo` with the URLs that match your
+environment; the files are not exercised by tests.
+
+## Same-repo / all-in-one
+
+The ArgoCD Application and the chart it consumes live in the same repository:
+
+```
+.
+├── apps/
+│   └── myapp.yaml                  # ArgoCD Application, spec.source.path: charts/myapp
+└── charts/
+    └── myapp/
+        ├── .argo-compare.yml       # anchor pointing back at apps/myapp.yaml
+        ├── Chart.yaml
+        ├── values.yaml
+        └── templates/
+            └── deployment.yaml
+```
+
+See [`same-repo/`](./same-repo) for the file contents.
+
+## Manifest-only repository
+
+The ArgoCD Application lives in a different repo (an "apps" repo); this
+repo just hosts the chart content the Application consumes:
+
+```
+.
+└── charts/
+    └── myapp/
+        ├── .argo-compare.yml       # anchor pointing at the external apps repo
+        ├── Chart.yaml
+        ├── values.yaml
+        └── templates/
+            └── deployment.yaml
+```
+
+See [`cross-repo/`](./cross-repo) for the file contents.
+
+## How to test against a fixture
+
+From inside a clone of either repository layout, run:
+
+```bash
+argo-compare branch main
+```
+
+Argo Compare detects the changed file under `charts/myapp/`, walks up to
+the nearest `.argo-compare.yml`, fetches the named Application (locally
+or via a clone of the apps repo), and renders the chart twice — once
+against the working tree (post-PR state) and once against the merge-base
+(pre-PR state) — before producing the diff.

--- a/examples/anchor/README.md
+++ b/examples/anchor/README.md
@@ -1,12 +1,16 @@
 # `.argo-compare.yml` anchor examples
 
-These fixtures illustrate the two layouts that the anchor flow supports.
-Replace `example.com` and `group/repo` with the URLs that match your
-environment; the files are not exercised by tests.
+Structural reference fixtures for the two repository layouts the anchor
+flow supports. These are not runnable — the umbrella `Chart.yaml`
+declares a dependency on `https://charts.example.com` which does not
+resolve. Replace the placeholder URLs (`example.com`, `group/repo`)
+with the values that match your environment before using these files
+in a real repository.
 
 ## Same-repo / all-in-one
 
-The ArgoCD Application and the chart it consumes live in the same repository:
+The ArgoCD Application and the chart it consumes live in the same
+repository. See [`same-repo/`](./same-repo) for the files.
 
 ```
 .
@@ -16,17 +20,14 @@ The ArgoCD Application and the chart it consumes live in the same repository:
     └── myapp/
         ├── .argo-compare.yml       # anchor pointing back at apps/myapp.yaml
         ├── Chart.yaml
-        ├── values.yaml
-        └── templates/
-            └── deployment.yaml
+        └── values.yaml
 ```
-
-See [`same-repo/`](./same-repo) for the file contents.
 
 ## Manifest-only repository
 
 The ArgoCD Application lives in a different repo (an "apps" repo); this
-repo just hosts the chart content the Application consumes:
+repo just hosts the chart content the Application consumes. See
+[`cross-repo/`](./cross-repo) for the files.
 
 ```
 .
@@ -34,23 +35,14 @@ repo just hosts the chart content the Application consumes:
     └── myapp/
         ├── .argo-compare.yml       # anchor pointing at the external apps repo
         ├── Chart.yaml
-        ├── values.yaml
-        └── templates/
-            └── deployment.yaml
+        └── values.yaml
 ```
 
-See [`cross-repo/`](./cross-repo) for the file contents.
+## How the anchor flow uses these files
 
-## How to test against a fixture
-
-From inside a clone of either repository layout, run:
-
-```bash
-argo-compare branch main
-```
-
-Argo Compare detects the changed file under `charts/myapp/`, walks up to
-the nearest `.argo-compare.yml`, fetches the named Application (locally
-or via a clone of the apps repo), and renders the chart twice — once
-against the working tree (post-PR state) and once against the merge-base
-(pre-PR state) — before producing the diff.
+When a PR touches a file under `charts/myapp/`, argo-compare walks up
+to the nearest `.argo-compare.yml`, fetches the named Application
+(reading from the local working tree for same-repo, or via an
+in-memory clone for cross-repo), and renders the chart twice — once
+against the working tree (post-PR state) and once against the
+merge-base (pre-PR state) — before producing the diff.

--- a/examples/anchor/cross-repo/charts/myapp/.argo-compare.yml
+++ b/examples/anchor/cross-repo/charts/myapp/.argo-compare.yml
@@ -1,0 +1,5 @@
+application:
+  # The Application lives in a different repo (an "apps" repo).
+  repo: ssh://git@git.example.com/group/apps.git
+  path: cluster-state/myapp/myapp.yaml
+  branch: main

--- a/examples/anchor/cross-repo/charts/myapp/Chart.yaml
+++ b/examples/anchor/cross-repo/charts/myapp/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: myapp
+description: Example umbrella chart wrapping an upstream Helm chart.
+type: application
+version: 0.1.0
+dependencies:
+  - name: web-app
+    version: "0.9.0"
+    repository: "https://charts.example.com"
+    alias: myapp

--- a/examples/anchor/cross-repo/charts/myapp/values.yaml
+++ b/examples/anchor/cross-repo/charts/myapp/values.yaml
@@ -1,0 +1,7 @@
+myapp:
+  image:
+    repository: registry.example.com/myapp/myapp
+    tag: "1.2.3"
+  service:
+    port: 80
+    targetPort: 8080

--- a/examples/anchor/same-repo/apps/myapp.yaml
+++ b/examples/anchor/same-repo/apps/myapp.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: myapp
+  namespace: argocd
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: myapp
+  source:
+    repoURL: ssh://git@git.example.com/group/repo.git
+    path: charts/myapp
+    targetRevision: main
+    helm:
+      releaseName: myapp
+      values: |
+        replicaCount: 2
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/examples/anchor/same-repo/charts/myapp/.argo-compare.yml
+++ b/examples/anchor/same-repo/charts/myapp/.argo-compare.yml
@@ -1,0 +1,3 @@
+application:
+  # No `repo:` set — the Application lives in this same repo.
+  path: apps/myapp.yaml

--- a/examples/anchor/same-repo/charts/myapp/Chart.yaml
+++ b/examples/anchor/same-repo/charts/myapp/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: myapp
+description: Example umbrella chart wrapping an upstream Helm chart.
+type: application
+version: 0.1.0
+dependencies:
+  - name: web-app
+    version: "0.9.0"
+    repository: "https://charts.example.com"
+    alias: myapp

--- a/examples/anchor/same-repo/charts/myapp/values.yaml
+++ b/examples/anchor/same-repo/charts/myapp/values.yaml
@@ -1,0 +1,7 @@
+myapp:
+  image:
+    repository: registry.example.com/myapp/myapp
+    tag: "1.2.3"
+  service:
+    port: 80
+    targetPort: 8080

--- a/internal/anchor/anchor.go
+++ b/internal/anchor/anchor.go
@@ -1,0 +1,67 @@
+// Package anchor defines the .argo-compare.yml configuration file used by
+// argo-compare to locate the ArgoCD Application affected by changes in a
+// directory. The file acts as a forward pointer from "where changes happen"
+// (e.g. Helm values, umbrella chart) to "the Application whose render is
+// affected" — which may live in the same repo or a different one.
+package anchor
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/afero"
+	"gopkg.in/yaml.v3"
+)
+
+// Anchor is the top-level schema of a .argo-compare.yml file.
+type Anchor struct {
+	Application ApplicationRef `yaml:"application"`
+}
+
+// ApplicationRef points to an ArgoCD Application manifest somewhere in Git.
+//
+// Repo and Branch are optional; their resolution semantics (e.g. defaulting
+// to the local repo, defaulting to a remote's default branch) are defined
+// by the consumer that loads this struct.
+//
+// Path is required and identifies the Application YAML inside the target repo.
+type ApplicationRef struct {
+	Repo   string `yaml:"repo,omitempty"`
+	Path   string `yaml:"path"`
+	Branch string `yaml:"branch,omitempty"`
+}
+
+// ErrInvalidAnchor is returned for any structural or semantic failure
+// while loading a .argo-compare.yml file. Callers should treat it as a
+// hard error; the comparison cannot proceed without a valid anchor.
+var ErrInvalidAnchor = errors.New("invalid .argo-compare.yml")
+
+// Load reads and validates a .argo-compare.yml file from fs.
+//
+// The decoder is strict: unknown top-level keys, unknown keys inside the
+// application block, and malformed YAML all yield an error. After
+// decoding, application.path is required and must be non-empty.
+func Load(fs afero.Fs, path string) (Anchor, error) {
+	raw, err := afero.ReadFile(fs, path)
+	if err != nil {
+		return Anchor{}, fmt.Errorf("read anchor %q: %w", path, err)
+	}
+
+	var a Anchor
+	dec := yaml.NewDecoder(bytes.NewReader(raw))
+	dec.KnownFields(true)
+	if err := dec.Decode(&a); err != nil && !errors.Is(err, io.EOF) {
+		// io.EOF means the document was empty or comment-only. Fall through to
+		// the required-field check so the user sees a consistent message.
+		return Anchor{}, fmt.Errorf("%w: parse %q: %w", ErrInvalidAnchor, path, err)
+	}
+
+	if strings.TrimSpace(a.Application.Path) == "" {
+		return Anchor{}, fmt.Errorf("%w: %s: application.path is required", ErrInvalidAnchor, path)
+	}
+
+	return a, nil
+}

--- a/internal/anchor/anchor_test.go
+++ b/internal/anchor/anchor_test.go
@@ -1,0 +1,134 @@
+package anchor
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoad_SameRepo(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/repo/charts/foo/.argo-compare.yml", []byte(`
+application:
+  path: cluster-state/foo/foo.yaml
+`), 0o644))
+
+	got, err := Load(fs, "/repo/charts/foo/.argo-compare.yml")
+	require.NoError(t, err)
+	assert.Equal(t, "cluster-state/foo/foo.yaml", got.Application.Path)
+	assert.Empty(t, got.Application.Repo, "same-repo anchor should leave Repo empty")
+	assert.Empty(t, got.Application.Branch, "branch is optional")
+}
+
+func TestLoad_CrossRepo(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/repo/manifests/foo/staging/.argo-compare.yml", []byte(`
+application:
+  repo: ssh://git@example.com/group/apps.git
+  path: stage/foo.yaml
+  branch: main
+`), 0o644))
+
+	got, err := Load(fs, "/repo/manifests/foo/staging/.argo-compare.yml")
+	require.NoError(t, err)
+	assert.Equal(t, "ssh://git@example.com/group/apps.git", got.Application.Repo)
+	assert.Equal(t, "stage/foo.yaml", got.Application.Path)
+	assert.Equal(t, "main", got.Application.Branch)
+}
+
+func TestLoad_MissingApplicationPath(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/repo/a/.argo-compare.yml", []byte(`
+application:
+  repo: ssh://git@example.com/group/apps.git
+  branch: main
+`), 0o644))
+
+	_, err := Load(fs, "/repo/a/.argo-compare.yml")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidAnchor)
+	assert.Contains(t, err.Error(), "application.path")
+}
+
+func TestLoad_MissingApplicationBlock(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/repo/a/.argo-compare.yml", []byte("# only a comment\n"), 0o644))
+
+	_, err := Load(fs, "/repo/a/.argo-compare.yml")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidAnchor)
+	assert.Contains(t, err.Error(), "application.path")
+}
+
+func TestLoad_MalformedYAML(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/repo/a/.argo-compare.yml", []byte("application: : : not-yaml\n"), 0o644))
+
+	_, err := Load(fs, "/repo/a/.argo-compare.yml")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidAnchor)
+}
+
+func TestLoad_UnknownTopLevelKey(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/repo/a/.argo-compare.yml", []byte(`
+application:
+  path: x.yaml
+extras:
+  unsupported: true
+`), 0o644))
+
+	_, err := Load(fs, "/repo/a/.argo-compare.yml")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidAnchor)
+	assert.Contains(t, err.Error(), "extras")
+}
+
+func TestLoad_UnknownApplicationKey(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/repo/a/.argo-compare.yml", []byte(`
+application:
+  path: x.yaml
+  commit: abc123
+`), 0o644))
+
+	_, err := Load(fs, "/repo/a/.argo-compare.yml")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidAnchor)
+	assert.Contains(t, err.Error(), "commit")
+}
+
+func TestLoad_FileNotFound(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	_, err := Load(fs, "/repo/missing/.argo-compare.yml")
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrInvalidAnchor, "read errors must stay distinct from invalid-anchor errors")
+}
+
+func TestLoad_EmptyApplicationPath(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/repo/a/.argo-compare.yml", []byte(`
+application:
+  path: ""
+`), 0o644))
+
+	_, err := Load(fs, "/repo/a/.argo-compare.yml")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidAnchor)
+	assert.Contains(t, err.Error(), "application.path")
+}
+
+func TestLoad_WhitespaceApplicationPath(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/repo/a/.argo-compare.yml", []byte(`
+application:
+  path: "   "
+`), 0o644))
+
+	_, err := Load(fs, "/repo/a/.argo-compare.yml")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidAnchor)
+	assert.Contains(t, err.Error(), "application.path")
+}

--- a/internal/app/anchor_discovery.go
+++ b/internal/app/anchor_discovery.go
@@ -1,0 +1,109 @@
+package app
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/shini4i/argo-compare/internal/anchor"
+
+	"github.com/spf13/afero"
+)
+
+// AnchorGroup is the result of grouping changed files by the nearest
+// enclosing `.argo-compare.yml`. Dir is the absolute path of the directory
+// that contains the anchor file. ChangedFiles is the subset of the
+// caller-supplied diff that lives at or below Dir, preserved with the
+// caller's original relative paths.
+type AnchorGroup struct {
+	Dir          string
+	Anchor       anchor.Anchor
+	ChangedFiles []string
+}
+
+// DiscoverAnchors walks up from each changed file to find the nearest
+// directory inside repoRoot that contains a file named anchorFileName,
+// loads that anchor once per directory, and groups the changed files by
+// their anchor directory.
+//
+// Files with no enclosing anchor inside repoRoot are silently dropped:
+// they belong to the existing changed-Application flow, not the anchor
+// flow. A malformed anchor file is a hard error so the caller can fail
+// loudly; partial results would silently hide a broken configuration.
+//
+// The returned slice is sorted by Dir for deterministic downstream logs
+// and comments.
+func DiscoverAnchors(repoRoot string, changedFiles []string, fs afero.Fs, anchorFileName string) ([]AnchorGroup, error) {
+	repoRoot = filepath.Clean(repoRoot)
+
+	cache := map[string]anchor.Anchor{}
+	files := map[string][]string{}
+
+	for _, rel := range changedFiles {
+		dir, err := findAnchorDir(fs, repoRoot, filepath.Dir(filepath.Join(repoRoot, rel)), anchorFileName)
+		if err != nil {
+			return nil, err
+		}
+		if dir == "" {
+			continue
+		}
+		if _, ok := cache[dir]; !ok {
+			a, err := anchor.Load(fs, filepath.Join(dir, anchorFileName))
+			if err != nil {
+				return nil, err
+			}
+			cache[dir] = a
+		}
+		files[dir] = append(files[dir], rel)
+	}
+
+	groups := make([]AnchorGroup, 0, len(cache))
+	for dir, a := range cache {
+		dirFiles := files[dir]
+		sort.Strings(dirFiles)
+		groups = append(groups, AnchorGroup{
+			Dir:          dir,
+			Anchor:       a,
+			ChangedFiles: dirFiles,
+		})
+	}
+	sort.Slice(groups, func(i, j int) bool { return groups[i].Dir < groups[j].Dir })
+	return groups, nil
+}
+
+// findAnchorDir walks from start upward until it finds a directory containing
+// anchorFileName, returning that directory's absolute path. It stops at
+// (and includes) repoRoot, and returns "" if no anchor exists in the chain.
+func findAnchorDir(fs afero.Fs, repoRoot, start, anchorFileName string) (string, error) {
+	dir := start
+	for {
+		if !pathWithin(repoRoot, dir) {
+			return "", nil
+		}
+		exists, err := afero.Exists(fs, filepath.Join(dir, anchorFileName))
+		if err != nil {
+			return "", fmt.Errorf("check %s at %q: %w", anchorFileName, dir, err)
+		}
+		if exists {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", nil
+		}
+		dir = parent
+	}
+}
+
+// pathWithin reports whether dir is repoRoot itself or a descendant of it.
+func pathWithin(repoRoot, dir string) bool {
+	if dir == repoRoot {
+		return true
+	}
+	rel, err := filepath.Rel(repoRoot, dir)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}

--- a/internal/app/anchor_discovery_test.go
+++ b/internal/app/anchor_discovery_test.go
@@ -1,0 +1,145 @@
+package app
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/shini4i/argo-compare/internal/anchor"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const anchorFileName = ".argo-compare.yml"
+
+func writeAnchor(t *testing.T, fs afero.Fs, dir, path string) {
+	t.Helper()
+	require.NoError(t, afero.WriteFile(fs, dir+"/"+anchorFileName, []byte("application:\n  path: "+path+"\n"), 0o644))
+}
+
+func TestDiscoverAnchors_SingleAnchor(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	writeAnchor(t, fs, "/repo/charts/foo", "cluster-state/foo.yaml")
+
+	groups, err := DiscoverAnchors("/repo", []string{
+		"charts/foo/values.yaml",
+		"charts/foo/Chart.yaml",
+	}, fs, anchorFileName)
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+
+	assert.Equal(t, "/repo/charts/foo", groups[0].Dir)
+	assert.Equal(t, "cluster-state/foo.yaml", groups[0].Anchor.Application.Path)
+	sort.Strings(groups[0].ChangedFiles)
+	assert.Equal(t, []string{"charts/foo/Chart.yaml", "charts/foo/values.yaml"}, groups[0].ChangedFiles)
+}
+
+func TestDiscoverAnchors_MultipleAnchors(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	writeAnchor(t, fs, "/repo/charts/foo", "apps/foo.yaml")
+	writeAnchor(t, fs, "/repo/charts/bar", "apps/bar.yaml")
+
+	groups, err := DiscoverAnchors("/repo", []string{
+		"charts/foo/values.yaml",
+		"charts/bar/values.yaml",
+		"charts/bar/templates/x.yaml",
+	}, fs, anchorFileName)
+	require.NoError(t, err)
+	require.Len(t, groups, 2)
+
+	byDir := map[string]AnchorGroup{}
+	for _, g := range groups {
+		byDir[g.Dir] = g
+	}
+
+	foo := byDir["/repo/charts/foo"]
+	assert.Equal(t, "apps/foo.yaml", foo.Anchor.Application.Path)
+	assert.Equal(t, []string{"charts/foo/values.yaml"}, foo.ChangedFiles)
+
+	bar := byDir["/repo/charts/bar"]
+	sort.Strings(bar.ChangedFiles)
+	assert.Equal(t, "apps/bar.yaml", bar.Anchor.Application.Path)
+	assert.Equal(t, []string{"charts/bar/templates/x.yaml", "charts/bar/values.yaml"}, bar.ChangedFiles)
+}
+
+func TestDiscoverAnchors_NestedAnchorsPickNearest(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	writeAnchor(t, fs, "/repo/charts", "apps/outer.yaml")
+	writeAnchor(t, fs, "/repo/charts/foo", "apps/foo.yaml")
+
+	groups, err := DiscoverAnchors("/repo", []string{
+		"charts/foo/values.yaml",
+	}, fs, anchorFileName)
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+	assert.Equal(t, "/repo/charts/foo", groups[0].Dir, "should pick the nearest enclosing anchor")
+}
+
+func TestDiscoverAnchors_FilesWithNoEnclosingAnchor(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	// No .argo-compare.yml anywhere.
+	groups, err := DiscoverAnchors("/repo", []string{
+		"apps/foo.yaml",
+		"apps/bar.yaml",
+	}, fs, anchorFileName)
+	require.NoError(t, err)
+	assert.Empty(t, groups, "files with no enclosing anchor produce no groups")
+}
+
+func TestDiscoverAnchors_MixedAnchoredAndUnanchored(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	writeAnchor(t, fs, "/repo/charts/foo", "apps/foo.yaml")
+
+	groups, err := DiscoverAnchors("/repo", []string{
+		"charts/foo/values.yaml",
+		"apps/some-app.yaml", // not under any anchor
+	}, fs, anchorFileName)
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+	assert.Equal(t, []string{"charts/foo/values.yaml"}, groups[0].ChangedFiles)
+}
+
+func TestDiscoverAnchors_AnchorFileItselfChanged(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	writeAnchor(t, fs, "/repo/charts/foo", "apps/foo.yaml")
+
+	groups, err := DiscoverAnchors("/repo", []string{
+		"charts/foo/.argo-compare.yml",
+	}, fs, anchorFileName)
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+	assert.Equal(t, "/repo/charts/foo", groups[0].Dir)
+	assert.Equal(t, []string{"charts/foo/.argo-compare.yml"}, groups[0].ChangedFiles)
+}
+
+func TestDiscoverAnchors_RepoRootAnchor(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	writeAnchor(t, fs, "/repo", "apps/root.yaml")
+
+	groups, err := DiscoverAnchors("/repo", []string{
+		"values.yaml",
+		"nested/inner/file.yaml",
+	}, fs, anchorFileName)
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+	assert.Equal(t, "/repo", groups[0].Dir)
+}
+
+func TestDiscoverAnchors_InvalidAnchorFile(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/repo/charts/foo/.argo-compare.yml", []byte("not-yaml: : :"), 0o644))
+
+	_, err := DiscoverAnchors("/repo", []string{
+		"charts/foo/values.yaml",
+	}, fs, anchorFileName)
+	require.Error(t, err, "malformed .argo-compare.yml must be a hard error")
+	assert.ErrorIs(t, err, anchor.ErrInvalidAnchor)
+}
+
+func TestDiscoverAnchors_EmptyChangedFiles(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	groups, err := DiscoverAnchors("/repo", nil, fs, anchorFileName)
+	require.NoError(t, err)
+	assert.Empty(t, groups)
+}

--- a/internal/app/anchor_flow.go
+++ b/internal/app/anchor_flow.go
@@ -1,0 +1,273 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"strings"
+
+	"github.com/shini4i/argo-compare/internal/anchor"
+	"github.com/shini4i/argo-compare/internal/models"
+	"github.com/shini4i/argo-compare/internal/ports"
+	"github.com/shini4i/argo-compare/internal/ui"
+
+	"github.com/spf13/afero"
+)
+
+// ErrAnchorRepoMismatch is returned when an anchored Application's
+// spec.source.repoURL does not identify the same Git repository argo-compare
+// is running in. The v1 path-based renderer only supports rendering from the
+// local repo; third-repo chart sources are explicitly out of scope.
+var ErrAnchorRepoMismatch = errors.New("anchored Application spec.source.repoURL does not match the local repository")
+
+// ErrAnchorNotPathBased is returned when an anchored Application uses a
+// registry-based source. The anchor flow exists specifically to render a
+// chart from a Git path; chart-based sources go through the existing
+// changed-Application-file flow.
+var ErrAnchorNotPathBased = errors.New("anchored Application is not path-based")
+
+// compareAnchorGroups runs the path-based rendering pipeline for every anchor
+// group discovered in the diff. It returns true if any rendering produced a
+// non-Valid validation result; the error return is reserved for terminal
+// failures that prevent rendering altogether.
+func (a *App) compareAnchorGroups(ctx context.Context, repo *GitRepo, groups []AnchorGroup) (bool, error) {
+	if len(groups) == 0 {
+		return false, nil
+	}
+
+	repoRoot, err := GetGitRepoRoot()
+	if err != nil {
+		return false, fmt.Errorf("resolve repo root for anchor flow: %w", err)
+	}
+	originURL, err := repo.OriginURL()
+	if err != nil {
+		return false, err
+	}
+
+	fetcher := a.applicationFetcher()
+
+	anyFailed := false
+	for _, group := range groups {
+		failed, err := a.processAnchorGroup(ctx, repo, group, fetcher, repoRoot, originURL)
+		if err != nil {
+			return anyFailed, err
+		}
+		if failed {
+			anyFailed = true
+		}
+	}
+	return anyFailed, nil
+}
+
+// processAnchorGroup renders, diffs, and validates the Application that the
+// anchor points to. tmpDir is created fresh per group and cleaned up at end.
+func (a *App) processAnchorGroup(ctx context.Context, repo *GitRepo, group AnchorGroup, fetcher ports.ApplicationFetcher, repoRoot, originURL string) (validationFailed bool, err error) {
+	a.logger.Infof("===> Processing anchored chart in [%s]", ui.Cyan(group.Dir))
+
+	ref := ports.ApplicationRef{
+		Repo:   group.Anchor.Application.Repo,
+		Path:   group.Anchor.Application.Path,
+		Branch: group.Anchor.Application.Branch,
+	}
+	app, err := fetcher.Fetch(ctx, ref, repoRoot)
+	if err != nil {
+		return false, err
+	}
+
+	classifyTarget := Target{App: app}
+	if classifyErr := classifyTarget.ClassifySources(); classifyErr != nil {
+		return false, classifyErr
+	}
+	if !classifyTarget.PathBased() {
+		return false, fmt.Errorf("%w: %s", ErrAnchorNotPathBased, anchorRefDisplay(group.Anchor.Application))
+	}
+	if mismatchErr := assertSameRepo(app.Spec.Source, app.Spec.Sources, originURL); mismatchErr != nil {
+		return false, fmt.Errorf("%w: %s", ErrAnchorRepoMismatch, mismatchErr)
+	}
+
+	tmpDir, err := afero.TempDir(a.fs, a.cfg.TempDirBase, "argo-compare-anchor-")
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		if removeErr := (afero.Afero{Fs: a.fs}).RemoveAll(tmpDir); err == nil && removeErr != nil {
+			err = removeErr
+		}
+	}()
+
+	validationResults := make(map[string]ports.ValidationResult)
+
+	if err = a.renderAnchorLeg(ctx, app, tmpDir, TargetTypeSource, repo, repoRoot, validationResults); err != nil {
+		return false, err
+	}
+	if err = a.renderAnchorLeg(ctx, app, tmpDir, TargetTypeDestination, repo, repoRoot, validationResults); err != nil {
+		return false, err
+	}
+
+	if err = a.runComparison(ctx, tmpDir, group.Anchor.Application.Path, validationResults); err != nil {
+		return false, err
+	}
+
+	for _, r := range validationResults {
+		if !r.Valid {
+			validationFailed = true
+			break
+		}
+	}
+	return validationFailed, nil
+}
+
+// renderAnchorLeg prepares the chart directory for one leg (src or dst) and
+// drives the existing Helm values / render / validate pipeline.
+func (a *App) renderAnchorLeg(ctx context.Context, app models.Application, tmpDir, leg string, repo *GitRepo, repoRoot string, validationResults map[string]ports.ValidationResult) error {
+	target := Target{
+		CmdRunner:           a.cmdRunner,
+		FileReader:          a.fileReader,
+		HelmProcessor:       a.helmProcessor,
+		Globber:             a.globber,
+		CacheDir:            a.cfg.CacheDir,
+		TmpDir:              tmpDir,
+		CredentialProviders: a.activeProviders,
+		Log:                 a.logger,
+		Type:                leg,
+		App:                 app,
+	}
+
+	switch leg {
+	case TargetTypeSource:
+		if err := target.MaterializeChartFromWorkingTree(ctx, a.fs, repoRoot); err != nil {
+			return err
+		}
+	case TargetTypeDestination:
+		mergeBaseTree, err := repo.MergeBaseTreeFor(a.cfg.TargetBranch)
+		if err != nil {
+			return err
+		}
+		if err := target.MaterializeChartFromTree(ctx, a.fs, mergeBaseTree); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unknown render leg %q", leg)
+	}
+
+	if err := target.generateValuesFiles(); err != nil {
+		return err
+	}
+	if err := target.renderAppSources(ctx); err != nil {
+		return err
+	}
+
+	if a.validator != nil && leg == TargetTypeSource {
+		manifests := filepath.Join(tmpDir, "templates", leg)
+		result, err := a.validator.Validate(ctx, leg, manifests)
+		if err != nil {
+			a.logger.Warningf("Manifest validation failed: %v", err)
+			validationResults[leg] = ports.ValidationResult{Target: leg, InvocationError: err.Error()}
+			return nil
+		}
+		validationResults[leg] = result
+		if !result.Valid {
+			a.logger.Warningf("Validation errors found: %d issues", result.ErrorCount)
+		}
+	}
+	return nil
+}
+
+// applicationFetcher returns the configured fetcher or builds a default real
+// implementation on demand. Tests override this via Dependencies.
+func (a *App) applicationFetcher() ports.ApplicationFetcher {
+	if a.fetcher != nil {
+		return a.fetcher
+	}
+	return &RealApplicationFetcher{
+		FS:         a.fs,
+		FileReader: a.fileReader,
+		CmdRunner:  a.cmdRunner,
+		Log:        a.logger,
+	}
+}
+
+// anchorRefDisplay produces a human-readable identifier for log/error messages.
+func anchorRefDisplay(ref anchor.ApplicationRef) string {
+	if ref.Repo == "" {
+		return ref.Path + " (local)"
+	}
+	branch := ref.Branch
+	if branch == "" {
+		branch = "<remote default>"
+	}
+	return fmt.Sprintf("%s@%s:%s", redactRepo(ref.Repo), branch, ref.Path)
+}
+
+// assertSameRepo verifies that every path-based source's repoURL identifies
+// the same repository as originURL. An empty originURL (no origin remote
+// configured locally) is treated as a hard fail because the v1 anchor flow
+// relies on the local repo for the chart contents.
+func assertSameRepo(single *models.Source, sources []*models.Source, originURL string) error {
+	if originURL == "" {
+		return errors.New("local repo has no origin remote configured")
+	}
+	check := func(s *models.Source) error {
+		if s == nil || s.Path == "" {
+			return nil
+		}
+		if !repoIdentityMatches(s.RepoURL, originURL) {
+			return fmt.Errorf("spec.source.repoURL %q does not match origin %q", redactRepo(s.RepoURL), redactRepo(originURL))
+		}
+		return nil
+	}
+	if len(sources) > 0 {
+		for _, s := range sources {
+			if err := check(s); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return check(single)
+}
+
+// normalizeRepoIdentity collapses common Git URL spellings (https, ssh,
+// scp-style, oci-prefixed) into a host[:port]/path key that is stable across
+// formats. .git suffix and trailing slashes are stripped.
+func normalizeRepoIdentity(repoURL string) string {
+	s := strings.TrimSpace(repoURL)
+	if s == "" {
+		return ""
+	}
+	s = strings.TrimPrefix(s, "oci://")
+
+	// scp-style: user@host:path (no scheme, no slashes before colon)
+	if i := strings.Index(s, "@"); i > 0 && !strings.Contains(s[:i], "://") {
+		rest := s[i+1:]
+		if j := strings.Index(rest, ":"); j > 0 && !strings.Contains(rest[:j], "/") {
+			return strings.ToLower(rest[:j]) + "/" + stripTrailingPathNoise(rest[j+1:])
+		}
+	}
+
+	if parsed, err := url.Parse(s); err == nil && parsed.Host != "" {
+		return strings.ToLower(parsed.Host) + stripTrailingPathNoise(parsed.Path)
+	}
+
+	return stripTrailingPathNoise(s)
+}
+
+// stripTrailingPathNoise removes a trailing `.git` suffix and trailing slashes.
+func stripTrailingPathNoise(p string) string {
+	p = strings.TrimSuffix(p, "/")
+	p = strings.TrimSuffix(p, ".git")
+	p = strings.TrimSuffix(p, "/")
+	return p
+}
+
+// repoIdentityMatches reports whether two Git URLs identify the same repo
+// under normalizeRepoIdentity. Empty URLs never match anything.
+func repoIdentityMatches(a, b string) bool {
+	na, nb := normalizeRepoIdentity(a), normalizeRepoIdentity(b)
+	if na == "" || nb == "" {
+		return false
+	}
+	return na == nb
+}

--- a/internal/app/anchor_flow.go
+++ b/internal/app/anchor_flow.go
@@ -66,12 +66,7 @@ func (a *App) compareAnchorGroups(ctx context.Context, repo *GitRepo, groups []A
 func (a *App) processAnchorGroup(ctx context.Context, repo *GitRepo, group AnchorGroup, fetcher ports.ApplicationFetcher, repoRoot, originURL string) (validationFailed bool, err error) {
 	a.logger.Infof("===> Processing anchored chart in [%s]", ui.Cyan(group.Dir))
 
-	ref := ports.ApplicationRef{
-		Repo:   group.Anchor.Application.Repo,
-		Path:   group.Anchor.Application.Path,
-		Branch: group.Anchor.Application.Branch,
-	}
-	app, err := fetcher.Fetch(ctx, ref, repoRoot)
+	app, err := fetcher.Fetch(ctx, group.Anchor.Application, repoRoot)
 	if err != nil {
 		return false, err
 	}
@@ -230,14 +225,17 @@ func assertSameRepo(single *models.Source, sources []*models.Source, originURL s
 }
 
 // normalizeRepoIdentity collapses common Git URL spellings (https, ssh,
-// scp-style, oci-prefixed) into a host[:port]/path key that is stable across
-// formats. .git suffix and trailing slashes are stripped.
+// scp-style, oci-prefixed, file://) into a host[:port]/path key that is
+// stable across formats. .git suffix and trailing slashes are stripped.
+// file:// is stripped so that a bare local-path origin (e.g. /srv/git/foo.git)
+// matches its file:///srv/git/foo.git equivalent.
 func normalizeRepoIdentity(repoURL string) string {
 	s := strings.TrimSpace(repoURL)
 	if s == "" {
 		return ""
 	}
 	s = strings.TrimPrefix(s, "oci://")
+	s = strings.TrimPrefix(s, "file://")
 
 	// scp-style: user@host:path (no scheme, no slashes before colon)
 	if i := strings.Index(s, "@"); i > 0 && !strings.Contains(s[:i], "://") {

--- a/internal/app/anchor_flow_integration_test.go
+++ b/internal/app/anchor_flow_integration_test.go
@@ -180,6 +180,16 @@ func TestDedupAnchorGroups(t *testing.T) {
 	assert.Contains(t, dirs, "/repo/charts/baz")
 }
 
+func TestDedupAnchorGroups_PathVariantsMatch(t *testing.T) {
+	// Anchor spells the Application with a leading "./", changedApps lists it
+	// without. After filepath.Clean both sides, dedup must still fire.
+	groups := []AnchorGroup{
+		{Dir: "/repo/charts/foo", Anchor: dedupAnchor("./apps/foo.yaml", "")},
+	}
+	deduped := dedupAnchorGroups(groups, []string{"apps/foo.yaml"})
+	assert.Empty(t, deduped, "./apps/foo.yaml must dedup against apps/foo.yaml")
+}
+
 func dedupAnchor(path, repo string) anchor.Anchor {
 	return anchor.Anchor{
 		Application: anchor.ApplicationRef{Path: path, Repo: repo},
@@ -279,4 +289,198 @@ func TestAppRunPathBasedApplicationFileInDiff(t *testing.T) {
 	assert.Equal(t, 0, helmStub.callCount("ExtractHelmChart"), "path-based Application must not extract a tarball")
 	// Both legs must still render.
 	assert.Equal(t, 2, helmStub.callCount("RenderAppSource"), "src and dst legs must both render")
+}
+
+// runAnchorFailureScenario sets up a same-repo path-based fixture, lets the
+// caller mutate files just before the initial commit (to provoke a specific
+// failure mode), then runs App.Run on a feature branch that bumps the chart
+// values (so the anchor flow triggers via the changed chart file). It returns
+// the terminal error from App.Run for the caller to assert errors.Is against.
+//
+// The helper backs the four failure-mode tests below (ErrAnchorNotPathBased,
+// ErrAnchorRepoMismatch, anchor.ErrInvalidAnchor, ErrMixedMultiSource) so each
+// test focuses on the mutation that triggers its sentinel.
+func runAnchorFailureScenario(t *testing.T, mutate func(workDir, originURL string)) error {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	cacheDir := filepath.Join(tempDir, "cache")
+	tmpBase := filepath.Join(tempDir, "tmp")
+	require.NoError(t, os.MkdirAll(tmpBase, 0o755))
+
+	remoteDir := filepath.Join(tempDir, "origin.git")
+	bareRepo, err := git.PlainInit(remoteDir, true)
+	require.NoError(t, err)
+	require.NoError(t, bareRepo.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.NewBranchReferenceName("main"))))
+
+	workDir := filepath.Join(tempDir, "work")
+	repo, err := git.PlainInit(workDir, false)
+	require.NoError(t, err)
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.NewBranchReferenceName("main"))))
+
+	originURL := "file://" + remoteDir
+	require.NoError(t, writePathBasedAppFixture(workDir, originURL, 1))
+
+	if mutate != nil {
+		mutate(workDir, originURL)
+	}
+
+	worktree, err := repo.Worktree()
+	require.NoError(t, err)
+	_, err = worktree.Add(".")
+	require.NoError(t, err)
+	initialHash, err := worktree.Commit("initial", &git.CommitOptions{Author: defaultSignature()})
+	require.NoError(t, err)
+
+	_, err = repo.CreateRemote(&config.RemoteConfig{Name: "origin", URLs: []string{originURL}})
+	require.NoError(t, err)
+	require.NoError(t, repo.Push(&git.PushOptions{
+		RemoteName: "origin",
+		RefSpecs:   []config.RefSpec{"refs/heads/main:refs/heads/main"},
+	}))
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName("refs/remotes/origin/main"), initialHash)))
+
+	require.NoError(t, worktree.Checkout(&git.CheckoutOptions{
+		Branch: plumbing.NewBranchReferenceName("feature/anchor-fail"),
+		Create: true,
+	}))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "charts", "demo", "values.yaml"), []byte("replicaCount: 9\n"), 0o644))
+	_, err = worktree.Add("charts/demo/values.yaml")
+	require.NoError(t, err)
+	_, err = worktree.Commit("bump replicas", &git.CommitOptions{Author: defaultSignature()})
+	require.NoError(t, err)
+
+	oldWD, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(workDir))
+	t.Cleanup(func() { require.NoError(t, os.Chdir(oldWD)) })
+
+	logger.RedirectForTest(t, new(bytes.Buffer))
+	appLogger := logger.New("anchor-fail-" + t.Name())
+
+	helmStub := newStubHelmProcessor(t)
+	cfg := Config{
+		TargetBranch:        "main",
+		CacheDir:            cacheDir,
+		TempDirBase:         tmpBase,
+		PrintAddedManifests: true,
+		Version:             "test",
+		AnchorFileName:      DefaultAnchorFileName,
+	}
+	appInstance, err := New(cfg, Dependencies{
+		FS:            afero.NewOsFs(),
+		CmdRunner:     &stubCmdRunner{},
+		FileReader:    utils.OsFileReader{},
+		HelmProcessor: helmStub,
+		Globber:       utils.CustomGlobber{},
+		Logger:        appLogger,
+	})
+	require.NoError(t, err)
+
+	return appInstance.Run(context.Background())
+}
+
+func TestAppRunAnchorFlow_NotPathBased(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip integration test in short mode")
+	}
+	err := runAnchorFailureScenario(t, func(workDir, originURL string) {
+		chartBased := `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: demo
+  namespace: argocd
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: demo
+  source:
+    repoURL: https://charts.example.com
+    chart: demo
+    targetRevision: 0.0.1
+    helm:
+      releaseName: demo
+`
+		require.NoError(t, os.WriteFile(filepath.Join(workDir, "apps", "demo.yaml"), []byte(chartBased), 0o644))
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrAnchorNotPathBased)
+}
+
+func TestAppRunAnchorFlow_RepoMismatch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip integration test in short mode")
+	}
+	err := runAnchorFailureScenario(t, func(workDir, originURL string) {
+		// Application is path-based but repoURL points at a different repo.
+		// assertSameRepo must reject before any chart materialization.
+		mismatched := `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: demo
+  namespace: argocd
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: demo
+  source:
+    repoURL: https://other.example.com/group/other.git
+    path: charts/demo
+    targetRevision: HEAD
+    helm:
+      releaseName: demo
+`
+		require.NoError(t, os.WriteFile(filepath.Join(workDir, "apps", "demo.yaml"), []byte(mismatched), 0o644))
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrAnchorRepoMismatch)
+}
+
+func TestAppRunAnchorFlow_InvalidAnchor(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip integration test in short mode")
+	}
+	err := runAnchorFailureScenario(t, func(workDir, originURL string) {
+		// Malformed YAML — anchor.Load must wrap ErrInvalidAnchor and the
+		// error must propagate through DiscoverAnchors → App.Run.
+		require.NoError(t, os.WriteFile(
+			filepath.Join(workDir, "charts", "demo", ".argo-compare.yml"),
+			[]byte("application:\n  : missing key\n  path:\n    - not a string\n"),
+			0o644,
+		))
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, anchor.ErrInvalidAnchor)
+}
+
+func TestAppRunAnchorFlow_MixedMultiSource(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip integration test in short mode")
+	}
+	err := runAnchorFailureScenario(t, func(workDir, originURL string) {
+		// Multi-source Application mixing chart-based and path-based sources.
+		// ClassifySources must reject before PathBased check.
+		mixed := `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: demo
+  namespace: argocd
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: demo
+  sources:
+    - repoURL: ` + originURL + `
+      path: charts/demo
+      targetRevision: HEAD
+      helm:
+        releaseName: demo
+    - repoURL: https://charts.example.com
+      chart: extra
+      targetRevision: 0.0.1
+`
+		require.NoError(t, os.WriteFile(filepath.Join(workDir, "apps", "demo.yaml"), []byte(mixed), 0o644))
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMixedMultiSource)
 }

--- a/internal/app/anchor_flow_integration_test.go
+++ b/internal/app/anchor_flow_integration_test.go
@@ -84,6 +84,7 @@ func TestAppRunAnchorFlowSameRepo(t *testing.T) {
 		TempDirBase:         tmpBase,
 		PrintAddedManifests: true,
 		Version:             "test",
+		AnchorFileName:      DefaultAnchorFileName,
 	}
 	appInstance, err := New(cfg, Dependencies{
 		FS:            afero.NewOsFs(),
@@ -183,4 +184,99 @@ func dedupAnchor(path, repo string) anchor.Anchor {
 	return anchor.Anchor{
 		Application: anchor.ApplicationRef{Path: path, Repo: repo},
 	}
+}
+
+// TestAppRunPathBasedApplicationFileInDiff covers the case where the changed
+// file in the diff IS the path-based Application manifest (rather than a chart
+// file underneath it). Before the routing fix, this Application would land in
+// the chart pipeline and fail at helm pull with an empty chart name. After
+// the fix, the existing changed-file flow recognizes path-based sources and
+// routes them through MaterializeChartFromWorkingTree / MaterializeChartFromTree.
+func TestAppRunPathBasedApplicationFileInDiff(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip integration test in short mode")
+	}
+
+	tempDir := t.TempDir()
+	cacheDir := filepath.Join(tempDir, "cache")
+	tmpBase := filepath.Join(tempDir, "tmp")
+	require.NoError(t, os.MkdirAll(tmpBase, 0o755))
+
+	remoteDir := filepath.Join(tempDir, "origin.git")
+	bareRepo, err := git.PlainInit(remoteDir, true)
+	require.NoError(t, err)
+	require.NoError(t, bareRepo.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.NewBranchReferenceName("main"))))
+
+	workDir := filepath.Join(tempDir, "work")
+	repo, err := git.PlainInit(workDir, false)
+	require.NoError(t, err)
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.NewBranchReferenceName("main"))))
+
+	originURL := "file://" + remoteDir
+	require.NoError(t, writePathBasedAppFixture(workDir, originURL, 1))
+
+	worktree, err := repo.Worktree()
+	require.NoError(t, err)
+	_, err = worktree.Add(".")
+	require.NoError(t, err)
+	initialHash, err := worktree.Commit("initial", &git.CommitOptions{Author: defaultSignature()})
+	require.NoError(t, err)
+
+	_, err = repo.CreateRemote(&config.RemoteConfig{Name: "origin", URLs: []string{originURL}})
+	require.NoError(t, err)
+	require.NoError(t, repo.Push(&git.PushOptions{
+		RemoteName: "origin",
+		RefSpecs:   []config.RefSpec{"refs/heads/main:refs/heads/main"},
+	}))
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName("refs/remotes/origin/main"), initialHash)))
+
+	require.NoError(t, worktree.Checkout(&git.CheckoutOptions{
+		Branch: plumbing.NewBranchReferenceName("feature/app-edit"),
+		Create: true,
+	}))
+	// Modify the Application file itself (not chart contents). This is the
+	// path that previously hit the chart pipeline and failed.
+	appBody, err := os.ReadFile(filepath.Join(workDir, "apps", "demo.yaml"))
+	require.NoError(t, err)
+	mutated := bytes.ReplaceAll(appBody, []byte("releaseName: demo"), []byte("releaseName: demo-v2"))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "apps", "demo.yaml"), mutated, 0o644))
+	_, err = worktree.Add("apps/demo.yaml")
+	require.NoError(t, err)
+	_, err = worktree.Commit("rename release", &git.CommitOptions{Author: defaultSignature()})
+	require.NoError(t, err)
+
+	oldWD, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(workDir))
+	t.Cleanup(func() { require.NoError(t, os.Chdir(oldWD)) })
+
+	logger.RedirectForTest(t, new(bytes.Buffer))
+	appLogger := logger.New("app-pathbased-diff-test")
+
+	helmStub := newStubHelmProcessor(t)
+	cfg := Config{
+		TargetBranch:        "main",
+		CacheDir:            cacheDir,
+		TempDirBase:         tmpBase,
+		PrintAddedManifests: true,
+		Version:             "test",
+		AnchorFileName:      DefaultAnchorFileName,
+	}
+	appInstance, err := New(cfg, Dependencies{
+		FS:            afero.NewOsFs(),
+		CmdRunner:     &stubCmdRunner{},
+		FileReader:    utils.OsFileReader{},
+		HelmProcessor: helmStub,
+		Globber:       utils.CustomGlobber{},
+		Logger:        appLogger,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, appInstance.Run(context.Background()))
+
+	// Path-based source MUST NOT trigger helm pull / extract.
+	assert.Equal(t, 0, helmStub.callCount("DownloadHelmChart"), "path-based Application must not trigger helm pull")
+	assert.Equal(t, 0, helmStub.callCount("ExtractHelmChart"), "path-based Application must not extract a tarball")
+	// Both legs must still render.
+	assert.Equal(t, 2, helmStub.callCount("RenderAppSource"), "src and dst legs must both render")
 }

--- a/internal/app/anchor_flow_integration_test.go
+++ b/internal/app/anchor_flow_integration_test.go
@@ -1,0 +1,186 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/shini4i/argo-compare/cmd/argo-compare/utils"
+	"github.com/shini4i/argo-compare/cmd/argo-compare/utils/logger"
+	"github.com/shini4i/argo-compare/internal/anchor"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppRunAnchorFlowSameRepo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip integration test in short mode")
+	}
+
+	tempDir := t.TempDir()
+	cacheDir := filepath.Join(tempDir, "cache")
+	tmpBase := filepath.Join(tempDir, "tmp")
+	require.NoError(t, os.MkdirAll(tmpBase, 0o755))
+
+	remoteDir := filepath.Join(tempDir, "origin.git")
+	bareRepo, err := git.PlainInit(remoteDir, true)
+	require.NoError(t, err)
+	require.NoError(t, bareRepo.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.NewBranchReferenceName("main"))))
+
+	workDir := filepath.Join(tempDir, "work")
+	repo, err := git.PlainInit(workDir, false)
+	require.NoError(t, err)
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.NewBranchReferenceName("main"))))
+
+	originURL := "file://" + remoteDir
+	require.NoError(t, writePathBasedAppFixture(workDir, originURL, 1))
+
+	worktree, err := repo.Worktree()
+	require.NoError(t, err)
+	_, err = worktree.Add(".")
+	require.NoError(t, err)
+	initialHash, err := worktree.Commit("initial", &git.CommitOptions{Author: defaultSignature()})
+	require.NoError(t, err)
+
+	_, err = repo.CreateRemote(&config.RemoteConfig{Name: "origin", URLs: []string{originURL}})
+	require.NoError(t, err)
+	require.NoError(t, repo.Push(&git.PushOptions{
+		RemoteName: "origin",
+		RefSpecs:   []config.RefSpec{"refs/heads/main:refs/heads/main"},
+	}))
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName("refs/remotes/origin/main"), initialHash)))
+
+	require.NoError(t, worktree.Checkout(&git.CheckoutOptions{
+		Branch: plumbing.NewBranchReferenceName("feature/anchor"),
+		Create: true,
+	}))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "charts", "demo", "values.yaml"), []byte("replicaCount: 7\n"), 0o644))
+	_, err = worktree.Add("charts/demo/values.yaml")
+	require.NoError(t, err)
+	_, err = worktree.Commit("bump replicas", &git.CommitOptions{Author: defaultSignature()})
+	require.NoError(t, err)
+
+	oldWD, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(workDir))
+	t.Cleanup(func() { require.NoError(t, os.Chdir(oldWD)) })
+
+	var logBuffer bytes.Buffer
+	logger.RedirectForTest(t, &logBuffer)
+	appLogger := logger.New("app-anchor-test")
+
+	helmStub := newStubHelmProcessor(t)
+
+	cfg := Config{
+		TargetBranch:        "main",
+		CacheDir:            cacheDir,
+		TempDirBase:         tmpBase,
+		PrintAddedManifests: true,
+		Version:             "test",
+	}
+	appInstance, err := New(cfg, Dependencies{
+		FS:            afero.NewOsFs(),
+		CmdRunner:     &stubCmdRunner{},
+		FileReader:    utils.OsFileReader{},
+		HelmProcessor: helmStub,
+		Globber:       utils.CustomGlobber{},
+		Logger:        appLogger,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, appInstance.Run(context.Background()))
+
+	// Anchor flow renders both legs, but Helm is stubbed so the only signal we
+	// can assert here is that the render entry log appeared and that
+	// RenderAppSource was invoked twice (src + dst). The detailed templates
+	// come from stub manifests written by stubHelmProcessor.
+	assert.Equal(t, 2, helmStub.callCount("RenderAppSource"), "anchor flow must render src and dst legs")
+	assert.Equal(t, 2, helmStub.callCount("GenerateValuesFile"), "anchor flow must produce values files for both legs")
+	// Download/Extract must NOT be called for a path-based source.
+	assert.Equal(t, 0, helmStub.callCount("DownloadHelmChart"), "path-based source must not trigger helm pull")
+	assert.Equal(t, 0, helmStub.callCount("ExtractHelmChart"), "path-based source must not extract a tarball")
+	assert.Contains(t, logBuffer.String(), "Processing anchored chart")
+}
+
+// writePathBasedAppFixture lays out a same-repo all-in-one structure: a path-
+// based Application manifest plus an umbrella chart it points at, plus an
+// .argo-compare.yml in the chart dir pointing back at the Application.
+func writePathBasedAppFixture(repoDir, originURL string, replicas int) error {
+	appsDir := filepath.Join(repoDir, "apps")
+	chartDir := filepath.Join(repoDir, "charts", "demo")
+	if err := os.MkdirAll(appsDir, 0o755); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Join(chartDir, "templates"), 0o755); err != nil {
+		return err
+	}
+
+	app := `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: demo
+  namespace: argocd
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: demo
+  source:
+    repoURL: ` + originURL + `
+    path: charts/demo
+    targetRevision: HEAD
+    helm:
+      releaseName: demo
+      values: |
+        extraValue: from-app
+`
+	if err := os.WriteFile(filepath.Join(appsDir, "demo.yaml"), []byte(app), 0o644); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(chartDir, "Chart.yaml"), []byte("apiVersion: v2\nname: demo\nversion: 0.0.1\n"), 0o644); err != nil {
+		return err
+	}
+	values := []byte("replicaCount: ")
+	switch replicas {
+	case 0:
+		values = append(values, '0')
+	default:
+		values = append(values, byte('0'+replicas))
+	}
+	values = append(values, '\n')
+	if err := os.WriteFile(filepath.Join(chartDir, "values.yaml"), values, 0o644); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(chartDir, "templates", "dep.yaml"), []byte("kind: Deployment\n"), 0o644); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(chartDir, ".argo-compare.yml"), []byte("application:\n  path: apps/demo.yaml\n"), 0o644)
+}
+
+func TestDedupAnchorGroups(t *testing.T) {
+	groups := []AnchorGroup{
+		{Dir: "/repo/charts/foo", Anchor: dedupAnchor("apps/foo.yaml", "")},
+		{Dir: "/repo/charts/bar", Anchor: dedupAnchor("apps/bar.yaml", "")},
+		{Dir: "/repo/charts/baz", Anchor: dedupAnchor("apps/baz.yaml", "ssh://git@example.com/group/repo.git")},
+	}
+	// "apps/foo.yaml" is both an anchor target AND in changedApps → drop foo's group.
+	// "apps/baz.yaml" is a cross-repo anchor → never dropped, even when listed.
+	deduped := dedupAnchorGroups(groups, []string{"apps/foo.yaml", "apps/baz.yaml"})
+	require.Len(t, deduped, 2)
+	dirs := []string{deduped[0].Dir, deduped[1].Dir}
+	assert.NotContains(t, dirs, "/repo/charts/foo")
+	assert.Contains(t, dirs, "/repo/charts/bar")
+	assert.Contains(t, dirs, "/repo/charts/baz")
+}
+
+func dedupAnchor(path, repo string) anchor.Anchor {
+	return anchor.Anchor{
+		Application: anchor.ApplicationRef{Path: path, Repo: repo},
+	}
+}

--- a/internal/app/anchor_flow_test.go
+++ b/internal/app/anchor_flow_test.go
@@ -1,0 +1,51 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeRepoIdentity(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"https with .git", "https://host.example.com/group/repo.git", "host.example.com/group/repo"},
+		{"https without .git", "https://host.example.com/group/repo", "host.example.com/group/repo"},
+		{"ssh standard", "ssh://git@host.example.com/group/repo.git", "host.example.com/group/repo"},
+		{"ssh non-standard port", "ssh://git@host.example.com:1022/group/repo.git", "host.example.com:1022/group/repo"},
+		{"scp style", "git@host.example.com:group/repo.git", "host.example.com/group/repo"},
+		{"scp style no .git", "git@host.example.com:group/repo", "host.example.com/group/repo"},
+		{"trailing slash", "https://host.example.com/group/repo/", "host.example.com/group/repo"},
+		{"oci prefix", "oci://host.example.com/group/repo", "host.example.com/group/repo"},
+		{"lowercase host", "HTTPS://Host.Example.Com/group/repo.git", "host.example.com/group/repo"},
+		{"local path", "/tmp/foo.git", "/tmp/foo"},
+		{"empty", "", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, normalizeRepoIdentity(c.in))
+		})
+	}
+}
+
+func TestRepoIdentityMatches(t *testing.T) {
+	cases := []struct {
+		name      string
+		a, b      string
+		wantMatch bool
+	}{
+		{"https vs ssh same repo", "https://host.example.com/group/repo.git", "ssh://git@host.example.com/group/repo.git", true},
+		{"scp vs https same repo", "git@host.example.com:group/repo.git", "https://host.example.com/group/repo.git", true},
+		{"different repo", "https://host.example.com/group/repo.git", "https://host.example.com/group/other.git", false},
+		{"different host", "https://a.example.com/group/repo.git", "https://b.example.com/group/repo.git", false},
+		{"one empty", "", "https://host.example.com/group/repo.git", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.wantMatch, repoIdentityMatches(c.a, c.b))
+		})
+	}
+}

--- a/internal/app/anchor_flow_test.go
+++ b/internal/app/anchor_flow_test.go
@@ -22,6 +22,7 @@ func TestNormalizeRepoIdentity(t *testing.T) {
 		{"oci prefix", "oci://host.example.com/group/repo", "host.example.com/group/repo"},
 		{"lowercase host", "HTTPS://Host.Example.Com/group/repo.git", "host.example.com/group/repo"},
 		{"local path", "/tmp/foo.git", "/tmp/foo"},
+		{"file scheme", "file:///tmp/foo.git", "/tmp/foo"},
 		{"empty", "", ""},
 	}
 	for _, c := range cases {
@@ -41,6 +42,7 @@ func TestRepoIdentityMatches(t *testing.T) {
 		{"scp vs https same repo", "git@host.example.com:group/repo.git", "https://host.example.com/group/repo.git", true},
 		{"different repo", "https://host.example.com/group/repo.git", "https://host.example.com/group/other.git", false},
 		{"different host", "https://a.example.com/group/repo.git", "https://b.example.com/group/repo.git", false},
+		{"file vs bare path same repo", "file:///tmp/foo.git", "/tmp/foo.git", true},
 		{"one empty", "", "https://host.example.com/group/repo.git", false},
 	}
 	for _, c := range cases {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -227,18 +227,21 @@ func (a *App) Run(ctx context.Context) error {
 // existing flow, so processing the anchor on top would render the same
 // Application twice. Cross-repo anchors are never deduplicated since their
 // target Application lives outside the local diff.
+//
+// Paths on both sides are normalized via filepath.Clean so that anchor entries
+// spelled "./apps/foo.yaml" still match a changedApps entry of "apps/foo.yaml".
 func dedupAnchorGroups(groups []AnchorGroup, changedApps []string) []AnchorGroup {
 	if len(groups) == 0 || len(changedApps) == 0 {
 		return groups
 	}
 	changed := make(map[string]struct{}, len(changedApps))
 	for _, f := range changedApps {
-		changed[f] = struct{}{}
+		changed[filepath.Clean(f)] = struct{}{}
 	}
 	out := groups[:0]
 	for _, g := range groups {
 		if g.Anchor.Application.Repo == "" {
-			if _, dup := changed[g.Anchor.Application.Path]; dup {
+			if _, dup := changed[filepath.Clean(g.Anchor.Application.Path)]; dup {
 				continue
 			}
 		}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -78,14 +78,10 @@ func New(cfg Config, deps Dependencies) (*App, error) {
 		return nil, errors.New("cache directory must be provided")
 	}
 
-	// Default the anchor file name when callers use a Config struct literal
-	// directly (NewConfig already sets it). Users who actively want to disable
-	// anchor discovery should simply not commit any anchor files; setting the
-	// name to an unused string is supported but explicit "disable" is out of
-	// scope for v1.
-	if cfg.AnchorFileName == "" {
-		cfg.AnchorFileName = DefaultAnchorFileName
-	}
+	// NewConfig defaults AnchorFileName to DefaultAnchorFileName for the
+	// public-API path. Struct-literal Config users get whatever they set,
+	// including the empty-string opt-out documented on WithAnchorFileName
+	// and surfaced via --anchor-file / ARGO_COMPARE_ANCHOR_FILE.
 
 	if deps.FS == nil {
 		deps.FS = afero.NewOsFs()
@@ -296,7 +292,7 @@ func (a *App) processChangedFile(ctx context.Context, repo *GitRepo, file string
 	// Scoped per-comparison: keeps state local and avoids cross-app leakage.
 	validationResults := make(map[string]ports.ValidationResult)
 
-	if err = a.processFile(ctx, file, TargetTypeSource, models.Application{}, tmpDir, validationResults); err != nil {
+	if err = a.processFile(ctx, repo, file, TargetTypeSource, models.Application{}, tmpDir, validationResults); err != nil {
 		return false, err
 	}
 
@@ -310,7 +306,7 @@ func (a *App) processChangedFile(ctx context.Context, repo *GitRepo, file string
 	}
 
 	if action == destinationProcess {
-		if destErr := a.processFile(ctx, file, TargetTypeDestination, targetApp, tmpDir, validationResults); destErr != nil && !a.cfg.PrintAddedManifests {
+		if destErr := a.processFile(ctx, repo, file, TargetTypeDestination, targetApp, tmpDir, validationResults); destErr != nil && !a.cfg.PrintAddedManifests {
 			return false, destErr
 		}
 	}
@@ -345,6 +341,29 @@ func (a *App) resolveTargetApplication(repo *GitRepo, file string) (models.Appli
 	return models.Application{}, action, nil
 }
 
+// prepareChartFromPath materializes a path-based source's chart directory into
+// the layout the renderer expects. The source leg copies from the local
+// working tree; the destination leg extracts from the merge-base tree of the
+// configured target branch.
+func (a *App) prepareChartFromPath(ctx context.Context, repo *GitRepo, target *Target, fileType string) error {
+	switch fileType {
+	case TargetTypeSource:
+		repoRoot, err := GetGitRepoRoot()
+		if err != nil {
+			return fmt.Errorf("resolve repo root for path-based source: %w", err)
+		}
+		return target.MaterializeChartFromWorkingTree(ctx, a.fs, repoRoot)
+	case TargetTypeDestination:
+		tree, err := repo.MergeBaseTreeFor(a.cfg.TargetBranch)
+		if err != nil {
+			return err
+		}
+		return target.MaterializeChartFromTree(ctx, a.fs, tree)
+	default:
+		return fmt.Errorf("unknown render leg %q", fileType)
+	}
+}
+
 // decideDestinationAction maps the outcome of GetChangedFileContent to a destinationAction.
 // Errors other than the two named sentinels are returned to the caller; previously they
 // were logged and silently downgraded to destinationProcess, which produced confusing
@@ -364,7 +383,13 @@ func decideDestinationAction(err error, printAdded bool) (destinationAction, err
 
 // processFile prepares Helm inputs for a single manifest and renders its templates.
 // validationResults is populated when a validator is configured; entries are keyed by fileType.
-func (a *App) processFile(ctx context.Context, fileName, fileType string, application models.Application, tmpDir string, validationResults map[string]ports.ValidationResult) error {
+//
+// For registry-based sources (spec.source.chart set) the chart is fetched via
+// the existing helm pull + extract pipeline. For path-based sources
+// (spec.source.path set) the chart directory is materialized into the same
+// on-disk layout from the local working tree (src leg) or the merge-base tree
+// (dst leg), and the registry plumbing is skipped.
+func (a *App) processFile(ctx context.Context, repo *GitRepo, fileName, fileType string, application models.Application, tmpDir string, validationResults map[string]ports.ValidationResult) error {
 	target := Target{
 		CmdRunner:           a.cmdRunner,
 		FileReader:          a.fileReader,
@@ -385,16 +410,25 @@ func (a *App) processFile(ctx context.Context, fileName, fileType string, applic
 		}
 	}
 
+	if err := target.ClassifySources(); err != nil {
+		return err
+	}
+
 	if err := target.generateValuesFiles(); err != nil {
 		return err
 	}
 
-	if err := target.ensureHelmCharts(ctx); err != nil {
-		return err
-	}
-
-	if err := target.extractCharts(ctx); err != nil {
-		return err
+	if target.PathBased() {
+		if err := a.prepareChartFromPath(ctx, repo, &target, fileType); err != nil {
+			return err
+		}
+	} else {
+		if err := target.ensureHelmCharts(ctx); err != nil {
+			return err
+		}
+		if err := target.extractCharts(ctx); err != nil {
+			return err
+		}
 	}
 
 	if err := target.renderAppSources(ctx); err != nil {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -78,6 +78,15 @@ func New(cfg Config, deps Dependencies) (*App, error) {
 		return nil, errors.New("cache directory must be provided")
 	}
 
+	// Default the anchor file name when callers use a Config struct literal
+	// directly (NewConfig already sets it). Users who actively want to disable
+	// anchor discovery should simply not commit any anchor files; setting the
+	// name to an unused string is supported but explicit "disable" is out of
+	// scope for v1.
+	if cfg.AnchorFileName == "" {
+		cfg.AnchorFileName = DefaultAnchorFileName
+	}
+
 	if deps.FS == nil {
 		deps.FS = afero.NewOsFs()
 	}
@@ -175,7 +184,7 @@ func (a *App) Run(ctx context.Context) error {
 		}
 	} else {
 		var result ChangedFilesResult
-		result, err = repo.GetChangedFiles(a.cfg.TargetBranch, a.cfg.FilesToIgnore, DefaultAnchorFileName)
+		result, err = repo.GetChangedFiles(a.cfg.TargetBranch, a.cfg.FilesToIgnore, a.cfg.AnchorFileName)
 		if err != nil {
 			return err
 		}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -171,7 +171,7 @@ func (a *App) Run(ctx context.Context) error {
 		}
 	} else {
 		var result ChangedFilesResult
-		result, err = repo.GetChangedFiles(a.cfg.TargetBranch, a.cfg.FilesToIgnore)
+		result, err = repo.GetChangedFiles(a.cfg.TargetBranch, a.cfg.FilesToIgnore, DefaultAnchorFileName)
 		if err != nil {
 			return err
 		}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -42,6 +42,7 @@ type Dependencies struct {
 	SensitiveDataMasker  ports.SensitiveDataMasker  // Responsible for redacting sensitive manifest fields.
 	CredentialProviders  []ports.CredentialProvider // Dynamic credential providers (e.g. ECR). Optional; defaults include ECR.
 	ManifestValidator    ports.ManifestValidator    // Validator for rendered manifests. Optional; defaults to KubeconformValidator if validation is enabled.
+	ApplicationFetcher   ports.ApplicationFetcher   // Resolves anchored Applications. Optional; defaults to RealApplicationFetcher.
 }
 
 // App orchestrates the end-to-end comparison workflow.
@@ -59,6 +60,7 @@ type App struct {
 	commentFactory      CommentPosterFactory
 	sensitiveDataMasker ports.SensitiveDataMasker // Applied to manifest content prior to diff generation.
 	validator           ports.ManifestValidator   // Optional validator for rendered manifests.
+	fetcher             ports.ApplicationFetcher  // Resolves anchored Applications. Optional; defaults to a real impl.
 }
 
 // CommentPosterFactory builds a comment poster based on the active configuration.
@@ -134,6 +136,7 @@ func New(cfg Config, deps Dependencies) (*App, error) {
 		commentFactory:      deps.CommentPosterFactory,
 		sensitiveDataMasker: deps.SensitiveDataMasker,
 		validator:           validator,
+		fetcher:             deps.ApplicationFetcher,
 	}, nil
 }
 
@@ -161,6 +164,7 @@ func (a *App) Run(ctx context.Context) error {
 	var (
 		changedFiles []string
 		invalidFiles []string
+		anchorGroups []AnchorGroup
 	)
 
 	if a.cfg.FileToCompare != "" {
@@ -177,16 +181,29 @@ func (a *App) Run(ctx context.Context) error {
 		}
 		changedFiles = result.Applications
 		invalidFiles = result.Invalid
+		anchorGroups = dedupAnchorGroups(result.AnchorGroups, changedFiles)
 	}
 
-	if len(changedFiles) == 0 {
+	if len(changedFiles) == 0 && len(anchorGroups) == 0 {
 		a.logger.Info("No changed Application files found. Exiting...")
 		return nil
 	}
 
-	validationFailed, err := a.compareFiles(ctx, repo, changedFiles)
-	if err != nil {
-		return err
+	validationFailed := false
+	if len(changedFiles) > 0 {
+		failed, cmpErr := a.compareFiles(ctx, repo, changedFiles)
+		if cmpErr != nil {
+			return cmpErr
+		}
+		validationFailed = validationFailed || failed
+	}
+
+	if len(anchorGroups) > 0 {
+		failed, anchorErr := a.compareAnchorGroups(ctx, repo, anchorGroups)
+		if anchorErr != nil {
+			return anchorErr
+		}
+		validationFailed = validationFailed || failed
 	}
 
 	if err := a.reportInvalidFiles(invalidFiles); err != nil {
@@ -198,6 +215,31 @@ func (a *App) Run(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// dedupAnchorGroups drops anchor groups whose target Application file already
+// appears among the changed Application files — that path is handled by the
+// existing flow, so processing the anchor on top would render the same
+// Application twice. Cross-repo anchors are never deduplicated since their
+// target Application lives outside the local diff.
+func dedupAnchorGroups(groups []AnchorGroup, changedApps []string) []AnchorGroup {
+	if len(groups) == 0 || len(changedApps) == 0 {
+		return groups
+	}
+	changed := make(map[string]struct{}, len(changedApps))
+	for _, f := range changedApps {
+		changed[f] = struct{}{}
+	}
+	out := groups[:0]
+	for _, g := range groups {
+		if g.Anchor.Application.Repo == "" {
+			if _, dup := changed[g.Anchor.Application.Path]; dup {
+				continue
+			}
+		}
+		out = append(out, g)
+	}
+	return out
 }
 
 // compareFiles renders and evaluates each changed Application manifest against the target branch.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -166,52 +166,25 @@ func (a *App) Run(ctx context.Context) error {
 
 	a.logger.Infof("===> Running Argo Compare version [%s]", ui.Cyan(a.cfg.Version))
 
-	var (
-		changedFiles []string
-		invalidFiles []string
-		anchorGroups []AnchorGroup
-	)
-
-	if a.cfg.FileToCompare != "" {
-		changedFiles = filterIgnored([]string{a.cfg.FileToCompare}, a.cfg.FilesToIgnore)
-		if len(changedFiles) == 0 {
-			a.logger.Infof("Specified file [%s] ignored by filters. Exiting...", a.cfg.FileToCompare)
-			return nil
-		}
-	} else {
-		var result ChangedFilesResult
-		result, err = repo.GetChangedFiles(a.cfg.TargetBranch, a.cfg.FilesToIgnore, a.cfg.AnchorFileName)
-		if err != nil {
-			return err
-		}
-		changedFiles = result.Applications
-		invalidFiles = result.Invalid
-		anchorGroups = dedupAnchorGroups(result.AnchorGroups, changedFiles)
+	inputs, err := a.collectComparisonInputs(repo)
+	if err != nil {
+		return err
+	}
+	if inputs.exitEarly {
+		return nil
 	}
 
-	if len(changedFiles) == 0 && len(anchorGroups) == 0 {
+	if len(inputs.changed) == 0 && len(inputs.groups) == 0 {
 		a.logger.Info("No changed Application files found. Exiting...")
 		return nil
 	}
 
-	validationFailed := false
-	if len(changedFiles) > 0 {
-		failed, cmpErr := a.compareFiles(ctx, repo, changedFiles)
-		if cmpErr != nil {
-			return cmpErr
-		}
-		validationFailed = validationFailed || failed
+	validationFailed, err := a.runComparisons(ctx, repo, inputs.changed, inputs.groups)
+	if err != nil {
+		return err
 	}
 
-	if len(anchorGroups) > 0 {
-		failed, anchorErr := a.compareAnchorGroups(ctx, repo, anchorGroups)
-		if anchorErr != nil {
-			return anchorErr
-		}
-		validationFailed = validationFailed || failed
-	}
-
-	if err := a.reportInvalidFiles(invalidFiles); err != nil {
+	if err := a.reportInvalidFiles(inputs.invalid); err != nil {
 		return err
 	}
 
@@ -220,6 +193,67 @@ func (a *App) Run(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// comparisonInputs bundles the inputs needed by the comparison loop. exitEarly
+// is set when the only configured target was filtered out, allowing the caller
+// to short-circuit without surfacing an error.
+type comparisonInputs struct {
+	changed   []string
+	invalid   []string
+	groups    []AnchorGroup
+	exitEarly bool
+}
+
+// collectComparisonInputs resolves the changed Application files, invalid
+// manifests, and anchor groups that should be processed in this run. The
+// explicit FileToCompare path and the diff-based path are handled here so Run
+// stays a flat orchestration step.
+func (a *App) collectComparisonInputs(repo *GitRepo) (comparisonInputs, error) {
+	if a.cfg.FileToCompare != "" {
+		changed := filterIgnored([]string{a.cfg.FileToCompare}, a.cfg.FilesToIgnore)
+		if len(changed) == 0 {
+			a.logger.Infof("Specified file [%s] ignored by filters. Exiting...", a.cfg.FileToCompare)
+			return comparisonInputs{exitEarly: true}, nil
+		}
+		return comparisonInputs{changed: changed}, nil
+	}
+
+	result, err := repo.GetChangedFiles(a.cfg.TargetBranch, a.cfg.FilesToIgnore, a.cfg.AnchorFileName)
+	if err != nil {
+		return comparisonInputs{}, err
+	}
+	return comparisonInputs{
+		changed: result.Applications,
+		invalid: result.Invalid,
+		groups:  dedupAnchorGroups(result.AnchorGroups, result.Applications),
+	}, nil
+}
+
+// runComparisons fans out the comparison work across changed Application files
+// and anchor groups, returning whether any validation step produced a non-Valid
+// result. Errors short-circuit; the validation flag is accumulated across both
+// branches so a single failure surfaces ErrManifestValidationFailed.
+func (a *App) runComparisons(ctx context.Context, repo *GitRepo, changedFiles []string, anchorGroups []AnchorGroup) (bool, error) {
+	validationFailed := false
+
+	if len(changedFiles) > 0 {
+		failed, err := a.compareFiles(ctx, repo, changedFiles)
+		if err != nil {
+			return false, err
+		}
+		validationFailed = validationFailed || failed
+	}
+
+	if len(anchorGroups) > 0 {
+		failed, err := a.compareAnchorGroups(ctx, repo, anchorGroups)
+		if err != nil {
+			return false, err
+		}
+		validationFailed = validationFailed || failed
+	}
+
+	return validationFailed, nil
 }
 
 // dedupAnchorGroups drops anchor groups whose target Application file already
@@ -421,46 +455,57 @@ func (a *App) processFile(ctx context.Context, repo *GitRepo, fileName, fileType
 		return err
 	}
 
-	if target.PathBased() {
-		if err := a.prepareChartFromPath(ctx, repo, &target, fileType); err != nil {
-			return err
-		}
-	} else {
-		if err := target.ensureHelmCharts(ctx); err != nil {
-			return err
-		}
-		if err := target.extractCharts(ctx); err != nil {
-			return err
-		}
+	if err := a.prepareChart(ctx, repo, &target, fileType); err != nil {
+		return err
 	}
 
 	if err := target.renderAppSources(ctx); err != nil {
 		return err
 	}
 
-	// Only validate source manifests: src represents the post-merge state (what will land
-	// on the target branch). Validating dst (current target branch state) would surface
-	// pre-existing breakage unrelated to the PR, which is noise for a merge gate.
-	if a.validator != nil && fileType == TargetTypeSource {
-		// Rendered manifests land at <tmpDir>/templates/<src|dst> (set by RenderAppSource).
-		manifests := filepath.Join(tmpDir, "templates", fileType)
-		result, err := a.validator.Validate(ctx, fileType, manifests)
-		if err != nil {
-			a.logger.Warningf("Manifest validation failed: %v", err)
-			// Record a synthetic result so the failure surfaces in presenters.
-			validationResults[fileType] = ports.ValidationResult{
-				Target:          fileType,
-				InvocationError: err.Error(),
-			}
-		} else {
-			validationResults[fileType] = result
-			if !result.Valid {
-				a.logger.Warningf("Validation errors found: %d issues", result.ErrorCount)
-			}
-		}
-	}
-
+	a.runManifestValidation(ctx, fileType, tmpDir, validationResults)
 	return nil
+}
+
+// prepareChart materializes the chart inputs for a target. Path-based sources
+// are copied from the working tree (src) or extracted from the merge-base tree
+// (dst); registry-based sources go through the existing helm pull + extract
+// pipeline.
+func (a *App) prepareChart(ctx context.Context, repo *GitRepo, target *Target, fileType string) error {
+	if target.PathBased() {
+		return a.prepareChartFromPath(ctx, repo, target, fileType)
+	}
+	if err := target.ensureHelmCharts(ctx); err != nil {
+		return err
+	}
+	return target.extractCharts(ctx)
+}
+
+// runManifestValidation invokes the configured validator on rendered source
+// manifests and records the outcome. Destination manifests are intentionally
+// skipped: src reflects the post-merge state, while dst reflects the current
+// target branch — validating dst would surface pre-existing breakage unrelated
+// to the PR, which is noise for a merge gate.
+func (a *App) runManifestValidation(ctx context.Context, fileType, tmpDir string, validationResults map[string]ports.ValidationResult) {
+	if a.validator == nil || fileType != TargetTypeSource {
+		return
+	}
+	// Rendered manifests land at <tmpDir>/templates/<src|dst> (set by RenderAppSource).
+	manifests := filepath.Join(tmpDir, "templates", fileType)
+	result, err := a.validator.Validate(ctx, fileType, manifests)
+	if err != nil {
+		a.logger.Warningf("Manifest validation failed: %v", err)
+		// Record a synthetic result so the failure surfaces in presenters.
+		validationResults[fileType] = ports.ValidationResult{
+			Target:          fileType,
+			InvocationError: err.Error(),
+		}
+		return
+	}
+	validationResults[fileType] = result
+	if !result.Valid {
+		a.logger.Warningf("Validation errors found: %d issues", result.ErrorCount)
+	}
 }
 
 // runComparison executes the diff strategy for the prepared temporary workspace.

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -499,7 +499,7 @@ func TestProcessFileRecordsValidatorInvocationError(t *testing.T) {
 	appFile := filepath.Join(t.TempDir(), "test-app.yaml")
 
 	validationResults := make(map[string]ports.ValidationResult)
-	err = appInstance.processFile(context.Background(), appFile, TargetTypeSource, models.Application{}, tmpDir, validationResults)
+	err = appInstance.processFile(context.Background(), nil, appFile, TargetTypeSource, models.Application{}, tmpDir, validationResults)
 	require.NoError(t, err, "validator invocation failure should not propagate from processFile")
 
 	require.Contains(t, validationResults, TargetTypeSource)
@@ -553,7 +553,7 @@ func TestProcessFileRecordsInvalidValidationResult(t *testing.T) {
 	appFile := filepath.Join(t.TempDir(), "test-app.yaml")
 
 	validationResults := make(map[string]ports.ValidationResult)
-	err = appInstance.processFile(context.Background(), appFile, TargetTypeSource, models.Application{}, tmpDir, validationResults)
+	err = appInstance.processFile(context.Background(), nil, appFile, TargetTypeSource, models.Application{}, tmpDir, validationResults)
 	require.NoError(t, err, "schema-invalid manifests must not cause processFile to fail")
 
 	require.Contains(t, validationResults, TargetTypeSource)
@@ -592,7 +592,7 @@ func TestProcessFileSkipsValidationWhenValidatorNil(t *testing.T) {
 	validationResults := make(map[string]ports.ValidationResult)
 	// Use TargetTypeSource so parse() is exercised and the nil-validator guard is
 	// reached on the same code path that production code takes.
-	err = appInstance.processFile(context.Background(), appFile, TargetTypeSource, models.Application{}, tmpDir, validationResults)
+	err = appInstance.processFile(context.Background(), nil, appFile, TargetTypeSource, models.Application{}, tmpDir, validationResults)
 	require.NoError(t, err)
 
 	assert.Empty(t, validationResults, "validationResults must remain empty when no validator is configured")
@@ -651,7 +651,7 @@ func TestProcessFileCallsValidatorForSource(t *testing.T) {
 	appFile := filepath.Join(t.TempDir(), "test-app.yaml")
 
 	validationResults := make(map[string]ports.ValidationResult)
-	err = appInstance.processFile(context.Background(), appFile, TargetTypeSource, models.Application{}, tmpDir, validationResults)
+	err = appInstance.processFile(context.Background(), nil, appFile, TargetTypeSource, models.Application{}, tmpDir, validationResults)
 	require.NoError(t, err)
 
 	require.Contains(t, validationResults, TargetTypeSource)
@@ -696,7 +696,7 @@ func TestProcessFileSkipsValidationForDestination(t *testing.T) {
 	testApp.Spec.Destination = &models.Destination{Server: "https://kubernetes.default.svc", Namespace: "default"}
 
 	validationResults := make(map[string]ports.ValidationResult)
-	err = appInstance.processFile(context.Background(), "apps/test.yaml", TargetTypeDestination, testApp, tmpDir, validationResults)
+	err = appInstance.processFile(context.Background(), nil, "apps/test.yaml", TargetTypeDestination, testApp, tmpDir, validationResults)
 	require.NoError(t, err)
 
 	assert.Empty(t, validationResults, "validation must be skipped for destination manifests")

--- a/internal/app/application_fetcher.go
+++ b/internal/app/application_fetcher.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"path/filepath"
-	"strings"
 
 	"github.com/shini4i/argo-compare/cmd/argo-compare/utils/logger"
+	"github.com/shini4i/argo-compare/internal/anchor"
 	"github.com/shini4i/argo-compare/internal/helpers"
 	"github.com/shini4i/argo-compare/internal/models"
 	"github.com/shini4i/argo-compare/internal/ports"
@@ -35,7 +34,7 @@ type RealApplicationFetcher struct {
 }
 
 // Fetch resolves ref to a parsed Application.
-func (f *RealApplicationFetcher) Fetch(ctx context.Context, ref ports.ApplicationRef, localRepoRoot string) (models.Application, error) {
+func (f *RealApplicationFetcher) Fetch(ctx context.Context, ref anchor.ApplicationRef, localRepoRoot string) (models.Application, error) {
 	if ref.Repo == "" {
 		return f.fetchFromLocal(ref.Path, localRepoRoot)
 	}
@@ -47,12 +46,12 @@ func (f *RealApplicationFetcher) Fetch(ctx context.Context, ref ports.Applicatio
 // within localRepoRoot — a same-repo anchor pointing at `../../etc/passwd`
 // would otherwise resolve to a file outside the project. The threat is low
 // (the attacker already needs commit access to plant the anchor), but the
-// guard matches the symmetric defense in MaterializeTreeDir.
+// guard matches the symmetric defense in MaterializeTreeDir, and is shared
+// with MaterializeChartFromWorkingTree via resolveRepoPath.
 func (f *RealApplicationFetcher) fetchFromLocal(path, localRepoRoot string) (models.Application, error) {
-	rootClean := filepath.Clean(localRepoRoot)
-	abs := filepath.Clean(filepath.Join(rootClean, path))
-	if abs != rootClean && !strings.HasPrefix(abs, rootClean+string(filepath.Separator)) {
-		return models.Application{}, fmt.Errorf("anchor application.path %q escapes repository root", path)
+	abs, err := resolveRepoPath(localRepoRoot, path)
+	if err != nil {
+		return models.Application{}, fmt.Errorf("anchor application.path %q: %w", path, err)
 	}
 	target := Target{
 		CmdRunner:  f.CmdRunner,
@@ -70,7 +69,7 @@ func (f *RealApplicationFetcher) fetchFromLocal(path, localRepoRoot string) (mod
 // from the resulting tree. The clone happens against memory storage and a
 // memfs worktree so nothing touches the local filesystem until the parsed
 // content is written to a temp file for Target.parse.
-func (f *RealApplicationFetcher) fetchFromRemote(ctx context.Context, ref ports.ApplicationRef) (models.Application, error) {
+func (f *RealApplicationFetcher) fetchFromRemote(ctx context.Context, ref anchor.ApplicationRef) (models.Application, error) {
 	cloneOpts := &git.CloneOptions{
 		URL:          ref.Repo,
 		SingleBranch: true,

--- a/internal/app/application_fetcher.go
+++ b/internal/app/application_fetcher.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"path/filepath"
+	"strings"
 
 	"github.com/shini4i/argo-compare/cmd/argo-compare/utils/logger"
 	"github.com/shini4i/argo-compare/internal/helpers"
@@ -42,9 +43,17 @@ func (f *RealApplicationFetcher) Fetch(ctx context.Context, ref ports.Applicatio
 }
 
 // fetchFromLocal reads ref.Path under localRepoRoot through the same Target.parse
-// pipeline used for in-repo Application files.
+// pipeline used for in-repo Application files. The path is constrained to stay
+// within localRepoRoot — a same-repo anchor pointing at `../../etc/passwd`
+// would otherwise resolve to a file outside the project. The threat is low
+// (the attacker already needs commit access to plant the anchor), but the
+// guard matches the symmetric defense in MaterializeTreeDir.
 func (f *RealApplicationFetcher) fetchFromLocal(path, localRepoRoot string) (models.Application, error) {
-	abs := filepath.Join(localRepoRoot, path)
+	rootClean := filepath.Clean(localRepoRoot)
+	abs := filepath.Clean(filepath.Join(rootClean, path))
+	if abs != rootClean && !strings.HasPrefix(abs, rootClean+string(filepath.Separator)) {
+		return models.Application{}, fmt.Errorf("anchor application.path %q escapes repository root", path)
+	}
 	target := Target{
 		CmdRunner:  f.CmdRunner,
 		FileReader: f.FileReader,

--- a/internal/app/application_fetcher.go
+++ b/internal/app/application_fetcher.go
@@ -1,0 +1,139 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"path/filepath"
+
+	"github.com/shini4i/argo-compare/cmd/argo-compare/utils/logger"
+	"github.com/shini4i/argo-compare/internal/helpers"
+	"github.com/shini4i/argo-compare/internal/models"
+	"github.com/shini4i/argo-compare/internal/ports"
+
+	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/storage/memory"
+	"github.com/spf13/afero"
+)
+
+// RealApplicationFetcher implements ports.ApplicationFetcher.
+//
+// Same-repo fetches read the file directly from localRepoRoot using the
+// existing FileReader port (no Git plumbing involved). Cross-repo fetches
+// perform an in-memory clone of Repo at Branch tip (or the remote's default
+// branch when Branch is empty) and read the manifest from the resulting
+// tree. Auth relies on the user's local Git environment (SSH agent,
+// ~/.gitconfig); no credentials are passed in.
+type RealApplicationFetcher struct {
+	FS         afero.Fs
+	FileReader ports.FileReader
+	CmdRunner  ports.CmdRunner
+	Log        *logger.Logger
+}
+
+// Fetch resolves ref to a parsed Application.
+func (f *RealApplicationFetcher) Fetch(ctx context.Context, ref ports.ApplicationRef, localRepoRoot string) (models.Application, error) {
+	if ref.Repo == "" {
+		return f.fetchFromLocal(ref.Path, localRepoRoot)
+	}
+	return f.fetchFromRemote(ctx, ref)
+}
+
+// fetchFromLocal reads ref.Path under localRepoRoot through the same Target.parse
+// pipeline used for in-repo Application files.
+func (f *RealApplicationFetcher) fetchFromLocal(path, localRepoRoot string) (models.Application, error) {
+	abs := filepath.Join(localRepoRoot, path)
+	target := Target{
+		CmdRunner:  f.CmdRunner,
+		FileReader: f.FileReader,
+		Log:        f.Log,
+		File:       abs,
+	}
+	if err := target.parse(); err != nil {
+		return models.Application{}, fmt.Errorf("read local Application %q: %w", abs, err)
+	}
+	return target.App, nil
+}
+
+// fetchFromRemote clones ref.Repo into memory at Branch tip and reads ref.Path
+// from the resulting tree. The clone happens against memory storage and a
+// memfs worktree so nothing touches the local filesystem until the parsed
+// content is written to a temp file for Target.parse.
+func (f *RealApplicationFetcher) fetchFromRemote(ctx context.Context, ref ports.ApplicationRef) (models.Application, error) {
+	cloneOpts := &git.CloneOptions{
+		URL:          ref.Repo,
+		SingleBranch: true,
+		Depth:        1,
+		Tags:         git.NoTags,
+	}
+	if ref.Branch != "" {
+		cloneOpts.ReferenceName = plumbing.NewBranchReferenceName(ref.Branch)
+	}
+
+	safeRepo := redactRepo(ref.Repo)
+	repo, err := git.CloneContext(ctx, memory.NewStorage(), memfs.New(), cloneOpts)
+	if err != nil {
+		return models.Application{}, fmt.Errorf("clone %s: %w", safeRepo, err)
+	}
+
+	head, err := repo.Head()
+	if err != nil {
+		return models.Application{}, fmt.Errorf("resolve HEAD of %s: %w", safeRepo, err)
+	}
+
+	commit, err := repo.CommitObject(head.Hash())
+	if err != nil {
+		return models.Application{}, fmt.Errorf("read HEAD commit of %s: %w", safeRepo, err)
+	}
+
+	tree, err := commit.Tree()
+	if err != nil {
+		return models.Application{}, fmt.Errorf("read HEAD tree of %s: %w", safeRepo, err)
+	}
+
+	file, err := tree.File(ref.Path)
+	if err != nil {
+		return models.Application{}, fmt.Errorf("read %s from %s: %w", ref.Path, safeRepo, err)
+	}
+
+	content, err := file.Contents()
+	if err != nil {
+		return models.Application{}, fmt.Errorf("read contents of %s from %s: %w", ref.Path, safeRepo, err)
+	}
+
+	tmpFile, err := helpers.CreateTempFile(f.FS, content)
+	if err != nil {
+		return models.Application{}, fmt.Errorf("buffer fetched Application: %w", err)
+	}
+	defer func() {
+		if removeErr := afero.Fs.Remove(f.FS, tmpFile.Name()); removeErr != nil {
+			f.Log.Errorf("Failed to remove temporary file [%s]: %s", tmpFile.Name(), removeErr)
+		}
+	}()
+
+	target := Target{
+		CmdRunner:  f.CmdRunner,
+		FileReader: f.FileReader,
+		Log:        f.Log,
+		File:       tmpFile.Name(),
+	}
+	if err := target.parse(); err != nil {
+		return models.Application{}, fmt.Errorf("parse Application %s from %s: %w", ref.Path, safeRepo, err)
+	}
+	return target.App, nil
+}
+
+// redactRepo strips userinfo from a Git URL before it lands in an error or log
+// message. Embedding credentials in the URL is unsupported by this fetcher
+// (auth flows via the user's local Git environment), but defending against a
+// foot-gun is cheap.
+func redactRepo(repo string) string {
+	u, err := url.Parse(repo)
+	if err != nil || u.User == nil {
+		return repo
+	}
+	u.User = nil
+	return u.String()
+}

--- a/internal/app/application_fetcher_test.go
+++ b/internal/app/application_fetcher_test.go
@@ -1,0 +1,234 @@
+package app
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/shini4i/argo-compare/cmd/argo-compare/utils"
+	"github.com/shini4i/argo-compare/cmd/argo-compare/utils/logger"
+	"github.com/shini4i/argo-compare/internal/ports"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const sampleApplicationYAML = `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: example
+  namespace: argocd
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: example
+  source:
+    repoURL: https://chart.example.com
+    chart: example-chart
+    targetRevision: 1.0.0
+    helm:
+      releaseName: example
+      values: |
+        replicaCount: 1
+`
+
+func newTestFetcher(t *testing.T) *RealApplicationFetcher {
+	t.Helper()
+	return &RealApplicationFetcher{
+		FS:         afero.NewOsFs(),
+		FileReader: utils.OsFileReader{},
+		CmdRunner:  noopCmdRunner{},
+		Log:        logger.New("fetcher-test-" + t.Name()),
+	}
+}
+
+func TestFetcher_SameRepo_HappyPath(t *testing.T) {
+	repoRoot := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, "apps"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "apps", "example.yaml"), []byte(sampleApplicationYAML), 0o644))
+
+	f := newTestFetcher(t)
+	app, err := f.Fetch(context.Background(), ports.ApplicationRef{Path: "apps/example.yaml"}, repoRoot)
+	require.NoError(t, err)
+	assert.Equal(t, "Application", app.Kind)
+	assert.Equal(t, "example", app.Metadata.Name)
+	assert.Equal(t, "example-chart", app.Spec.Source.Chart)
+}
+
+func TestFetcher_SameRepo_FileMissing(t *testing.T) {
+	repoRoot := t.TempDir()
+
+	f := newTestFetcher(t)
+	_, err := f.Fetch(context.Background(), ports.ApplicationRef{Path: "apps/missing.yaml"}, repoRoot)
+	require.Error(t, err)
+}
+
+func TestFetcher_SameRepo_NotAnApplication(t *testing.T) {
+	repoRoot := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, "apps"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "apps", "x.yaml"), []byte("kind: ConfigMap\nmetadata:\n  name: not-an-app\n"), 0o644))
+
+	f := newTestFetcher(t)
+	_, err := f.Fetch(context.Background(), ports.ApplicationRef{Path: "apps/x.yaml"}, repoRoot)
+	require.Error(t, err)
+}
+
+func TestFetcher_CrossRepo_HappyPath(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip cross-repo integration test in short mode")
+	}
+
+	tempDir := t.TempDir()
+	bareDir := filepath.Join(tempDir, "remote.git")
+	require.NoError(t, seedBareRepoWithApplication(t, bareDir, "main", "apps/example.yaml", sampleApplicationYAML))
+
+	f := newTestFetcher(t)
+	app, err := f.Fetch(context.Background(), ports.ApplicationRef{
+		Repo:   bareDir,
+		Path:   "apps/example.yaml",
+		Branch: "main",
+	}, "")
+	require.NoError(t, err)
+	assert.Equal(t, "example", app.Metadata.Name)
+	assert.Equal(t, "example-chart", app.Spec.Source.Chart)
+}
+
+func TestFetcher_CrossRepo_FileMissing(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip cross-repo integration test in short mode")
+	}
+
+	tempDir := t.TempDir()
+	bareDir := filepath.Join(tempDir, "remote.git")
+	require.NoError(t, seedBareRepoWithApplication(t, bareDir, "main", "apps/other.yaml", sampleApplicationYAML))
+
+	f := newTestFetcher(t)
+	_, err := f.Fetch(context.Background(), ports.ApplicationRef{
+		Repo:   bareDir,
+		Path:   "apps/missing.yaml",
+		Branch: "main",
+	}, "")
+	require.Error(t, err)
+}
+
+func TestFetcher_CrossRepo_BadURL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip cross-repo integration test in short mode")
+	}
+
+	f := newTestFetcher(t)
+	_, err := f.Fetch(context.Background(), ports.ApplicationRef{
+		Repo:   "file:///nonexistent/path/that/does/not/exist.git",
+		Path:   "apps/x.yaml",
+		Branch: "main",
+	}, "")
+	require.Error(t, err)
+}
+
+func TestFetcher_CrossRepo_BadBranch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip cross-repo integration test in short mode")
+	}
+
+	tempDir := t.TempDir()
+	bareDir := filepath.Join(tempDir, "remote.git")
+	require.NoError(t, seedBareRepoWithApplication(t, bareDir, "main", "apps/example.yaml", sampleApplicationYAML))
+
+	f := newTestFetcher(t)
+	_, err := f.Fetch(context.Background(), ports.ApplicationRef{
+		Repo:   bareDir,
+		Path:   "apps/example.yaml",
+		Branch: "nonexistent-branch",
+	}, "")
+	require.Error(t, err)
+}
+
+func TestFetcher_CrossRepo_BranchDefaultsToHEAD(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip cross-repo integration test in short mode")
+	}
+
+	tempDir := t.TempDir()
+	bareDir := filepath.Join(tempDir, "remote.git")
+	require.NoError(t, seedBareRepoWithApplication(t, bareDir, "main", "apps/example.yaml", sampleApplicationYAML))
+
+	f := newTestFetcher(t)
+	app, err := f.Fetch(context.Background(), ports.ApplicationRef{
+		Repo: bareDir,
+		Path: "apps/example.yaml",
+		// Branch intentionally omitted.
+	}, "")
+	require.NoError(t, err)
+	assert.Equal(t, "example", app.Metadata.Name)
+}
+
+func TestRedactRepo(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"https://user:token@host.example.com/group/repo.git", "https://host.example.com/group/repo.git"},
+		{"https://host.example.com/group/repo.git", "https://host.example.com/group/repo.git"},
+		{"ssh://git@host.example.com/group/repo.git", "ssh://host.example.com/group/repo.git"},
+		{"git@host.example.com:group/repo.git", "git@host.example.com:group/repo.git"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, redactRepo(c.in), "redactRepo(%q)", c.in)
+	}
+}
+
+// seedBareRepoWithApplication creates a bare git repo at bareDir and pushes a
+// single commit containing the given file with the given content on branch.
+// The bare repo's HEAD is set to point at the seeded branch so that clients
+// cloning without an explicit ReferenceName resolve to it.
+func seedBareRepoWithApplication(t *testing.T, bareDir, branch, filePath, content string) error {
+	t.Helper()
+	bareRepo, err := git.PlainInit(bareDir, true)
+	if err != nil {
+		return err
+	}
+	if err := bareRepo.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.NewBranchReferenceName(branch))); err != nil {
+		return err
+	}
+
+	workDir := t.TempDir()
+	repo, err := git.PlainInit(workDir, false)
+	if err != nil {
+		return err
+	}
+	if err := repo.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.NewBranchReferenceName(branch))); err != nil {
+		return err
+	}
+
+	absFile := filepath.Join(workDir, filePath)
+	if err := os.MkdirAll(filepath.Dir(absFile), 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(absFile, []byte(content), 0o644); err != nil {
+		return err
+	}
+
+	worktree, err := repo.Worktree()
+	if err != nil {
+		return err
+	}
+	if _, err := worktree.Add(filePath); err != nil {
+		return err
+	}
+	if _, err := worktree.Commit("seed", &git.CommitOptions{Author: defaultSignature()}); err != nil {
+		return err
+	}
+
+	if _, err := repo.CreateRemote(&config.RemoteConfig{Name: "origin", URLs: []string{bareDir}}); err != nil {
+		return err
+	}
+	return repo.Push(&git.PushOptions{
+		RemoteName: "origin",
+		RefSpecs:   []config.RefSpec{config.RefSpec("refs/heads/" + branch + ":refs/heads/" + branch)},
+	})
+}

--- a/internal/app/application_fetcher_test.go
+++ b/internal/app/application_fetcher_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/shini4i/argo-compare/cmd/argo-compare/utils"
 	"github.com/shini4i/argo-compare/cmd/argo-compare/utils/logger"
-	"github.com/shini4i/argo-compare/internal/ports"
+	"github.com/shini4i/argo-compare/internal/anchor"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
@@ -53,7 +53,7 @@ func TestFetcher_SameRepo_HappyPath(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "apps", "example.yaml"), []byte(sampleApplicationYAML), 0o644))
 
 	f := newTestFetcher(t)
-	app, err := f.Fetch(context.Background(), ports.ApplicationRef{Path: "apps/example.yaml"}, repoRoot)
+	app, err := f.Fetch(context.Background(), anchor.ApplicationRef{Path: "apps/example.yaml"}, repoRoot)
 	require.NoError(t, err)
 	assert.Equal(t, "Application", app.Kind)
 	assert.Equal(t, "example", app.Metadata.Name)
@@ -64,7 +64,7 @@ func TestFetcher_SameRepo_FileMissing(t *testing.T) {
 	repoRoot := t.TempDir()
 
 	f := newTestFetcher(t)
-	_, err := f.Fetch(context.Background(), ports.ApplicationRef{Path: "apps/missing.yaml"}, repoRoot)
+	_, err := f.Fetch(context.Background(), anchor.ApplicationRef{Path: "apps/missing.yaml"}, repoRoot)
 	require.Error(t, err)
 }
 
@@ -74,8 +74,18 @@ func TestFetcher_SameRepo_NotAnApplication(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "apps", "x.yaml"), []byte("kind: ConfigMap\nmetadata:\n  name: not-an-app\n"), 0o644))
 
 	f := newTestFetcher(t)
-	_, err := f.Fetch(context.Background(), ports.ApplicationRef{Path: "apps/x.yaml"}, repoRoot)
+	_, err := f.Fetch(context.Background(), anchor.ApplicationRef{Path: "apps/x.yaml"}, repoRoot)
 	require.Error(t, err)
+}
+
+func TestFetcher_SameRepo_PathEscape(t *testing.T) {
+	repoRoot := t.TempDir()
+	f := newTestFetcher(t)
+	for _, path := range []string{"../escape.yaml", "charts/../../../escape.yaml"} {
+		_, err := f.Fetch(context.Background(), anchor.ApplicationRef{Path: path}, repoRoot)
+		require.Error(t, err, "path %q must be rejected", path)
+		assert.Contains(t, err.Error(), "escapes repository root")
+	}
 }
 
 func TestFetcher_CrossRepo_HappyPath(t *testing.T) {
@@ -88,7 +98,7 @@ func TestFetcher_CrossRepo_HappyPath(t *testing.T) {
 	require.NoError(t, seedBareRepoWithApplication(t, bareDir, "main", "apps/example.yaml", sampleApplicationYAML))
 
 	f := newTestFetcher(t)
-	app, err := f.Fetch(context.Background(), ports.ApplicationRef{
+	app, err := f.Fetch(context.Background(), anchor.ApplicationRef{
 		Repo:   bareDir,
 		Path:   "apps/example.yaml",
 		Branch: "main",
@@ -108,7 +118,7 @@ func TestFetcher_CrossRepo_FileMissing(t *testing.T) {
 	require.NoError(t, seedBareRepoWithApplication(t, bareDir, "main", "apps/other.yaml", sampleApplicationYAML))
 
 	f := newTestFetcher(t)
-	_, err := f.Fetch(context.Background(), ports.ApplicationRef{
+	_, err := f.Fetch(context.Background(), anchor.ApplicationRef{
 		Repo:   bareDir,
 		Path:   "apps/missing.yaml",
 		Branch: "main",
@@ -122,7 +132,7 @@ func TestFetcher_CrossRepo_BadURL(t *testing.T) {
 	}
 
 	f := newTestFetcher(t)
-	_, err := f.Fetch(context.Background(), ports.ApplicationRef{
+	_, err := f.Fetch(context.Background(), anchor.ApplicationRef{
 		Repo:   "file:///nonexistent/path/that/does/not/exist.git",
 		Path:   "apps/x.yaml",
 		Branch: "main",
@@ -140,7 +150,7 @@ func TestFetcher_CrossRepo_BadBranch(t *testing.T) {
 	require.NoError(t, seedBareRepoWithApplication(t, bareDir, "main", "apps/example.yaml", sampleApplicationYAML))
 
 	f := newTestFetcher(t)
-	_, err := f.Fetch(context.Background(), ports.ApplicationRef{
+	_, err := f.Fetch(context.Background(), anchor.ApplicationRef{
 		Repo:   bareDir,
 		Path:   "apps/example.yaml",
 		Branch: "nonexistent-branch",
@@ -158,7 +168,7 @@ func TestFetcher_CrossRepo_BranchDefaultsToHEAD(t *testing.T) {
 	require.NoError(t, seedBareRepoWithApplication(t, bareDir, "main", "apps/example.yaml", sampleApplicationYAML))
 
 	f := newTestFetcher(t)
-	app, err := f.Fetch(context.Background(), ports.ApplicationRef{
+	app, err := f.Fetch(context.Background(), anchor.ApplicationRef{
 		Repo: bareDir,
 		Path: "apps/example.yaml",
 		// Branch intentionally omitted.

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	KubeconformPath         string
 	ValidateSkipKinds       []string
 	ValidateSchemaLocations []string
+	AnchorFileName          string
 }
 
 // ConfigOption mutates a Config during construction.
@@ -36,8 +37,9 @@ func NewConfig(targetBranch string, opts ...ConfigOption) (Config, error) {
 	}
 
 	cfg := Config{
-		TargetBranch: targetBranch,
-		TempDirBase:  os.TempDir(),
+		TargetBranch:   targetBranch,
+		TempDirBase:    os.TempDir(),
+		AnchorFileName: DefaultAnchorFileName,
 	}
 
 	for _, opt := range opts {
@@ -202,5 +204,14 @@ func WithValidateSkipKinds(kinds []string) ConfigOption {
 func WithValidateSchemaLocations(locations []string) ConfigOption {
 	return func(cfg *Config) {
 		cfg.ValidateSchemaLocations = append([]string{}, locations...)
+	}
+}
+
+// WithAnchorFileName overrides the file name that marks an anchor directory
+// (default `.argo-compare.yml`). Pass an empty string to disable anchor
+// discovery entirely; pass a custom name to use a different convention.
+func WithAnchorFileName(name string) ConfigOption {
+	return func(cfg *Config) {
+		cfg.AnchorFileName = name
 	}
 }

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -17,6 +17,17 @@ func TestNewConfigDefaults(t *testing.T) {
 	assert.False(t, cfg.PreserveHelmLabels)
 	assert.False(t, cfg.PrintAddedManifests)
 	assert.False(t, cfg.PrintRemovedManifests)
+	assert.Equal(t, DefaultAnchorFileName, cfg.AnchorFileName)
+}
+
+func TestWithAnchorFileName(t *testing.T) {
+	cfg, err := NewConfig("main", WithAnchorFileName("custom-anchor.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, "custom-anchor.yaml", cfg.AnchorFileName)
+
+	disabled, err := NewConfig("main", WithAnchorFileName(""))
+	require.NoError(t, err)
+	assert.Equal(t, "", disabled.AnchorFileName, "explicit empty disables anchor discovery before New() defaulting")
 }
 
 func TestNewConfigWithOptions(t *testing.T) {

--- a/internal/app/git.go
+++ b/internal/app/git.go
@@ -160,6 +160,49 @@ func (g *GitRepo) GetChangedFiles(targetBranch string, filesToIgnore []string, a
 	return ChangedFilesResult{Applications: filtered, Invalid: invalid, AnchorGroups: anchorGroups}, nil
 }
 
+// MergeBaseTreeFor returns the tree of the merge-base commit between HEAD and
+// origin/targetBranch. Path-based rendering uses this tree to materialize the
+// "before the PR" snapshot of a chart directory while the working tree holds
+// the "after the PR" snapshot.
+func (g *GitRepo) MergeBaseTreeFor(targetBranch string) (*object.Tree, error) {
+	targetRef, err := g.repo.Reference(plumbing.ReferenceName("refs/remotes/origin/"+targetBranch), true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve target branch %s: %w", targetBranch, err)
+	}
+	headRef, err := g.repo.Head()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get HEAD: %w", err)
+	}
+	targetCommit, err := g.repo.CommitObject(targetRef.Hash())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get commit object for target branch %s: %w", targetBranch, err)
+	}
+	headCommit, err := g.repo.CommitObject(headRef.Hash())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get commit object for current branch: %w", err)
+	}
+	return g.mergeBaseTree(headCommit, targetCommit)
+}
+
+// OriginURL returns the URL configured for the `origin` remote, or an empty
+// string with a nil error when the local repo has no `origin` remote. Callers
+// use this to verify that an Application's spec.source.repoURL points back at
+// the local repo (path-based v1 requires this).
+func (g *GitRepo) OriginURL() (string, error) {
+	remote, err := g.repo.Remote("origin")
+	if err != nil {
+		if errors.Is(err, git.ErrRemoteNotFound) {
+			return "", nil
+		}
+		return "", fmt.Errorf("read origin remote: %w", err)
+	}
+	urls := remote.Config().URLs
+	if len(urls) == 0 {
+		return "", nil
+	}
+	return urls[0], nil
+}
+
 // mergeBaseTree returns the tree of the merge-base commit between headCommit
 // and targetCommit — the snapshot from which the source branch diverged.
 // Diffing against this snapshot yields only the changes the source branch

--- a/internal/app/git.go
+++ b/internal/app/git.go
@@ -94,19 +94,14 @@ func NewGitRepo(fs afero.Fs, cmdRunner ports.CmdRunner, fileReader ports.FileRea
 // additionally returned in the result's AnchorGroups field. Passing an empty
 // string disables anchor discovery — useful for callers that opt out.
 func (g *GitRepo) GetChangedFiles(targetBranch string, filesToIgnore []string, anchorFileName string) (ChangedFilesResult, error) {
-	targetRef, err := g.repo.Reference(plumbing.ReferenceName(fmt.Sprintf("refs/remotes/origin/%s", targetBranch)), true)
+	targetCommit, err := g.commitForBranch(targetBranch)
 	if err != nil {
-		return ChangedFilesResult{}, fmt.Errorf("failed to resolve target branch %s: %w", targetBranch, err)
+		return ChangedFilesResult{}, err
 	}
 
 	headRef, err := g.repo.Head()
 	if err != nil {
 		return ChangedFilesResult{}, fmt.Errorf("failed to get HEAD: %w", err)
-	}
-
-	targetCommit, err := g.repo.CommitObject(targetRef.Hash())
-	if err != nil {
-		return ChangedFilesResult{}, fmt.Errorf("failed to get commit object for target branch %s: %w", targetBranch, err)
 	}
 
 	headCommit, err := g.repo.CommitObject(headRef.Hash())
@@ -165,23 +160,34 @@ func (g *GitRepo) GetChangedFiles(targetBranch string, filesToIgnore []string, a
 // "before the PR" snapshot of a chart directory while the working tree holds
 // the "after the PR" snapshot.
 func (g *GitRepo) MergeBaseTreeFor(targetBranch string) (*object.Tree, error) {
-	targetRef, err := g.repo.Reference(plumbing.ReferenceName("refs/remotes/origin/"+targetBranch), true)
+	targetCommit, err := g.commitForBranch(targetBranch)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve target branch %s: %w", targetBranch, err)
+		return nil, err
 	}
 	headRef, err := g.repo.Head()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get HEAD: %w", err)
-	}
-	targetCommit, err := g.repo.CommitObject(targetRef.Hash())
-	if err != nil {
-		return nil, fmt.Errorf("failed to get commit object for target branch %s: %w", targetBranch, err)
 	}
 	headCommit, err := g.repo.CommitObject(headRef.Hash())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get commit object for current branch: %w", err)
 	}
 	return g.mergeBaseTree(headCommit, targetCommit)
+}
+
+// commitForBranch resolves the commit at the tip of origin/<branch>. It centralizes
+// the ref + commit-object lookup so the surrounding error strings are not duplicated
+// across each caller (SonarCloud go:S1192).
+func (g *GitRepo) commitForBranch(branch string) (*object.Commit, error) {
+	ref, err := g.repo.Reference(plumbing.ReferenceName("refs/remotes/origin/"+branch), true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve target branch %s: %w", branch, err)
+	}
+	commit, err := g.repo.CommitObject(ref.Hash())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get commit object for target branch %s: %w", branch, err)
+	}
+	return commit, nil
 }
 
 // OriginURL returns the URL configured for the `origin` remote, or an empty
@@ -252,14 +258,9 @@ func (g *GitRepo) GetChangedFileContent(targetBranch, targetFile string, printAd
 
 // treeForBranch resolves the Git tree for the provided remote branch reference.
 func (g *GitRepo) treeForBranch(targetBranch string) (*object.Tree, error) {
-	targetRef, err := g.repo.Reference(plumbing.ReferenceName("refs/remotes/origin/"+targetBranch), true)
+	targetCommit, err := g.commitForBranch(targetBranch)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve target branch %s: %w", targetBranch, err)
-	}
-
-	targetCommit, err := g.repo.CommitObject(targetRef.Hash())
-	if err != nil {
-		return nil, fmt.Errorf("failed to get commit object for target branch %s: %w", targetBranch, err)
+		return nil, err
 	}
 
 	targetTree, err := targetCommit.Tree()

--- a/internal/app/git.go
+++ b/internal/app/git.go
@@ -27,11 +27,27 @@ type GitRepo struct {
 	log        *logger.Logger
 }
 
-// ChangedFilesResult encapsulates the changed application files and any invalid manifests.
+// ChangedFilesResult encapsulates the changed application files, any invalid
+// manifests, and anchor groups discovered from changed files that fall under
+// a directory containing an anchor file (default `.argo-compare.yml`).
+//
+// Applications and Invalid are unchanged from the original contract: every
+// changed *.yaml that parses as a valid ArgoCD Application (kind: Application)
+// appears in Applications; manifests that fail to parse appear in Invalid.
+//
+// AnchorGroups is populated in addition to Applications, not instead of it.
+// A single PR can touch both an Application file and a chart directory that
+// sits under an anchor — the caller is responsible for deduplicating before
+// rendering, since the anchor flow ultimately points back at an Application.
 type ChangedFilesResult struct {
 	Applications []string
 	Invalid      []string
+	AnchorGroups []AnchorGroup
 }
+
+// DefaultAnchorFileName is the conventional file name for an anchor config.
+// Callers may override via the anchorFileName parameter of GetChangedFiles.
+const DefaultAnchorFileName = ".argo-compare.yml"
 
 var (
 	errGitFileDoesNotExist = errors.New("file does not exist in target branch")
@@ -72,7 +88,12 @@ func NewGitRepo(fs afero.Fs, cmdRunner ports.CmdRunner, fileReader ports.FileRea
 // has modified since it diverged from targetBranch. Files modified only on
 // targetBranch after the divergence point are intentionally excluded — those
 // are not changes the source branch is proposing.
-func (g *GitRepo) GetChangedFiles(targetBranch string, filesToIgnore []string) (ChangedFilesResult, error) {
+//
+// anchorFileName names the file that marks an "anchor" directory (e.g.
+// `.argo-compare.yml`). Changed files that fall under such a directory are
+// additionally returned in the result's AnchorGroups field. Passing an empty
+// string disables anchor discovery — useful for callers that opt out.
+func (g *GitRepo) GetChangedFiles(targetBranch string, filesToIgnore []string, anchorFileName string) (ChangedFilesResult, error) {
 	targetRef, err := g.repo.Reference(plumbing.ReferenceName(fmt.Sprintf("refs/remotes/origin/%s", targetBranch)), true)
 	if err != nil {
 		return ChangedFilesResult{}, fmt.Errorf("failed to resolve target branch %s: %w", targetBranch, err)
@@ -123,7 +144,20 @@ func (g *GitRepo) GetChangedFiles(targetBranch string, filesToIgnore []string) (
 	applications, invalid := g.sortChangedFiles(foundFiles)
 	filtered := filterIgnored(applications, filesToIgnore)
 
-	return ChangedFilesResult{Applications: filtered, Invalid: invalid}, nil
+	var anchorGroups []AnchorGroup
+	if anchorFileName != "" {
+		repoRoot, rootErr := GetGitRepoRoot()
+		if rootErr != nil {
+			return ChangedFilesResult{}, fmt.Errorf("resolve repo root for anchor discovery: %w", rootErr)
+		}
+		anchorChanged := filterIgnored(foundFiles, filesToIgnore)
+		anchorGroups, err = DiscoverAnchors(repoRoot, anchorChanged, g.fs, anchorFileName)
+		if err != nil {
+			return ChangedFilesResult{}, err
+		}
+	}
+
+	return ChangedFilesResult{Applications: filtered, Invalid: invalid, AnchorGroups: anchorGroups}, nil
 }
 
 // mergeBaseTree returns the tree of the merge-base commit between headCommit

--- a/internal/app/git_test.go
+++ b/internal/app/git_test.go
@@ -80,7 +80,7 @@ func TestGitRepoGetChangedFilesRespectsIgnore(t *testing.T) {
 	repoInstance, err := NewGitRepo(afero.NewOsFs(), noopCmdRunner{}, utils.OsFileReader{}, log)
 	require.NoError(t, err)
 
-	result, err := repoInstance.GetChangedFiles("main", []string{"apps/secondary.yaml"})
+	result, err := repoInstance.GetChangedFiles("main", []string{"apps/secondary.yaml"}, "")
 	require.NoError(t, err)
 
 	require.ElementsMatch(t, []string{"apps/demo.yaml"}, result.Applications)
@@ -156,7 +156,7 @@ func TestGitRepoGetChangedFilesExcludesDstOnlyChanges(t *testing.T) {
 	repoInstance, err := NewGitRepo(afero.NewOsFs(), noopCmdRunner{}, utils.OsFileReader{}, log)
 	require.NoError(t, err)
 
-	result, err := repoInstance.GetChangedFiles("main", nil)
+	result, err := repoInstance.GetChangedFiles("main", nil, "")
 	require.NoError(t, err)
 
 	// Only the file src actually touched should be reported.
@@ -207,7 +207,7 @@ func TestGitRepoGetChangedFilesUnrelatedHistories(t *testing.T) {
 	repoInstance, err := NewGitRepo(afero.NewOsFs(), noopCmdRunner{}, utils.OsFileReader{}, log)
 	require.NoError(t, err)
 
-	_, err = repoInstance.GetChangedFiles("main", nil)
+	_, err = repoInstance.GetChangedFiles("main", nil, "")
 	require.ErrorIs(t, err, ErrNoCommonAncestor)
 }
 
@@ -260,7 +260,7 @@ func TestGitRepoGetChangedFilesAmbiguousMergeBase(t *testing.T) {
 	repoInstance, err := NewGitRepo(afero.NewOsFs(), noopCmdRunner{}, utils.OsFileReader{}, log)
 	require.NoError(t, err)
 
-	_, err = repoInstance.GetChangedFiles("main", nil)
+	_, err = repoInstance.GetChangedFiles("main", nil, "")
 	require.ErrorIs(t, err, ErrAmbiguousMergeBase)
 }
 
@@ -354,6 +354,117 @@ spec:
 	require.NoError(t, err)
 	require.Equal(t, "parsed", application.Metadata.Name)
 	require.Equal(t, "parsed-chart", application.Spec.Source.Chart)
+}
+
+func TestGitRepoGetChangedFilesPopulatesAnchorGroups(t *testing.T) {
+	tempDir := t.TempDir()
+	workDir := filepath.Join(tempDir, "repo")
+	require.NoError(t, os.MkdirAll(workDir, 0o755))
+
+	repo, err := git.PlainInit(workDir, false)
+	require.NoError(t, err)
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.NewBranchReferenceName("main"))))
+
+	chartDir := filepath.Join(workDir, "charts", "foo")
+	require.NoError(t, os.MkdirAll(chartDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(chartDir, ".argo-compare.yml"), []byte("application:\n  path: apps/foo.yaml\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(chartDir, "Chart.yaml"), []byte("apiVersion: v2\nname: foo\nversion: 0.0.1\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(chartDir, "values.yaml"), []byte("replicaCount: 1\n"), 0o644))
+
+	worktree, err := repo.Worktree()
+	require.NoError(t, err)
+	_, err = worktree.Add("charts/foo")
+	require.NoError(t, err)
+	commitHash, err := worktree.Commit("initial", &git.CommitOptions{Author: defaultSignature()})
+	require.NoError(t, err)
+
+	remotePath := filepath.Join(tempDir, "origin.git")
+	_, err = git.PlainInit(remotePath, true)
+	require.NoError(t, err)
+	_, err = repo.CreateRemote(&config.RemoteConfig{Name: "origin", URLs: []string{remotePath}})
+	require.NoError(t, err)
+	require.NoError(t, repo.Push(&git.PushOptions{RemoteName: "origin", RefSpecs: []config.RefSpec{"refs/heads/main:refs/heads/main"}}))
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName("refs/remotes/origin/main"), commitHash)))
+
+	require.NoError(t, worktree.Checkout(&git.CheckoutOptions{Branch: plumbing.NewBranchReferenceName("feature"), Create: true}))
+	require.NoError(t, os.WriteFile(filepath.Join(chartDir, "values.yaml"), []byte("replicaCount: 2\n"), 0o644))
+	_, err = worktree.Add("charts/foo/values.yaml")
+	require.NoError(t, err)
+	_, err = worktree.Commit("bump replicas", &git.CommitOptions{Author: defaultSignature()})
+	require.NoError(t, err)
+
+	originalWD, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(workDir))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(originalWD))
+	})
+
+	log := logger.New("git-test-anchor")
+	repoInstance, err := NewGitRepo(afero.NewOsFs(), noopCmdRunner{}, utils.OsFileReader{}, log)
+	require.NoError(t, err)
+
+	result, err := repoInstance.GetChangedFiles("main", nil, ".argo-compare.yml")
+	require.NoError(t, err)
+
+	require.Empty(t, result.Applications, "the chart files are not Application manifests")
+	require.Len(t, result.AnchorGroups, 1)
+	g := result.AnchorGroups[0]
+	require.True(t, filepath.IsAbs(g.Dir))
+	require.Equal(t, "apps/foo.yaml", g.Anchor.Application.Path)
+	require.Equal(t, []string{"charts/foo/values.yaml"}, g.ChangedFiles)
+}
+
+func TestGitRepoGetChangedFilesNoAnchorDiscoveryWhenDisabled(t *testing.T) {
+	tempDir := t.TempDir()
+	workDir := filepath.Join(tempDir, "repo")
+	require.NoError(t, os.MkdirAll(workDir, 0o755))
+
+	repo, err := git.PlainInit(workDir, false)
+	require.NoError(t, err)
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.NewBranchReferenceName("main"))))
+
+	chartDir := filepath.Join(workDir, "charts", "foo")
+	require.NoError(t, os.MkdirAll(chartDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(chartDir, ".argo-compare.yml"), []byte("application:\n  path: apps/foo.yaml\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(chartDir, "values.yaml"), []byte("replicaCount: 1\n"), 0o644))
+
+	worktree, err := repo.Worktree()
+	require.NoError(t, err)
+	_, err = worktree.Add("charts/foo")
+	require.NoError(t, err)
+	commitHash, err := worktree.Commit("initial", &git.CommitOptions{Author: defaultSignature()})
+	require.NoError(t, err)
+
+	remotePath := filepath.Join(tempDir, "origin.git")
+	_, err = git.PlainInit(remotePath, true)
+	require.NoError(t, err)
+	_, err = repo.CreateRemote(&config.RemoteConfig{Name: "origin", URLs: []string{remotePath}})
+	require.NoError(t, err)
+	require.NoError(t, repo.Push(&git.PushOptions{RemoteName: "origin", RefSpecs: []config.RefSpec{"refs/heads/main:refs/heads/main"}}))
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName("refs/remotes/origin/main"), commitHash)))
+
+	require.NoError(t, worktree.Checkout(&git.CheckoutOptions{Branch: plumbing.NewBranchReferenceName("feature"), Create: true}))
+	require.NoError(t, os.WriteFile(filepath.Join(chartDir, "values.yaml"), []byte("replicaCount: 2\n"), 0o644))
+	_, err = worktree.Add("charts/foo/values.yaml")
+	require.NoError(t, err)
+	_, err = worktree.Commit("bump", &git.CommitOptions{Author: defaultSignature()})
+	require.NoError(t, err)
+
+	originalWD, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(workDir))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(originalWD))
+	})
+
+	log := logger.New("git-test-anchor-disabled")
+	repoInstance, err := NewGitRepo(afero.NewOsFs(), noopCmdRunner{}, utils.OsFileReader{}, log)
+	require.NoError(t, err)
+
+	result, err := repoInstance.GetChangedFiles("main", nil, "")
+	require.NoError(t, err)
+	require.Empty(t, result.AnchorGroups, "anchor discovery must be skipped when anchorFileName is empty")
 }
 
 func writeExtraApplication(t *testing.T, repoDir, name, version string, replicas int) {

--- a/internal/app/target.go
+++ b/internal/app/target.go
@@ -72,10 +72,13 @@ func (t *Target) parse() error {
 }
 
 // generateValuesFiles materializes Helm values files so templates can be rendered.
+// The chart name used for the values file derives from effectiveChartName so
+// registry-based (chart) and Git-path-based (path) sources both produce
+// stably-named values files for the downstream render step to find.
 func (t *Target) generateValuesFiles() error {
 	if t.App.Spec.MultiSource {
 		for _, source := range t.App.Spec.Sources {
-			if err := t.HelmProcessor.GenerateValuesFile(source.Chart, t.TmpDir, t.Type, source.Helm.Values, source.Helm.ValuesObject); err != nil {
+			if err := t.HelmProcessor.GenerateValuesFile(effectiveChartName(source), t.TmpDir, t.Type, source.Helm.Values, source.Helm.ValuesObject); err != nil {
 				return err
 			}
 		}
@@ -83,7 +86,7 @@ func (t *Target) generateValuesFiles() error {
 	}
 
 	return t.HelmProcessor.GenerateValuesFile(
-		t.App.Spec.Source.Chart,
+		effectiveChartName(t.App.Spec.Source),
 		t.TmpDir,
 		t.Type,
 		t.App.Spec.Source.Helm.Values,
@@ -168,7 +171,7 @@ func (t *Target) renderAppSources(ctx context.Context) error {
 			}
 			req := ports.ChartRenderRequest{
 				ReleaseName:  releaseName,
-				ChartName:    source.Chart,
+				ChartName:    effectiveChartName(source),
 				ChartVersion: source.TargetRevision,
 				TmpDir:       t.TmpDir,
 				TargetType:   t.Type,
@@ -187,7 +190,7 @@ func (t *Target) renderAppSources(ctx context.Context) error {
 	}
 	req := ports.ChartRenderRequest{
 		ReleaseName:  releaseName,
-		ChartName:    t.App.Spec.Source.Chart,
+		ChartName:    effectiveChartName(t.App.Spec.Source),
 		ChartVersion: t.App.Spec.Source.TargetRevision,
 		TmpDir:       t.TmpDir,
 		TargetType:   t.Type,

--- a/internal/app/target_path.go
+++ b/internal/app/target_path.go
@@ -1,0 +1,180 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/shini4i/argo-compare/internal/models"
+
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/spf13/afero"
+)
+
+// ErrMixedMultiSource is returned when an Application's `sources` mixes
+// registry-based (chart) and Git-path-based (path) entries. The first version
+// of path-based support requires that every source in a multi-source
+// Application use the same kind, so the renderer can pick a single code path.
+var ErrMixedMultiSource = errors.New("multi-source Application mixes chart-based and path-based sources; mixed sources are not supported")
+
+// effectiveChartName returns a non-empty chart name suitable for naming the
+// extracted/materialized chart directory and the per-source values file.
+// Registry sources use Source.Chart directly; path-based sources fall back to
+// the last component of Source.Path (without a trailing slash).
+func effectiveChartName(s *models.Source) string {
+	if s == nil {
+		return ""
+	}
+	if s.Chart != "" {
+		return s.Chart
+	}
+	trimmed := strings.TrimRight(s.Path, "/")
+	if trimmed == "" {
+		return ""
+	}
+	return filepath.Base(trimmed)
+}
+
+// PathBased reports whether the Application uses Git path sources. A
+// multi-source Application is path-based if all of its sources are path-based;
+// callers should invoke ClassifySources first to reject mixed configurations.
+func (t *Target) PathBased() bool {
+	if t.App.Spec.MultiSource {
+		if len(t.App.Spec.Sources) == 0 {
+			return false
+		}
+		for _, s := range t.App.Spec.Sources {
+			if s == nil || s.Path == "" {
+				return false
+			}
+		}
+		return true
+	}
+	return t.App.Spec.Source != nil && t.App.Spec.Source.Path != ""
+}
+
+// ClassifySources rejects multi-source Applications that mix registry and
+// path sources. Single-source Applications and uniform multi-source
+// Applications return nil.
+func (t *Target) ClassifySources() error {
+	if !t.App.Spec.MultiSource {
+		return nil
+	}
+	var (
+		seenChart bool
+		seenPath  bool
+	)
+	for _, s := range t.App.Spec.Sources {
+		if s == nil {
+			continue
+		}
+		if s.Chart != "" {
+			seenChart = true
+		}
+		if s.Path != "" {
+			seenPath = true
+		}
+	}
+	if seenChart && seenPath {
+		return ErrMixedMultiSource
+	}
+	return nil
+}
+
+// MaterializeChartFromWorkingTree copies the chart directory referenced by each
+// path-based source from the local working tree into the same on-disk layout
+// the registry pipeline produces (TmpDir/charts/<TargetType>/<ChartName>). It
+// is only meaningful for source-side rendering (t.Type == TargetTypeSource);
+// the destination side reads from a Git tree via MaterializeChartFromTree.
+func (t *Target) MaterializeChartFromWorkingTree(ctx context.Context, fs afero.Fs, repoRoot string) error {
+	for _, src := range t.pathSources() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		from := filepath.Join(repoRoot, src.Path)
+		to := filepath.Join(t.TmpDir, "charts", t.Type, effectiveChartName(src))
+		if err := copyDirOnDisk(fs, from, to); err != nil {
+			return fmt.Errorf("materialize chart %q from working tree: %w", src.Path, err)
+		}
+	}
+	return nil
+}
+
+// MaterializeChartFromTree extracts the chart directory referenced by each
+// path-based source from tree into TmpDir/charts/<TargetType>/<ChartName>.
+// It is the destination-side counterpart of MaterializeChartFromWorkingTree
+// and uses MaterializeTreeDir under the hood for the actual walk.
+func (t *Target) MaterializeChartFromTree(ctx context.Context, fs afero.Fs, tree *object.Tree) error {
+	for _, src := range t.pathSources() {
+		dest := filepath.Join(t.TmpDir, "charts", t.Type, effectiveChartName(src))
+		if err := MaterializeTreeDir(ctx, fs, tree, src.Path, dest); err != nil {
+			return fmt.Errorf("materialize chart %q from tree: %w", src.Path, err)
+		}
+	}
+	return nil
+}
+
+// pathSources enumerates the path-based sources for the Application,
+// transparently handling the single-source / multi-source split.
+func (t *Target) pathSources() []*models.Source {
+	if t.App.Spec.MultiSource {
+		return t.App.Spec.Sources
+	}
+	if t.App.Spec.Source == nil {
+		return nil
+	}
+	return []*models.Source{t.App.Spec.Source}
+}
+
+// copyDirOnDisk recursively copies the contents of src into dst using fs.
+// It is intentionally minimal: no symlink handling, no permissions beyond what
+// os.Stat reports, no atomicity. The caller owns the destination directory.
+func copyDirOnDisk(fs afero.Fs, src, dst string) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("source %q is not a directory", src)
+	}
+	if err := fs.MkdirAll(dst, 0o755); err != nil {
+		return err
+	}
+	return filepath.WalkDir(src, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return fs.MkdirAll(target, 0o755)
+		}
+		return copyFile(fs, path, target)
+	})
+}
+
+func copyFile(fs afero.Fs, src, dst string) error {
+	in, err := os.Open(src) // #nosec G304 -- src is derived from a path inside the local repo
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+
+	if err := fs.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	out, err := fs.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = out.Close() }()
+	_, err = io.Copy(out, in)
+	return err
+}

--- a/internal/app/target_path.go
+++ b/internal/app/target_path.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -90,18 +91,46 @@ func (t *Target) ClassifySources() error {
 // the registry pipeline produces (TmpDir/charts/<TargetType>/<ChartName>). It
 // is only meaningful for source-side rendering (t.Type == TargetTypeSource);
 // the destination side reads from a Git tree via MaterializeChartFromTree.
+//
+// spec.source.path is treated as untrusted (a malicious or misconfigured
+// Application can set it to "../../etc" or an absolute path); resolveRepoPath
+// rejects anything that escapes repoRoot before any I/O happens. The
+// destination leg does not need the same guard because go-git tree walks
+// cannot contain ".." entries.
 func (t *Target) MaterializeChartFromWorkingTree(ctx context.Context, fs afero.Fs, repoRoot string) error {
 	for _, src := range t.pathSources() {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		from := filepath.Join(repoRoot, src.Path)
+		from, err := resolveRepoPath(repoRoot, src.Path)
+		if err != nil {
+			return fmt.Errorf("materialize chart %q from working tree: %w", src.Path, err)
+		}
 		to := filepath.Join(t.TmpDir, "charts", t.Type, effectiveChartName(src))
 		if err := copyDirOnDisk(fs, from, to); err != nil {
 			return fmt.Errorf("materialize chart %q from working tree: %w", src.Path, err)
 		}
 	}
 	return nil
+}
+
+// resolveRepoPath joins rel onto repoRoot and rejects results that escape
+// repoRoot via ".." segments. It is the shared defense against untrusted-path
+// inputs from anchor / Application YAML on the local-filesystem code paths
+// (MaterializeChartFromWorkingTree, RealApplicationFetcher.fetchFromLocal).
+// The matching defense on the Git-tree code paths lives inside
+// MaterializeTreeDir; go-git tree entries cannot themselves contain "..".
+//
+// Note: an absolute rel (e.g. "/etc/passwd") is rebased under repoRoot by
+// filepath.Join and is therefore not an escape vector — it resolves to a
+// nonsense path inside the repo that will fail benignly at later I/O.
+func resolveRepoPath(repoRoot, rel string) (string, error) {
+	rootClean := filepath.Clean(repoRoot)
+	abs := filepath.Clean(filepath.Join(rootClean, rel))
+	if abs != rootClean && !strings.HasPrefix(abs, rootClean+string(filepath.Separator)) {
+		return "", fmt.Errorf("path %q escapes repository root", rel)
+	}
+	return abs, nil
 }
 
 // MaterializeChartFromTree extracts the chart directory referenced by each
@@ -130,23 +159,32 @@ func (t *Target) pathSources() []*models.Source {
 	return []*models.Source{t.App.Spec.Source}
 }
 
-// copyDirOnDisk recursively copies the contents of src into dst using fs.
-// It is intentionally minimal: no symlink handling, no permissions beyond what
-// os.Stat reports, no atomicity. The caller owns the destination directory.
-func copyDirOnDisk(fs afero.Fs, src, dst string) error {
-	info, err := os.Stat(src)
+// copyDirOnDisk recursively copies the contents of src into dst using dstFs.
+// Only regular files and directories are accepted; symlinks, FIFOs, sockets,
+// and devices are rejected. Symlinks would let an attacker-controlled chart
+// leak files outside the chart dir into rendered manifests (and the Git-tree
+// dst-leg counterpart cannot mirror them faithfully — it records the link
+// target, not the resolved content, producing misleading diffs). FIFOs and
+// sockets would hang copyFile's os.Open indefinitely on CI runners. Charts
+// wanting shared content can commit the file directly. The caller owns the
+// destination directory.
+func copyDirOnDisk(dstFs afero.Fs, src, dst string) error {
+	info, err := os.Lstat(src)
 	if err != nil {
 		return err
 	}
 	if !info.IsDir() {
-		return fmt.Errorf("source %q is not a directory", src)
+		return fmt.Errorf("source %q is not a regular directory (mode %s); only regular files and directories are supported in path-based chart sources", src, info.Mode())
 	}
-	if err := fs.MkdirAll(dst, 0o755); err != nil {
+	if err := dstFs.MkdirAll(dst, 0o755); err != nil {
 		return err
 	}
 	return filepath.WalkDir(src, func(path string, d os.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
+		}
+		if !d.IsDir() && d.Type()&fs.ModeType != 0 {
+			return fmt.Errorf("source %q contains %q with unsupported mode %s; only regular files and directories are supported in path-based chart sources", src, path, d.Type())
 		}
 		rel, err := filepath.Rel(src, path)
 		if err != nil {
@@ -154,23 +192,23 @@ func copyDirOnDisk(fs afero.Fs, src, dst string) error {
 		}
 		target := filepath.Join(dst, rel)
 		if d.IsDir() {
-			return fs.MkdirAll(target, 0o755)
+			return dstFs.MkdirAll(target, 0o755)
 		}
-		return copyFile(fs, path, target)
+		return copyFile(dstFs, path, target)
 	})
 }
 
-func copyFile(fs afero.Fs, src, dst string) error {
-	in, err := os.Open(src) // #nosec G304 -- src is derived from a path inside the local repo
+func copyFile(dstFs afero.Fs, src, dst string) error {
+	in, err := os.Open(src) // #nosec G304 -- src is constrained to the local repo by resolveRepoPath; symlinks are rejected in copyDirOnDisk
 	if err != nil {
 		return err
 	}
 	defer func() { _ = in.Close() }()
 
-	if err := fs.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+	if err := dstFs.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
 		return err
 	}
-	out, err := fs.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	out, err := dstFs.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {
 		return err
 	}

--- a/internal/app/target_path_test.go
+++ b/internal/app/target_path_test.go
@@ -144,6 +144,147 @@ func TestMaterializeChartFromWorkingTree(t *testing.T) {
 	}
 }
 
+func TestResolveRepoPath(t *testing.T) {
+	repoRoot := "/repo/root"
+	cases := []struct {
+		name    string
+		rel     string
+		wantAbs string
+		wantErr bool
+	}{
+		{"plain subdir", "charts/foo", "/repo/root/charts/foo", false},
+		{"current dir", "", "/repo/root", false},
+		{"dot prefix", "./charts/foo", "/repo/root/charts/foo", false},
+		{"parent escape", "../escape", "", true},
+		{"deep parent escape", "charts/../../../etc", "", true},
+		// Absolute paths are rebased under repoRoot by filepath.Join, not an escape.
+		{"absolute rebased", "/etc/passwd", "/repo/root/etc/passwd", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			abs, err := resolveRepoPath(repoRoot, c.rel)
+			if c.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, c.wantAbs, abs)
+		})
+	}
+}
+
+func TestMaterializeChartFromWorkingTree_PathEscape(t *testing.T) {
+	// Threat: a malicious or misconfigured Application sets spec.source.path to
+	// a value that resolves outside the local repo. The guard must reject the
+	// path before any I/O lands content from outside the repo in tmpDir.
+	repoRoot := t.TempDir()
+	tmpDir := t.TempDir()
+
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"parent escape", "../../etc"},
+		{"deep parent escape", "charts/../../etc"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tgt := Target{
+				TmpDir: tmpDir,
+				Type:   TargetTypeSource,
+				Log:    logger.New("target-path-escape-test"),
+				App: models.Application{Spec: struct {
+					Source      *models.Source      `yaml:"source"`
+					Sources     []*models.Source    `yaml:"sources"`
+					MultiSource bool                `yaml:"-"`
+					Destination *models.Destination `yaml:"destination"`
+				}{Source: &models.Source{Path: c.path}}},
+			}
+
+			err := tgt.MaterializeChartFromWorkingTree(context.Background(), afero.NewOsFs(), repoRoot)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "escapes repository root")
+
+			// Nothing should have been written to tmpDir/charts.
+			_, statErr := os.Stat(filepath.Join(tmpDir, "charts"))
+			assert.True(t, os.IsNotExist(statErr), "no chart dir must be materialized for %q", c.path)
+		})
+	}
+}
+
+func TestMaterializeChartFromWorkingTree_RejectsSymlinks(t *testing.T) {
+	// Threat: an attacker plants a symlink inside the chart directory pointing
+	// at /etc/passwd (or any file outside the chart). os.Open would silently
+	// dereference, copy the target into tmpDir, and helm template would surface
+	// the content in rendered manifests / PR comments. The materializer must
+	// refuse symlinks rather than follow them.
+	repoRoot := t.TempDir()
+	chartDir := filepath.Join(repoRoot, "charts", "demo")
+	require.NoError(t, os.MkdirAll(chartDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(chartDir, "Chart.yaml"), []byte("name: demo\n"), 0o644))
+
+	// Plant a file outside the chart that the symlink would expose.
+	outsideTarget := filepath.Join(t.TempDir(), "sensitive.txt")
+	require.NoError(t, os.WriteFile(outsideTarget, []byte("secret\n"), 0o644))
+
+	// values.yaml is a symlink to the outside file.
+	require.NoError(t, os.Symlink(outsideTarget, filepath.Join(chartDir, "values.yaml")))
+
+	tmpDir := t.TempDir()
+	tgt := Target{
+		TmpDir: tmpDir,
+		Type:   TargetTypeSource,
+		Log:    logger.New("target-path-symlink-test"),
+		App: models.Application{Spec: struct {
+			Source      *models.Source      `yaml:"source"`
+			Sources     []*models.Source    `yaml:"sources"`
+			MultiSource bool                `yaml:"-"`
+			Destination *models.Destination `yaml:"destination"`
+		}{Source: &models.Source{Path: "charts/demo"}}},
+	}
+
+	err := tgt.MaterializeChartFromWorkingTree(context.Background(), afero.NewOsFs(), repoRoot)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported mode")
+
+	// Confirm the sensitive file content was NOT copied into tmpDir.
+	leaked, statErr := os.Stat(filepath.Join(tmpDir, "charts", "src", "demo", "values.yaml"))
+	if statErr == nil {
+		t.Fatalf("symlinked file leaked into tmpDir: %v bytes", leaked.Size())
+	}
+}
+
+func TestMaterializeChartFromWorkingTree_RejectsSymlinkedChartDir(t *testing.T) {
+	// Variant of the above where the chart directory itself is a symlink to a
+	// directory outside the repo. Lstat must catch this before any I/O.
+	repoRoot := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, "charts"), 0o755))
+
+	outsideDir := filepath.Join(t.TempDir(), "outside-chart")
+	require.NoError(t, os.MkdirAll(outsideDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(outsideDir, "Chart.yaml"), []byte("name: outside\n"), 0o644))
+
+	// charts/demo -> outsideDir
+	require.NoError(t, os.Symlink(outsideDir, filepath.Join(repoRoot, "charts", "demo")))
+
+	tmpDir := t.TempDir()
+	tgt := Target{
+		TmpDir: tmpDir,
+		Type:   TargetTypeSource,
+		Log:    logger.New("target-path-symlink-dir-test"),
+		App: models.Application{Spec: struct {
+			Source      *models.Source      `yaml:"source"`
+			Sources     []*models.Source    `yaml:"sources"`
+			MultiSource bool                `yaml:"-"`
+			Destination *models.Destination `yaml:"destination"`
+		}{Source: &models.Source{Path: "charts/demo"}}},
+	}
+
+	err := tgt.MaterializeChartFromWorkingTree(context.Background(), afero.NewOsFs(), repoRoot)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a regular directory")
+}
+
 func TestMaterializeChartFromTree(t *testing.T) {
 	tree := commitTreeWith(t, map[string]string{
 		"charts/foo/Chart.yaml":          "name: foo\n",

--- a/internal/app/target_path_test.go
+++ b/internal/app/target_path_test.go
@@ -1,0 +1,173 @@
+package app
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/shini4i/argo-compare/cmd/argo-compare/utils/logger"
+	"github.com/shini4i/argo-compare/internal/models"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEffectiveChartName(t *testing.T) {
+	cases := []struct {
+		name string
+		src  models.Source
+		want string
+	}{
+		{"chart only", models.Source{Chart: "foo"}, "foo"},
+		{"path only", models.Source{Path: "charts/foo"}, "foo"},
+		{"trailing slash path", models.Source{Path: "charts/foo/"}, "foo"},
+		{"single-component path", models.Source{Path: "foo"}, "foo"},
+		{"empty source", models.Source{}, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, effectiveChartName(&c.src))
+		})
+	}
+}
+
+func TestTargetPathBased(t *testing.T) {
+	cases := []struct {
+		name string
+		app  models.Application
+		want bool
+	}{
+		{
+			name: "single source registry",
+			app: models.Application{Spec: struct {
+				Source      *models.Source      `yaml:"source"`
+				Sources     []*models.Source    `yaml:"sources"`
+				MultiSource bool                `yaml:"-"`
+				Destination *models.Destination `yaml:"destination"`
+			}{Source: &models.Source{Chart: "foo"}}},
+			want: false,
+		},
+		{
+			name: "single source path",
+			app: models.Application{Spec: struct {
+				Source      *models.Source      `yaml:"source"`
+				Sources     []*models.Source    `yaml:"sources"`
+				MultiSource bool                `yaml:"-"`
+				Destination *models.Destination `yaml:"destination"`
+			}{Source: &models.Source{Path: "charts/foo"}}},
+			want: true,
+		},
+		{
+			name: "multi source all path",
+			app: models.Application{Spec: struct {
+				Source      *models.Source      `yaml:"source"`
+				Sources     []*models.Source    `yaml:"sources"`
+				MultiSource bool                `yaml:"-"`
+				Destination *models.Destination `yaml:"destination"`
+			}{Sources: []*models.Source{{Path: "a"}, {Path: "b"}}, MultiSource: true}},
+			want: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tgt := Target{App: c.app}
+			assert.Equal(t, c.want, tgt.PathBased())
+		})
+	}
+}
+
+func TestTargetClassifySource_MixedMultiSourceRejected(t *testing.T) {
+	tgt := Target{App: models.Application{Spec: struct {
+		Source      *models.Source      `yaml:"source"`
+		Sources     []*models.Source    `yaml:"sources"`
+		MultiSource bool                `yaml:"-"`
+		Destination *models.Destination `yaml:"destination"`
+	}{
+		Sources: []*models.Source{
+			{Chart: "registry-chart"},
+			{Path: "charts/foo"},
+		},
+		MultiSource: true,
+	}}}
+	err := tgt.ClassifySources()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMixedMultiSource)
+}
+
+func TestTargetClassifySource_UniformPasses(t *testing.T) {
+	chartOnly := Target{App: models.Application{Spec: struct {
+		Source      *models.Source      `yaml:"source"`
+		Sources     []*models.Source    `yaml:"sources"`
+		MultiSource bool                `yaml:"-"`
+		Destination *models.Destination `yaml:"destination"`
+	}{Sources: []*models.Source{{Chart: "a"}, {Chart: "b"}}, MultiSource: true}}}
+	require.NoError(t, chartOnly.ClassifySources())
+
+	pathOnly := Target{App: models.Application{Spec: struct {
+		Source      *models.Source      `yaml:"source"`
+		Sources     []*models.Source    `yaml:"sources"`
+		MultiSource bool                `yaml:"-"`
+		Destination *models.Destination `yaml:"destination"`
+	}{Sources: []*models.Source{{Path: "a"}, {Path: "b"}}, MultiSource: true}}}
+	require.NoError(t, pathOnly.ClassifySources())
+}
+
+func TestMaterializeChartFromWorkingTree(t *testing.T) {
+	repoRoot := t.TempDir()
+	chartSrc := filepath.Join(repoRoot, "charts", "foo")
+	require.NoError(t, os.MkdirAll(filepath.Join(chartSrc, "templates"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(chartSrc, "Chart.yaml"), []byte("name: foo\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(chartSrc, "values.yaml"), []byte("replicaCount: 1\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(chartSrc, "templates", "dep.yaml"), []byte("kind: Deployment\n"), 0o644))
+
+	tmpDir := t.TempDir()
+	tgt := Target{
+		TmpDir: tmpDir,
+		Type:   TargetTypeSource,
+		Log:    logger.New("target-path-test"),
+		App: models.Application{Spec: struct {
+			Source      *models.Source      `yaml:"source"`
+			Sources     []*models.Source    `yaml:"sources"`
+			MultiSource bool                `yaml:"-"`
+			Destination *models.Destination `yaml:"destination"`
+		}{Source: &models.Source{Path: "charts/foo"}}},
+	}
+
+	require.NoError(t, tgt.MaterializeChartFromWorkingTree(context.Background(), afero.NewOsFs(), repoRoot))
+
+	destChart := filepath.Join(tmpDir, "charts", "src", "foo")
+	for _, rel := range []string{"Chart.yaml", "values.yaml", "templates/dep.yaml"} {
+		_, err := os.Stat(filepath.Join(destChart, rel))
+		require.NoError(t, err, "expected %s under %s", rel, destChart)
+	}
+}
+
+func TestMaterializeChartFromTree(t *testing.T) {
+	tree := commitTreeWith(t, map[string]string{
+		"charts/foo/Chart.yaml":          "name: foo\n",
+		"charts/foo/values.yaml":         "replicaCount: 9\n",
+		"charts/foo/templates/dep.yaml":  "kind: Deployment\n",
+	})
+
+	tmpDir := t.TempDir()
+	tgt := Target{
+		TmpDir: tmpDir,
+		Type:   TargetTypeDestination,
+		Log:    logger.New("target-path-tree-test"),
+		App: models.Application{Spec: struct {
+			Source      *models.Source      `yaml:"source"`
+			Sources     []*models.Source    `yaml:"sources"`
+			MultiSource bool                `yaml:"-"`
+			Destination *models.Destination `yaml:"destination"`
+		}{Source: &models.Source{Path: "charts/foo"}}},
+	}
+
+	require.NoError(t, tgt.MaterializeChartFromTree(context.Background(), afero.NewOsFs(), tree))
+
+	values, err := os.ReadFile(filepath.Join(tmpDir, "charts", "dst", "foo", "values.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, "replicaCount: 9\n", string(values))
+}
+

--- a/internal/app/tree_materialize.go
+++ b/internal/app/tree_materialize.go
@@ -25,13 +25,9 @@ func MaterializeTreeDir(ctx context.Context, fs afero.Fs, tree *object.Tree, sub
 		return err
 	}
 
-	sub := tree
-	if subpath != "" && subpath != "." {
-		t, err := tree.Tree(subpath)
-		if err != nil {
-			return fmt.Errorf("resolve subpath %q in tree: %w", subpath, err)
-		}
-		sub = t
+	sub, err := resolveSubtree(tree, subpath)
+	if err != nil {
+		return err
 	}
 
 	if err := fs.MkdirAll(destDir, 0o755); err != nil {
@@ -39,34 +35,52 @@ func MaterializeTreeDir(ctx context.Context, fs afero.Fs, tree *object.Tree, sub
 	}
 
 	destClean := filepath.Clean(destDir)
-	iter := sub.Files()
-	return iter.ForEach(func(file *object.File) error {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-		abs := filepath.Clean(filepath.Join(destClean, file.Name))
-		// Defense-in-depth: reject any tree entry whose materialized path
-		// escapes destDir. Standard git rejects `..` and `.` as entry names,
-		// so this should be unreachable for trees produced by `git commit`,
-		// but a hand-crafted malicious tree could otherwise write outside
-		// destDir when invoked in CI.
-		if abs != destClean && !strings.HasPrefix(abs, destClean+string(filepath.Separator)) {
-			return fmt.Errorf("tree entry %q escapes destination", file.Name)
-		}
-		if err := fs.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
-			return fmt.Errorf("create dir for %q: %w", abs, err)
-		}
-		content, err := file.Contents()
-		if err != nil {
-			return fmt.Errorf("read blob %q: %w", file.Name, err)
-		}
-		mode, err := file.Mode.ToOSFileMode()
-		if err != nil {
-			mode = 0o644
-		}
-		if err := afero.WriteFile(fs, abs, []byte(content), mode); err != nil {
-			return fmt.Errorf("write %q: %w", abs, err)
-		}
-		return nil
+	return sub.Files().ForEach(func(file *object.File) error {
+		return writeTreeFile(ctx, fs, destClean, file)
 	})
+}
+
+// resolveSubtree returns the subtree of tree at subpath, or tree itself when
+// subpath is empty or ".".
+func resolveSubtree(tree *object.Tree, subpath string) (*object.Tree, error) {
+	if subpath == "" || subpath == "." {
+		return tree, nil
+	}
+	sub, err := tree.Tree(subpath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve subpath %q in tree: %w", subpath, err)
+	}
+	return sub, nil
+}
+
+// writeTreeFile materializes a single tree blob to disk under destClean,
+// enforcing the escape guard and preserving the recorded file mode.
+//
+// Defense-in-depth: reject any tree entry whose materialized path escapes
+// destClean. Standard git rejects `..` and `.` as entry names, so this should
+// be unreachable for trees produced by `git commit`, but a hand-crafted
+// malicious tree could otherwise write outside destDir when invoked in CI.
+func writeTreeFile(ctx context.Context, fs afero.Fs, destClean string, file *object.File) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	abs := filepath.Clean(filepath.Join(destClean, file.Name))
+	if abs != destClean && !strings.HasPrefix(abs, destClean+string(filepath.Separator)) {
+		return fmt.Errorf("tree entry %q escapes destination", file.Name)
+	}
+	if err := fs.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		return fmt.Errorf("create dir for %q: %w", abs, err)
+	}
+	content, err := file.Contents()
+	if err != nil {
+		return fmt.Errorf("read blob %q: %w", file.Name, err)
+	}
+	mode, err := file.Mode.ToOSFileMode()
+	if err != nil {
+		mode = 0o644
+	}
+	if err := afero.WriteFile(fs, abs, []byte(content), mode); err != nil {
+		return fmt.Errorf("write %q: %w", abs, err)
+	}
+	return nil
 }

--- a/internal/app/tree_materialize.go
+++ b/internal/app/tree_materialize.go
@@ -1,0 +1,72 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/spf13/afero"
+)
+
+// MaterializeTreeDir writes every file in the subpath of tree to destDir,
+// preserving the relative directory layout and the recorded file mode.
+//
+// subpath is resolved relative to tree's root. Use "" or "." to materialize
+// the entire tree. The destination directory is created if missing; existing
+// files at the destination are overwritten.
+//
+// MaterializeTreeDir returns an error if subpath does not resolve to a
+// directory inside the tree (including the case where it points at a blob),
+// or if the context is cancelled before or during the walk.
+func MaterializeTreeDir(ctx context.Context, fs afero.Fs, tree *object.Tree, subpath, destDir string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	sub := tree
+	if subpath != "" && subpath != "." {
+		t, err := tree.Tree(subpath)
+		if err != nil {
+			return fmt.Errorf("resolve subpath %q in tree: %w", subpath, err)
+		}
+		sub = t
+	}
+
+	if err := fs.MkdirAll(destDir, 0o755); err != nil {
+		return fmt.Errorf("create destination %q: %w", destDir, err)
+	}
+
+	destClean := filepath.Clean(destDir)
+	iter := sub.Files()
+	return iter.ForEach(func(file *object.File) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		abs := filepath.Clean(filepath.Join(destClean, file.Name))
+		// Defense-in-depth: reject any tree entry whose materialized path
+		// escapes destDir. Standard git rejects `..` and `.` as entry names,
+		// so this should be unreachable for trees produced by `git commit`,
+		// but a hand-crafted malicious tree could otherwise write outside
+		// destDir when invoked in CI.
+		if abs != destClean && !strings.HasPrefix(abs, destClean+string(filepath.Separator)) {
+			return fmt.Errorf("tree entry %q escapes destination", file.Name)
+		}
+		if err := fs.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			return fmt.Errorf("create dir for %q: %w", abs, err)
+		}
+		content, err := file.Contents()
+		if err != nil {
+			return fmt.Errorf("read blob %q: %w", file.Name, err)
+		}
+		mode, err := file.Mode.ToOSFileMode()
+		if err != nil {
+			mode = 0o644
+		}
+		if err := afero.WriteFile(fs, abs, []byte(content), mode); err != nil {
+			return fmt.Errorf("write %q: %w", abs, err)
+		}
+		return nil
+	})
+}

--- a/internal/app/tree_materialize_test.go
+++ b/internal/app/tree_materialize_test.go
@@ -1,0 +1,130 @@
+package app
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// commitTreeWith writes the given files (relative paths → contents) to a
+// fresh git repo, commits them, and returns the resulting tree object.
+func commitTreeWith(t *testing.T, files map[string]string) *object.Tree {
+	t.Helper()
+	dir := t.TempDir()
+	repo, err := git.PlainInit(dir, false)
+	require.NoError(t, err)
+
+	for path, content := range files {
+		abs := filepath.Join(dir, path)
+		require.NoError(t, os.MkdirAll(filepath.Dir(abs), 0o755))
+		require.NoError(t, os.WriteFile(abs, []byte(content), 0o644))
+	}
+
+	worktree, err := repo.Worktree()
+	require.NoError(t, err)
+	for path := range files {
+		_, err := worktree.Add(path)
+		require.NoError(t, err)
+	}
+	hash, err := worktree.Commit("seed", &git.CommitOptions{Author: defaultSignature()})
+	require.NoError(t, err)
+	commit, err := repo.CommitObject(hash)
+	require.NoError(t, err)
+	tree, err := commit.Tree()
+	require.NoError(t, err)
+	return tree
+}
+
+func TestMaterializeTreeDir_FlatChart(t *testing.T) {
+	tree := commitTreeWith(t, map[string]string{
+		"charts/foo/Chart.yaml":  "name: foo\n",
+		"charts/foo/values.yaml": "replicaCount: 1\n",
+		"unrelated/other.yaml":   "ignored\n",
+	})
+
+	dest := t.TempDir()
+	require.NoError(t, MaterializeTreeDir(context.Background(), afero.NewOsFs(), tree, "charts/foo", dest))
+
+	chart, err := os.ReadFile(filepath.Join(dest, "Chart.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, "name: foo\n", string(chart))
+
+	values, err := os.ReadFile(filepath.Join(dest, "values.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, "replicaCount: 1\n", string(values))
+
+	_, err = os.Stat(filepath.Join(dest, "unrelated"))
+	assert.True(t, os.IsNotExist(err), "files outside subpath must not be materialized")
+}
+
+func TestMaterializeTreeDir_NestedDirectories(t *testing.T) {
+	tree := commitTreeWith(t, map[string]string{
+		"charts/foo/Chart.yaml":          "name: foo\n",
+		"charts/foo/values.yaml":         "replicaCount: 1\n",
+		"charts/foo/templates/dep.yaml":  "kind: Deployment\n",
+		"charts/foo/templates/svc.yaml":  "kind: Service\n",
+		"charts/foo/charts/sub/x.yaml":   "sub-chart-file\n",
+	})
+
+	dest := t.TempDir()
+	require.NoError(t, MaterializeTreeDir(context.Background(), afero.NewOsFs(), tree, "charts/foo", dest))
+
+	for _, rel := range []string{"Chart.yaml", "values.yaml", "templates/dep.yaml", "templates/svc.yaml", "charts/sub/x.yaml"} {
+		_, err := os.Stat(filepath.Join(dest, rel))
+		assert.NoError(t, err, "expected %s to exist", rel)
+	}
+}
+
+func TestMaterializeTreeDir_SubpathMissing(t *testing.T) {
+	tree := commitTreeWith(t, map[string]string{
+		"charts/foo/Chart.yaml": "name: foo\n",
+	})
+
+	dest := t.TempDir()
+	err := MaterializeTreeDir(context.Background(), afero.NewOsFs(), tree, "charts/bar", dest)
+	require.Error(t, err)
+}
+
+func TestMaterializeTreeDir_SubpathIsFile(t *testing.T) {
+	tree := commitTreeWith(t, map[string]string{
+		"charts/foo/Chart.yaml": "name: foo\n",
+	})
+
+	dest := t.TempDir()
+	err := MaterializeTreeDir(context.Background(), afero.NewOsFs(), tree, "charts/foo/Chart.yaml", dest)
+	require.Error(t, err, "subpath must be a directory inside the tree")
+}
+
+func TestMaterializeTreeDir_RootSubpath(t *testing.T) {
+	tree := commitTreeWith(t, map[string]string{
+		"Chart.yaml":  "name: top\n",
+		"values.yaml": "replicaCount: 1\n",
+	})
+
+	dest := t.TempDir()
+	require.NoError(t, MaterializeTreeDir(context.Background(), afero.NewOsFs(), tree, ".", dest))
+
+	chart, err := os.ReadFile(filepath.Join(dest, "Chart.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, "name: top\n", string(chart))
+}
+
+func TestMaterializeTreeDir_ContextCancelled(t *testing.T) {
+	tree := commitTreeWith(t, map[string]string{
+		"charts/foo/Chart.yaml": "name: foo\n",
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	dest := t.TempDir()
+	err := MaterializeTreeDir(ctx, afero.NewOsFs(), tree, "charts/foo", dest)
+	require.Error(t, err)
+}

--- a/internal/models/application.go
+++ b/internal/models/application.go
@@ -51,19 +51,35 @@ type Source struct {
 	} `yaml:"helm"`
 }
 
-// validateHelmSources checks that all sources have a non-empty chart field.
-// Currently we support only helm repository based charts as a source.
+// validateHelmSources checks that every source declares exactly one chart kind:
+// either a Helm-registry chart (Source.Chart) or a Git path (Source.Path).
+// Sources with neither set, or with both set, are rejected with
+// ErrUnsupportedAppConfiguration. A nil Source is also rejected.
 func (app *Application) validateHelmSources() error {
 	if len(app.Spec.Sources) > 0 {
 		for _, source := range app.Spec.Sources {
-			if len(source.Chart) == 0 {
-				return ErrUnsupportedAppConfiguration
+			if err := validateSourceShape(source); err != nil {
+				return err
 			}
 		}
 		return nil
 	}
 
-	if app.Spec.Source == nil || len(app.Spec.Source.Chart) == 0 {
+	if app.Spec.Source == nil {
+		return ErrUnsupportedAppConfiguration
+	}
+	return validateSourceShape(app.Spec.Source)
+}
+
+// validateSourceShape ensures the supplied Source declares exactly one of
+// Chart or Path. "Neither" and "both" both yield ErrUnsupportedAppConfiguration.
+func validateSourceShape(source *Source) error {
+	if source == nil {
+		return ErrUnsupportedAppConfiguration
+	}
+	hasChart := len(source.Chart) > 0
+	hasPath := len(source.Path) > 0
+	if hasChart == hasPath {
 		return ErrUnsupportedAppConfiguration
 	}
 	return nil
@@ -74,7 +90,8 @@ func (app *Application) validateHelmSources() error {
 // - If the Application struct is empty, returns ErrEmptyFile.
 // - If both the 'source' and 'sources' fields are set at the same time, returns an error.
 // - If the kind of the application is not "Application", returns ErrNotApplication.
-// - If the application specifies sources, ensures that each source has a non-empty 'chart' field.
+// - For each source, ensures it declares exactly one of 'chart' (Helm-registry)
+//   or 'path' (Git path); both empty or both set yields ErrUnsupportedAppConfiguration.
 // - Sets the 'MultiSource' field to true if sources are specified.
 // - Returns nil if all validation checks pass.
 func (app *Application) Validate() error {

--- a/internal/models/application.go
+++ b/internal/models/application.go
@@ -72,15 +72,20 @@ func (app *Application) validateHelmSources() error {
 }
 
 // validateSourceShape ensures the supplied Source declares exactly one of
-// Chart or Path. "Neither" and "both" both yield ErrUnsupportedAppConfiguration.
+// Chart or Path. Each failure mode wraps ErrUnsupportedAppConfiguration with
+// a specific message so users see *why* their manifest was rejected without
+// losing the sentinel for errors.Is checks.
 func validateSourceShape(source *Source) error {
 	if source == nil {
-		return ErrUnsupportedAppConfiguration
+		return fmt.Errorf("%w: source is nil", ErrUnsupportedAppConfiguration)
 	}
 	hasChart := len(source.Chart) > 0
 	hasPath := len(source.Path) > 0
-	if hasChart == hasPath {
-		return ErrUnsupportedAppConfiguration
+	switch {
+	case hasChart && hasPath:
+		return fmt.Errorf("%w: source has both chart=%q and path=%q set; only one is allowed", ErrUnsupportedAppConfiguration, source.Chart, source.Path)
+	case !hasChart && !hasPath:
+		return fmt.Errorf("%w: source has neither chart nor path set", ErrUnsupportedAppConfiguration)
 	}
 	return nil
 }

--- a/internal/models/application_test.go
+++ b/internal/models/application_test.go
@@ -138,4 +138,112 @@ func TestApplication_Validate(t *testing.T) {
 	var nilApp *Application
 	err = nilApp.Validate()
 	assert.ErrorIs(t, err, ErrEmptyFile, "expected ErrEmptyFile for nil receiver")
+
+	// Test case 9: Path-based single source (chart empty, path set) - should pass
+	appWithPathSource := &Application{
+		Kind: "Application",
+		Spec: struct {
+			Source      *Source      `yaml:"source"`
+			Sources     []*Source    `yaml:"sources"`
+			MultiSource bool         `yaml:"-"`
+			Destination *Destination `yaml:"destination"`
+		}{
+			Source: &Source{
+				RepoURL:        "https://git.example.com/group/repo.git",
+				Path:           "charts/my-app",
+				TargetRevision: "main",
+			},
+		},
+	}
+	err = appWithPathSource.Validate()
+	assert.NoError(t, err, "expected no error for path-based source")
+
+	// Test case 10: Source with both chart and path - should be rejected
+	appWithChartAndPath := &Application{
+		Kind: "Application",
+		Spec: struct {
+			Source      *Source      `yaml:"source"`
+			Sources     []*Source    `yaml:"sources"`
+			MultiSource bool         `yaml:"-"`
+			Destination *Destination `yaml:"destination"`
+		}{
+			Source: &Source{
+				RepoURL:        "https://git.example.com/group/repo.git",
+				Chart:          "my-chart",
+				Path:           "charts/my-app",
+				TargetRevision: "main",
+			},
+		},
+	}
+	err = appWithChartAndPath.Validate()
+	assert.ErrorIs(t, err, ErrUnsupportedAppConfiguration, "expected ErrUnsupportedAppConfiguration when both chart and path are set")
+
+	// Test case 11: Path-based multi-source (each has path, none has chart) - should pass
+	appWithPathMultiSource := &Application{
+		Kind: "Application",
+		Spec: struct {
+			Source      *Source      `yaml:"source"`
+			Sources     []*Source    `yaml:"sources"`
+			MultiSource bool         `yaml:"-"`
+			Destination *Destination `yaml:"destination"`
+		}{
+			Source: nil,
+			Sources: []*Source{
+				{
+					RepoURL: "https://git.example.com/group/repo.git",
+					Path:    "charts/chart-a",
+				},
+				{
+					RepoURL: "https://git.example.com/group/repo.git",
+					Path:    "charts/chart-b",
+				},
+			},
+		},
+	}
+	err = appWithPathMultiSource.Validate()
+	assert.NoError(t, err, "expected no error for path-based multi-source")
+	assert.True(t, appWithPathMultiSource.Spec.MultiSource, "MultiSource flag must be set for path-based multi-source applications")
+
+	// Test case 12: Multi-source with one entry having both chart and path - should be rejected
+	appWithMixedMultiSource := &Application{
+		Kind: "Application",
+		Spec: struct {
+			Source      *Source      `yaml:"source"`
+			Sources     []*Source    `yaml:"sources"`
+			MultiSource bool         `yaml:"-"`
+			Destination *Destination `yaml:"destination"`
+		}{
+			Source: nil,
+			Sources: []*Source{
+				{
+					Chart: "chart-a",
+					Path:  "charts/chart-a",
+				},
+				{
+					Chart: "chart-b",
+				},
+			},
+		},
+	}
+	err = appWithMixedMultiSource.Validate()
+	assert.ErrorIs(t, err, ErrUnsupportedAppConfiguration, "expected ErrUnsupportedAppConfiguration when chart and path are both set in multi-source")
+
+	// Test case 13: Multi-source with a nil entry - should be rejected, not panic
+	appWithNilMultiSourceEntry := &Application{
+		Kind: "Application",
+		Spec: struct {
+			Source      *Source      `yaml:"source"`
+			Sources     []*Source    `yaml:"sources"`
+			MultiSource bool         `yaml:"-"`
+			Destination *Destination `yaml:"destination"`
+		}{
+			Source: nil,
+			Sources: []*Source{
+				nil,
+				{Path: "charts/chart-b"},
+			},
+		},
+	}
+	err = appWithNilMultiSourceEntry.Validate()
+	assert.ErrorIs(t, err, ErrUnsupportedAppConfiguration, "expected ErrUnsupportedAppConfiguration for nil entry in Sources")
 }

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"os"
 
+	"github.com/shini4i/argo-compare/internal/anchor"
 	"github.com/shini4i/argo-compare/internal/models"
 )
 
@@ -148,24 +149,8 @@ type ManifestValidator interface {
 	Validate(ctx context.Context, target, manifestDir string) (ValidationResult, error)
 }
 
-// ApplicationRef points to an ArgoCD Application manifest in Git.
-// It is the port-layer mirror of anchor.ApplicationRef, kept here to avoid
-// pulling an anchor-package dependency into ports. The canonical schema lives
-// in `internal/anchor` (the on-disk YAML format); when adding fields, update
-// `anchor.ApplicationRef` first, then this struct, then the mapping at the
-// call site that loads anchors and invokes the fetcher.
-type ApplicationRef struct {
-	// Repo is the Git URL of the repository hosting the Application.
-	// Empty means "the local repo argo-compare is running in".
-	Repo string
-	// Path is the path to the Application YAML inside Repo, relative to repo root.
-	Path string
-	// Branch is the branch to read from. Empty means "the remote's default branch"
-	// for cross-repo fetches, and is ignored for same-repo fetches.
-	Branch string
-}
-
-// ApplicationFetcher resolves an ApplicationRef to a parsed Application model.
+// ApplicationFetcher resolves an anchor.ApplicationRef to a parsed
+// Application model.
 //
 // For same-repo refs (Repo == ""), implementations read from the working tree
 // at localRepoRoot. For cross-repo refs, implementations fetch the file from
@@ -174,5 +159,5 @@ type ApplicationRef struct {
 // Any failure (network, missing file, parse error) is returned as a hard
 // error so the caller can fail loudly; partial results are not supported.
 type ApplicationFetcher interface {
-	Fetch(ctx context.Context, ref ApplicationRef, localRepoRoot string) (models.Application, error)
+	Fetch(ctx context.Context, ref anchor.ApplicationRef, localRepoRoot string) (models.Application, error)
 }

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -5,6 +5,8 @@ package ports
 import (
 	"context"
 	"os"
+
+	"github.com/shini4i/argo-compare/internal/models"
 )
 
 // CmdRunner executes shell commands and returns captured output.
@@ -144,4 +146,33 @@ type ManifestValidator interface {
 	// A non-nil error indicates the validator itself failed to run; schema
 	// errors in the manifests are returned via ValidationResult.
 	Validate(ctx context.Context, target, manifestDir string) (ValidationResult, error)
+}
+
+// ApplicationRef points to an ArgoCD Application manifest in Git.
+// It is the port-layer mirror of anchor.ApplicationRef, kept here to avoid
+// pulling an anchor-package dependency into ports. The canonical schema lives
+// in `internal/anchor` (the on-disk YAML format); when adding fields, update
+// `anchor.ApplicationRef` first, then this struct, then the mapping at the
+// call site that loads anchors and invokes the fetcher.
+type ApplicationRef struct {
+	// Repo is the Git URL of the repository hosting the Application.
+	// Empty means "the local repo argo-compare is running in".
+	Repo string
+	// Path is the path to the Application YAML inside Repo, relative to repo root.
+	Path string
+	// Branch is the branch to read from. Empty means "the remote's default branch"
+	// for cross-repo fetches, and is ignored for same-repo fetches.
+	Branch string
+}
+
+// ApplicationFetcher resolves an ApplicationRef to a parsed Application model.
+//
+// For same-repo refs (Repo == ""), implementations read from the working tree
+// at localRepoRoot. For cross-repo refs, implementations fetch the file from
+// the named remote at Branch tip without affecting the local working tree.
+//
+// Any failure (network, missing file, parse error) is returned as a hard
+// error so the caller can fail loudly; partial results are not supported.
+type ApplicationFetcher interface {
+	Fetch(ctx context.Context, ref ApplicationRef, localRepoRoot string) (models.Application, error)
 }

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,20 @@
+# Argo Compare
+
+> A CLI that shows what would change in helm-rendered ArgoCD Application manifests once a pull request is merged into the target branch.
+
+Argo Compare renders both the source and target branches with `helm template`, strips Helm-injected noise, and prints the diff. Optional features layer on top of the core flow: manifest schema validation via kubeconform, posting the diff as a GitLab Merge Request comment, anchored discovery for repos where the PR touches chart content instead of the Application YAML, and credential handling for private chart sources (password-protected Helm repos, OCI registries, AWS ECR).
+
+## Docs
+
+- [Installation](https://raw.githubusercontent.com/shini4i/argo-compare/main/docs/installation.md): Binary downloads and Docker image setup.
+- [Usage](https://raw.githubusercontent.com/shini4i/argo-compare/main/docs/usage.md): CLI flags, output modes, external diff tools, Helm label stripping, and secret masking.
+- [How it works](https://raw.githubusercontent.com/shini4i/argo-compare/main/docs/how-it-works.md): The end-to-end comparison pipeline.
+- [Anchored repositories](https://raw.githubusercontent.com/shini4i/argo-compare/main/docs/anchored-repositories.md): Path-based sources and the `.argo-compare.yml` anchor flow for chart-only repos.
+- [Manifest validation](https://raw.githubusercontent.com/shini4i/argo-compare/main/docs/manifest-validation.md): Schema validation with `kubeconform`, including flags and environment variables.
+- [Repository credentials](https://raw.githubusercontent.com/shini4i/argo-compare/main/docs/repository-credentials.md): Private Helm repos via `REPO_CREDS_*`, OCI registries, and automatic AWS ECR authentication.
+- [GitLab integration](https://raw.githubusercontent.com/shini4i/argo-compare/main/docs/gitlab-integration.md): Posting the diff as a Merge Request comment, with GitLab CI auto-detection.
+
+## Optional
+
+- [Project README](https://raw.githubusercontent.com/shini4i/argo-compare/main/README.md): Top-level overview, badges, quick start, and roadmap.
+- [Anchor examples](https://raw.githubusercontent.com/shini4i/argo-compare/main/examples/anchor/README.md): Structural reference fixtures for the same-repo and cross-repo anchor layouts.


### PR DESCRIPTION
  ## Summary

  - Adds a `.argo-compare.yml` anchor file that points argo-compare at the ArgoCD Application affected by a PR when the
  diff touches chart/values files rather than the Application YAML itself. Covers two repo layouts: **all-in-one**
  (Application and chart in the same repo, `spec.source.path` instead of `spec.source.chart`) and **manifest-only**
  (Application lives in a separate "apps" repo).
  - Path-based Applications are now first-class. `models.Application.Validate` accepts sources with `path` set instead
  of `chart`; the renderer materializes the chart directory from the local working tree (src leg) and the merge-base
  tree (dst leg), so the diff reflects exactly what will land after the merge. `helm pull` / extract are skipped for
  path-based sources.
  - New CLI surface: `--anchor-file <name>` and `ARGO_COMPARE_ANCHOR_FILE` (default `.argo-compare.yml`; empty disables
  discovery). The existing changed-Application-file flow is untouched for registry-based sources.
  - Failure modes are explicit and hard: malformed anchor → `anchor.ErrInvalidAnchor`; anchored Application whose
  `spec.source.repoURL` does not resolve to the local origin → `ErrAnchorRepoMismatch`; non-path-based anchored
  Application → `ErrAnchorNotPathBased`.

  ## Scope and known limits

  - Helm sources only (kustomize / plain-YAML out of scope).
  - Path sources must point at the local repo; chart files in a third repo are explicitly rejected.
  - A multi-source Application must use one kind consistently (mixing `chart` and `path` rejected via
  `ErrMixedMultiSource`).
  - Anchored Applications are read at the configured branch tip — no commit pinning.
  - **Cross-repo Application fetch uses the user's local Git environment** (SSH agent, `~/.gitconfig`). `REPO_CREDS_*`
  is still Helm-only. Dedicated token-based auth (`$CI_JOB_TOKEN` / `$GITHUB_TOKEN` ergonomics) is a planned follow-up —
   see the README's "Limits in this version".