### PR TITLE
docs(docs): add architecture overview and improve AI-friendliness

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ See [Installation](docs/installation.md) and [Usage](docs/usage.md) for the full
 - [Installation](docs/installation.md) — binary downloads and Docker image.
 - [Usage](docs/usage.md) — CLI flags, output modes, external diff tools.
 - [How it works](docs/how-it-works.md) — the comparison pipeline.
+- [Architecture](docs/architecture.md) — package map, dependency direction, entry flows.
 - [Anchored repositories](docs/anchored-repositories.md) — path-based sources and chart-only repos via `.argo-compare.yml`.
 - [Manifest validation](docs/manifest-validation.md) — schema validation with `kubeconform`.
 - [Repository credentials](docs/repository-credentials.md) — private Helm repos, OCI registries, AWS ECR.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,96 @@
+# Architecture
+
+This document describes the code structure of `argo-compare` — package
+responsibilities, dependency direction, and where the two entry flows live.
+For the user-facing pipeline (what the tool *does*, step by step), see
+[How it works](how-it-works.md).
+
+## Package map
+
+```
+cmd/argo-compare/
+├── main.go               # CLI entrypoint: wires dependencies, parses args
+├── command/              # cobra command definitions; calls internal/app
+└── utils/                # adapters: real implementations of internal/ports
+                          # (CmdRunner, HelmChartsProcessor, Globber, ...)
+
+internal/
+├── app/                  # orchestrator: end-to-end comparison workflow
+│                         # holds Config, App, the two entry flows, and the
+│                         # comment/diff strategies
+├── anchor/               # .argo-compare.yml schema + loader
+├── comment/              # Poster interface
+│   └── gitlab/           # GitLab MR comment adapter
+├── helpers/              # env vars, Helm label stripping, retry, fs utils
+├── models/               # ArgoCD Application and related YAML structs
+├── ports/                # interface contracts the adapters in cmd/.../utils
+│   └── portstest/        # shared no-op fakes for tests (NoopCmdRunner etc.)
+├── sanitizer/            # KubernetesSecretMasker — redacts Secret data
+│                         # before manifests are diffed
+├── testfixtures/         # shared manifest snippets used across test packages
+└── ui/                   # terminal color helpers
+```
+
+## Dependency direction
+
+```
+cmd/argo-compare/main.go
+        │
+        ▼
+cmd/argo-compare/command          (cobra wiring)
+        │
+        ▼
+internal/app  ──────────────►  internal/{anchor, models, sanitizer, comment, ui, helpers}
+        │                                      │
+        │                                      ▼
+        └────────► internal/ports ◄────── cmd/argo-compare/utils
+                       ▲                  (adapter implementations:
+                       │                   RealCmdRunner, OsFileReader,
+                       │                   RealHelmChartProcessor, ...)
+                       │
+                       └──────────────── internal/sanitizer
+                                         (also implements a port)
+```
+
+Only `cmd/argo-compare/utils` (and a few specific packages like `sanitizer`)
+implement the interfaces declared in `internal/ports`. Everything that needs
+to shell out, touch the filesystem, glob, or render Helm goes through a port
+— which keeps `internal/app` testable with the fakes in
+`internal/ports/portstest`.
+
+## Two entry flows
+
+`internal/app` selects between two entry paths based on what the PR diff
+contains:
+
+1. **Standard flow** — the PR modifies ArgoCD Application YAML files
+   directly. Driver code lives in `internal/app/app.go`,
+   `application_fetcher.go`, `git.go`, `target.go`, `compare.go`.
+
+2. **Anchor flow** — the PR modifies chart content (e.g. Helm values)
+   rather than an Application YAML. `argo-compare` walks up to the
+   nearest `.argo-compare.yml`, resolves the referenced Application, and
+   renders the chart twice (working tree vs. merge-base). Driver code
+   lives in `internal/app/anchor_discovery.go`, `anchor_flow.go`,
+   `tree_materialize.go`. The anchor schema itself is in
+   `internal/anchor`.
+
+Both flows converge on the same comparison + comment publication path in
+`internal/app/compare.go` and `comment_strategy.go`.
+
+## Side-effects and where they live
+
+| Side-effect            | Port (interface)                     | Default adapter                           |
+|------------------------|--------------------------------------|-------------------------------------------|
+| Shell commands         | `ports.CmdRunner`                    | `cmd/argo-compare/utils.RealCmdRunner`    |
+| Filesystem reads       | `ports.FileReader`                   | `cmd/argo-compare/utils.OsFileReader`     |
+| Helm template / pull   | `ports.HelmChartsProcessor`          | `cmd/argo-compare/utils.RealHelmChartProcessor` |
+| Glob expansion         | `ports.Globber`                      | `cmd/argo-compare/utils.CustomGlobber`    |
+| Manifest validation    | `ports.ManifestValidator`            | `internal/app` `KubeconformValidator` (opt-in) |
+| Secret masking         | `ports.SensitiveDataMasker`          | `internal/sanitizer.KubernetesSecretMasker` |
+| Credential resolution  | `ports.CredentialProvider`           | ECR provider + static `REPO_CREDS_*` fallback |
+| Application fetching   | `ports.ApplicationFetcher`           | `internal/app.RealApplicationFetcher`     |
+| Comment publishing     | `internal/comment.Poster`            | `internal/comment/gitlab` (when configured) |
+
+Tests substitute the corresponding `portstest` fake or a hand-rolled stub
+rather than mocking concrete types.

--- a/llms.txt
+++ b/llms.txt
@@ -9,6 +9,7 @@ Argo Compare renders both the source and target branches with `helm template`, s
 - [Installation](https://raw.githubusercontent.com/shini4i/argo-compare/main/docs/installation.md): Binary downloads and Docker image setup.
 - [Usage](https://raw.githubusercontent.com/shini4i/argo-compare/main/docs/usage.md): CLI flags, output modes, external diff tools, Helm label stripping, and secret masking.
 - [How it works](https://raw.githubusercontent.com/shini4i/argo-compare/main/docs/how-it-works.md): The end-to-end comparison pipeline.
+- [Architecture](https://raw.githubusercontent.com/shini4i/argo-compare/main/docs/architecture.md): Package map, dependency direction, and the two entry flows.
 - [Anchored repositories](https://raw.githubusercontent.com/shini4i/argo-compare/main/docs/anchored-repositories.md): Path-based sources and the `.argo-compare.yml` anchor flow for chart-only repos.
 - [Manifest validation](https://raw.githubusercontent.com/shini4i/argo-compare/main/docs/manifest-validation.md): Schema validation with `kubeconform`, including flags and environment variables.
 - [Repository credentials](https://raw.githubusercontent.com/shini4i/argo-compare/main/docs/repository-credentials.md): Private Helm repos via `REPO_CREDS_*`, OCI registries, and automatic AWS ECR authentication.


### PR DESCRIPTION
Add docs/architecture.md describing package map, dependency direction, the two entry flows (standard and anchor), and where side-effects live.

Link the new guide from README.md and llms.txt to surface it for agents and contributors navigating the codebase.