### PR TITLE
feat(app): add PAT auth for cross-repo anchor clones

### DIFF
--- a/cmd/argo-compare/command/root.go
+++ b/cmd/argo-compare/command/root.go
@@ -146,6 +146,8 @@ func newBranchCommand(opts Options, dropCache func() bool, debug func() bool) *c
 	cmd.Flags().StringSliceVar(&flags.validateSkipKinds, "skip-validation-kinds", flags.validateSkipKinds, "Resource kinds to skip during validation (comma-separated)")
 	cmd.Flags().StringSliceVar(&flags.validateSchemaLocations, "schema-location", flags.validateSchemaLocations, "Additional kubeconform -schema-location values (can be repeated or comma-separated)")
 	cmd.Flags().StringVar(&flags.anchorFileName, "anchor-file", flags.anchorFileName, "Name of the file that marks an anchor directory (default .argo-compare.yml; empty disables discovery)")
+	cmd.Flags().StringVar(&flags.gitUsername, "git-username", flags.gitUsername, "Username for HTTP Basic auth when cloning cross-repo anchored Applications (defaults to x-access-token; set to gitlab-ci-token for GitLab CI_JOB_TOKEN or your account name for Bitbucket)")
+	cmd.Flags().StringVar(&flags.gitToken, "git-token", flags.gitToken, "Token (typically a PAT) for HTTP Basic auth when cloning cross-repo anchored Applications")
 
 	return cmd
 }
@@ -167,6 +169,8 @@ type branchFlags struct {
 	validateSkipKinds       []string
 	validateSchemaLocations []string
 	anchorFileName          string
+	gitUsername             string
+	gitToken                string
 }
 
 // loadBranchDefaults gathers branch flag defaults from the environment.
@@ -236,6 +240,9 @@ func loadBranchDefaults() branchFlags {
 
 	defaults.anchorFileName = helpers.GetEnv("ARGO_COMPARE_ANCHOR_FILE", app.DefaultAnchorFileName)
 
+	defaults.gitUsername = helpers.GetEnv("ARGO_COMPARE_GIT_USERNAME", "")
+	defaults.gitToken = helpers.GetEnv("ARGO_COMPARE_GIT_TOKEN", "")
+
 	return defaults
 }
 
@@ -265,6 +272,7 @@ func (b branchFlags) configOptions(opts Options, debugEnabled bool) ([]app.Confi
 		app.WithValidateSkipKinds(b.validateSkipKinds),
 		app.WithValidateSchemaLocations(b.validateSchemaLocations),
 		app.WithAnchorFileName(b.anchorFileName),
+		app.WithGitAuth(b.gitUsername, b.gitToken),
 	}
 
 	commentOption, err := b.commentOption()

--- a/docs/anchored-repositories.md
+++ b/docs/anchored-repositories.md
@@ -8,7 +8,8 @@ To bridge that gap, drop a `.argo-compare.yml` file into any directory where cha
 # .argo-compare.yml — universal schema
 application:
   # Optional. Omit when the Application lives in this same repo.
-  repo: ssh://git@example.com/group/apps.git
+  # Prefer https:// so the same anchor works in CI (PAT auth — see below).
+  repo: https://example.com/group/apps.git
   # Required. Path to the Application YAML inside that repo.
   path: cluster-state/myapp/myapp.yaml
   # Optional. Defaults to the remote's default branch.
@@ -30,9 +31,38 @@ A worked example lives under [`examples/anchor/`](../examples/anchor).
 - For path-based Applications, `spec.source.repoURL` must identify the local repository — chart sources living in a _third_ repo are out of scope.
 - A multi-source Application must use one kind consistently; mixing `chart` and `path` entries is rejected.
 - The anchored Application is read at the configured branch tip; commit-pinning is not supported.
-- Cross-repo Application reads use your local Git environment (SSH agent, `~/.gitconfig`). The `REPO_CREDS_*` mechanism remains Helm-only.
 - Any failure to fetch, parse, or validate an anchored Application is a hard error — partial output would silently hide a broken configuration.
 
 ## Configuration
 
 - `--anchor-file <name>` (or `ARGO_COMPARE_ANCHOR_FILE`) overrides the anchor file name. Default: `.argo-compare.yml`. Pass an empty string to suppress discovery.
+
+## Authenticating cross-repo clones
+
+Same-repo anchors read from the local working tree — no credentials involved.
+
+Cross-repo anchors clone the target repository over its `repo:` URL. There are two auth paths, picked at runtime:
+
+- **Local development** — if no credentials are configured, `argo-compare` lets go-git fall back to its defaults: SSH agent + default keys for `ssh://` URLs, anonymous for `https://` URLs against public repos. This is the only mode that existed before the `ARGO_COMPARE_GIT_*` env vars were introduced; nothing changes for users who rely on it.
+- **CI / unattended** — set `ARGO_COMPARE_GIT_TOKEN` (or pass `--git-token`). Every cross-repo clone is sent with HTTP Basic auth. If `ARGO_COMPARE_GIT_USERNAME` is not set it defaults to `x-access-token`, which works for GitHub PATs, GitLab PATs, and Gitea. Set `ARGO_COMPARE_GIT_USERNAME` explicitly only when a different username is required (e.g. `gitlab-ci-token` for GitLab `CI_JOB_TOKEN`, or your account username for Bitbucket app passwords). Only `https://` URLs in the anchor file pick up these credentials — `ssh://` URLs continue to use the SSH agent regardless.
+
+The right username depends on the host (this table covers `https://` URLs only — `ssh://` URLs always use the SSH agent regardless of these env vars):
+
+| Host       | `ARGO_COMPARE_GIT_USERNAME`               | `ARGO_COMPARE_GIT_TOKEN`              |
+| ---------- | ----------------------------------------- | ------------------------------------- |
+| GitHub     | omit (defaults to `x-access-token`)       | PAT (or `${{ secrets.GITHUB_TOKEN }}` in Actions) |
+| GitLab     | omit for PAT; `gitlab-ci-token` for CI_JOB_TOKEN | PAT or `$CI_JOB_TOKEN`          |
+| Gitea      | omit (defaults to `x-access-token`)       | PAT                                   |
+| Bitbucket  | your Bitbucket account username           | App password                          |
+
+`ARGO_COMPARE_GIT_*` is intentionally separate from `ARGO_COMPARE_GITLAB_TOKEN` even though both can sometimes hold the same value. The GitLab token authenticates the **REST API** (posting MR comments); the git token authenticates **git clone**. Different scopes, different lifetimes, sometimes different hosts. If you want one source of truth in GitLab CI, set both:
+
+```yaml
+# .gitlab-ci.yml
+variables:
+  ARGO_COMPARE_GITLAB_TOKEN: $CI_JOB_TOKEN     # for posting MR comments
+  ARGO_COMPARE_GIT_USERNAME: gitlab-ci-token   # required when using CI_JOB_TOKEN for git clones
+  ARGO_COMPARE_GIT_TOKEN: $CI_JOB_TOKEN        # for cloning cross-repo anchors
+```
+
+For Helm chart credentials (a separate mechanism), see [`repository-credentials.md`](repository-credentials.md).

--- a/docs/repository-credentials.md
+++ b/docs/repository-credentials.md
@@ -1,5 +1,9 @@
 # Repository credentials
 
+This page covers credentials for **Helm chart repositories** (and OCI registries hosting Helm charts).
+
+For credentials used to **clone a cross-repo anchored Application** (`.argo-compare.yml` with a `repo:` pointing at a different Git repo), see [`anchored-repositories.md`](anchored-repositories.md#authenticating-cross-repo-clones). The two mechanisms are deliberately separate — they authenticate against different surfaces (a Helm registry vs. a Git host) and typically need different scopes.
+
 Public Helm repositories work with no configuration. For private sources, `argo-compare` reads credentials from environment variables matched against the `repoURL` of each Application.
 
 ## Password-protected Helm repositories

--- a/examples/anchor/cross-repo/charts/myapp/.argo-compare.yml
+++ b/examples/anchor/cross-repo/charts/myapp/.argo-compare.yml
@@ -1,5 +1,7 @@
 application:
   # The Application lives in a different repo (an "apps" repo).
-  repo: ssh://git@git.example.com/group/apps.git
+  # Use https:// so the same anchor works both locally and in CI;
+  # CI authenticates via ARGO_COMPARE_GIT_USERNAME + ARGO_COMPARE_GIT_TOKEN.
+  repo: https://git.example.com/group/apps.git
   path: cluster-state/myapp/myapp.yaml
   branch: main

--- a/internal/app/anchor_flow.go
+++ b/internal/app/anchor_flow.go
@@ -177,10 +177,12 @@ func (a *App) applicationFetcher() ports.ApplicationFetcher {
 		return a.fetcher
 	}
 	return &RealApplicationFetcher{
-		FS:         a.fs,
-		FileReader: a.fileReader,
-		CmdRunner:  a.cmdRunner,
-		Log:        a.logger,
+		FS:          a.fs,
+		FileReader:  a.fileReader,
+		CmdRunner:   a.cmdRunner,
+		Log:         a.logger,
+		GitUsername: a.cfg.GitUsername,
+		GitToken:    a.cfg.GitToken,
 	}
 }
 

--- a/internal/app/application_fetcher.go
+++ b/internal/app/application_fetcher.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
+	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/spf13/afero"
 )
@@ -24,13 +25,23 @@ import (
 // existing FileReader port (no Git plumbing involved). Cross-repo fetches
 // perform an in-memory clone of Repo at Branch tip (or the remote's default
 // branch when Branch is empty) and read the manifest from the resulting
-// tree. Auth relies on the user's local Git environment (SSH agent,
-// ~/.gitconfig); no credentials are passed in.
+// tree.
+//
+// Auth precedence for cross-repo clones:
+//  1. If GitUsername AND GitToken are both non-empty, an HTTP Basic auth
+//     header is attached to the clone — the canonical PAT path for GitHub,
+//     GitLab, Bitbucket, and Gitea (go-git's TokenAuth is Bearer and is
+//     not what those providers want; see go-git transport/http/common.go).
+//  2. Otherwise no Auth is set and go-git falls back to its defaults — SSH
+//     agent + default keys for ssh:// URLs, unauthenticated for https://.
+//     This preserves the pre-PAT behavior for local development.
 type RealApplicationFetcher struct {
-	FS         afero.Fs
-	FileReader ports.FileReader
-	CmdRunner  ports.CmdRunner
-	Log        *logger.Logger
+	FS          afero.Fs
+	FileReader  ports.FileReader
+	CmdRunner   ports.CmdRunner
+	Log         *logger.Logger
+	GitUsername string
+	GitToken    string
 }
 
 // Fetch resolves ref to a parsed Application.
@@ -70,15 +81,7 @@ func (f *RealApplicationFetcher) fetchFromLocal(path, localRepoRoot string) (mod
 // memfs worktree so nothing touches the local filesystem until the parsed
 // content is written to a temp file for Target.parse.
 func (f *RealApplicationFetcher) fetchFromRemote(ctx context.Context, ref anchor.ApplicationRef) (models.Application, error) {
-	cloneOpts := &git.CloneOptions{
-		URL:          ref.Repo,
-		SingleBranch: true,
-		Depth:        1,
-		Tags:         git.NoTags,
-	}
-	if ref.Branch != "" {
-		cloneOpts.ReferenceName = plumbing.NewBranchReferenceName(ref.Branch)
-	}
+	cloneOpts := f.buildCloneOptions(ref)
 
 	safeRepo := redactRepo(ref.Repo)
 	repo, err := git.CloneContext(ctx, memory.NewStorage(), memfs.New(), cloneOpts)
@@ -133,10 +136,36 @@ func (f *RealApplicationFetcher) fetchFromRemote(ctx context.Context, ref anchor
 	return target.App, nil
 }
 
+// buildCloneOptions assembles the *git.CloneOptions used by fetchFromRemote.
+//
+// Auth is attached when GitToken is non-empty. GitUsername defaults to
+// "x-access-token" when not set — sufficient for GitHub PATs, GitLab PATs,
+// and Gitea. Set GitUsername explicitly for CI_JOB_TOKEN or Bitbucket.
+func (f *RealApplicationFetcher) buildCloneOptions(ref anchor.ApplicationRef) *git.CloneOptions {
+	opts := &git.CloneOptions{
+		URL:          ref.Repo,
+		SingleBranch: true,
+		Depth:        1,
+		Tags:         git.NoTags,
+	}
+	if ref.Branch != "" {
+		opts.ReferenceName = plumbing.NewBranchReferenceName(ref.Branch)
+	}
+	if f.GitToken != "" {
+		username := f.GitUsername
+		if username == "" {
+			username = "x-access-token"
+		}
+		opts.Auth = &githttp.BasicAuth{Username: username, Password: f.GitToken}
+	}
+	return opts
+}
+
 // redactRepo strips userinfo from a Git URL before it lands in an error or log
-// message. Embedding credentials in the URL is unsupported by this fetcher
-// (auth flows via the user's local Git environment), but defending against a
-// foot-gun is cheap.
+// message. Embedding credentials in the URL is unsupported — auth flows either
+// via the local Git environment (SSH agent for ssh:// URLs) or via the
+// ARGO_COMPARE_GIT_* env vars (BasicAuth for https:// URLs). Defending against
+// a URL-embedded credential foot-gun is cheap regardless.
 func redactRepo(repo string) string {
 	u, err := url.Parse(repo)
 	if err != nil || u.User == nil {

--- a/internal/app/application_fetcher_test.go
+++ b/internal/app/application_fetcher_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
+	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -176,6 +177,80 @@ func TestFetcher_CrossRepo_BranchDefaultsToHEAD(t *testing.T) {
 	}, "")
 	require.NoError(t, err)
 	assert.Equal(t, "example", app.Metadata.Name)
+}
+
+func TestFetcher_buildCloneOptions_NoAuthWhenTokenEmpty(t *testing.T) {
+	f := newTestFetcher(t)
+	// GitUsername and GitToken intentionally left zero — emulates a runtime
+	// with no PAT configured (today's only mode).
+	opts := f.buildCloneOptions(anchor.ApplicationRef{
+		Repo:   "https://github.com/example/repo.git",
+		Path:   "apps/example.yaml",
+		Branch: "main",
+	})
+	assert.Nil(t, opts.Auth, "no Auth must be set when GitToken is empty (backwards compat with local-Git auth flows)")
+	assert.Equal(t, "https://github.com/example/repo.git", opts.URL)
+	assert.Equal(t, plumbing.NewBranchReferenceName("main"), opts.ReferenceName)
+	assert.True(t, opts.SingleBranch)
+	assert.Equal(t, 1, opts.Depth)
+	assert.Equal(t, git.NoTags, opts.Tags)
+}
+
+func TestFetcher_buildCloneOptions_NoAuthWhenOnlyUsername(t *testing.T) {
+	f := newTestFetcher(t)
+	f.GitUsername = "x-access-token"
+	// Token missing — must NOT set auth (username alone is meaningless and
+	// silently sending a blank password would be confusing).
+	opts := f.buildCloneOptions(anchor.ApplicationRef{
+		Repo: "https://github.com/example/repo.git",
+		Path: "apps/example.yaml",
+	})
+	assert.Nil(t, opts.Auth)
+}
+
+func TestFetcher_buildCloneOptions_BasicAuthWhenBothSet(t *testing.T) {
+	f := newTestFetcher(t)
+	f.GitUsername = "x-access-token"
+	f.GitToken = "ghp_secret"
+
+	opts := f.buildCloneOptions(anchor.ApplicationRef{
+		Repo: "https://github.com/example/repo.git",
+		Path: "apps/example.yaml",
+	})
+
+	require.NotNil(t, opts.Auth)
+	basic, ok := opts.Auth.(*githttp.BasicAuth)
+	require.True(t, ok, "Auth must be *githttp.BasicAuth (GitHub/GitLab/Gitea/Bitbucket all expect basic, not bearer — see go-git transport/http/common.go:530)")
+	assert.Equal(t, "x-access-token", basic.Username)
+	assert.Equal(t, "ghp_secret", basic.Password)
+}
+
+func TestFetcher_buildCloneOptions_DefaultsUsernameWhenTokenOnly(t *testing.T) {
+	f := newTestFetcher(t)
+	// Typical CI setup: only token provided. Username defaults to "x-access-token",
+	// which works for GitHub PATs, GitLab PATs, and Gitea — the common-case providers.
+	f.GitToken = "ghp_secret"
+
+	opts := f.buildCloneOptions(anchor.ApplicationRef{
+		Repo: "https://github.com/example/repo.git",
+		Path: "apps/example.yaml",
+	})
+
+	require.NotNil(t, opts.Auth)
+	basic, ok := opts.Auth.(*githttp.BasicAuth)
+	require.True(t, ok)
+	assert.Equal(t, "x-access-token", basic.Username)
+	assert.Equal(t, "ghp_secret", basic.Password)
+}
+
+func TestFetcher_buildCloneOptions_OmitsBranchWhenEmpty(t *testing.T) {
+	f := newTestFetcher(t)
+	opts := f.buildCloneOptions(anchor.ApplicationRef{
+		Repo: "https://github.com/example/repo.git",
+		Path: "apps/example.yaml",
+		// Branch intentionally omitted — go-git uses the remote's default.
+	})
+	assert.Empty(t, string(opts.ReferenceName))
 }
 
 func TestRedactRepo(t *testing.T) {

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -25,6 +25,8 @@ type Config struct {
 	ValidateSkipKinds       []string
 	ValidateSchemaLocations []string
 	AnchorFileName          string
+	GitUsername             string
+	GitToken                string
 }
 
 // ConfigOption mutates a Config during construction.
@@ -204,6 +206,20 @@ func WithValidateSkipKinds(kinds []string) ConfigOption {
 func WithValidateSchemaLocations(locations []string) ConfigOption {
 	return func(cfg *Config) {
 		cfg.ValidateSchemaLocations = append([]string{}, locations...)
+	}
+}
+
+// WithGitAuth configures HTTP Basic auth for cross-repo anchor clones.
+//
+// Pass the token (typically a PAT) and, optionally, a username. When username
+// is empty and token is non-empty, the clone defaults to "x-access-token" as
+// the username, which works for GitHub, GitLab PATs, and Gitea. Set an explicit
+// username for GitLab CI_JOB_TOKEN (gitlab-ci-token) or Bitbucket app passwords.
+// Empty token disables auth and preserves the local-Git fallback.
+func WithGitAuth(username, token string) ConfigOption {
+	return func(cfg *Config) {
+		cfg.GitUsername = username
+		cfg.GitToken = token
 	}
 }
 

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -58,6 +58,30 @@ func TestNewConfigWithOptions(t *testing.T) {
 	assert.Equal(t, "1.2.3", cfg.Version)
 }
 
+func TestWithGitAuth(t *testing.T) {
+	cfg, err := NewConfig("main", WithGitAuth("x-access-token", "ghp_secret"))
+	require.NoError(t, err)
+	assert.Equal(t, "x-access-token", cfg.GitUsername)
+	assert.Equal(t, "ghp_secret", cfg.GitToken)
+}
+
+func TestWithGitAuth_EmptyValuesAreFine(t *testing.T) {
+	// Both unset is the default, no-auth path — must not error.
+	cfg, err := NewConfig("main")
+	require.NoError(t, err)
+	assert.Empty(t, cfg.GitUsername)
+	assert.Empty(t, cfg.GitToken)
+}
+
+func TestWithGitAuth_TokenOnlyDefaultsUsername(t *testing.T) {
+	// Token without username is valid — buildCloneOptions falls back to
+	// "x-access-token", which works for GitHub, GitLab PAT, and Gitea.
+	cfg, err := NewConfig("main", WithGitAuth("", "ghp_secret"))
+	require.NoError(t, err)
+	assert.Empty(t, cfg.GitUsername, "Config stores whatever the caller passed; the default is applied later in buildCloneOptions")
+	assert.Equal(t, "ghp_secret", cfg.GitToken)
+}
+
 func TestNewConfigRequiresTargetBranch(t *testing.T) {
 	_, err := NewConfig("")
 	assert.Error(t, err)


### PR DESCRIPTION
Cross-repo anchored Applications previously relied on the local Git environment (SSH agent, ~/.gitconfig) for authentication, which is unavailable in CI runners. Adds opt-in HTTP Basic auth via two new env vars / flags:

  ARGO_COMPARE_GIT_TOKEN    / --git-token
  ARGO_COMPARE_GIT_USERNAME / --git-username  (optional)

When the token is set, every cross-repo clone is sent with BasicAuth. Username defaults to "x-access-token" (works for GitHub PATs, GitLab PATs, and Gitea); set explicitly for GitLab CI_JOB_TOKEN or Bitbucket. Empty token preserves today's local-Git fallback behavior unchanged.

The auth path uses go-git's BasicAuth (not TokenAuth) because GitHub, GitLab, Bitbucket, and Gitea all expect Basic, not Bearer.

Documents the new contract in docs/anchored-repositories.md (auth section, host table, GitLab CI recipe) and updates the cross-repo example from ssh:// to https:// so it works in both local and CI.