### PR TITLE
fix(app): honor helm.valueFiles and tolerate charts without values.yaml

### DIFF
--- a/cmd/argo-compare/utils/helm_chart_processor.go
+++ b/cmd/argo-compare/utils/helm_chart_processor.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -17,6 +19,31 @@ import (
 
 // ErrFailedToDownloadChart indicates Helm failed to pull the requested chart.
 var ErrFailedToDownloadChart = errors.New("failed to download chart")
+
+// ErrInvalidValueFile is returned when a helm.valueFiles entry is rejected for
+// security reasons (empty, absolute path, or parent-directory traversal).
+var ErrInvalidValueFile = errors.New("invalid valueFile path")
+
+// validateValueFile rejects valueFiles entries that could read files outside
+// the chart directory. It enforces three rules that together prevent the
+// Application YAML (an untrusted, PR-author-controlled input) from exfiltrating
+// host secrets through the rendered diff posted to MR comments:
+//   - non-empty (empty paths have no valid use and are a sign of misconfiguration)
+//   - not absolute (absolute paths bypass the chart-dir prefix entirely on POSIX)
+//   - no parent traversal (filepath.Clean("../foo") would escape the chart dir)
+func validateValueFile(vf string) error {
+	if vf == "" {
+		return fmt.Errorf("%w: path must not be empty", ErrInvalidValueFile)
+	}
+	if filepath.IsAbs(vf) {
+		return fmt.Errorf("%w: absolute paths are not allowed: %q", ErrInvalidValueFile, vf)
+	}
+	cleaned := filepath.Clean(vf)
+	if strings.HasPrefix(cleaned, "..") {
+		return fmt.Errorf("%w: path traversal is not allowed: %q", ErrInvalidValueFile, vf)
+	}
+	return nil
+}
 
 // isOCIRegistry returns true if the repo URL refers to an OCI registry (no http/https scheme).
 func isOCIRegistry(repoURL string) bool {
@@ -269,6 +296,14 @@ func (g RealHelmChartProcessor) ExtractHelmChart(ctx context.Context, deps ports
 // RenderAppSource uses the Helm CLI to render the templates of a given chart.
 // It takes a cmdRunner to run the Helm command and a request containing the chart
 // information needed for rendering.
+//
+// Argument ordering mirrors ArgoCD's helm renderer: the chart's own values.yaml
+// is auto-loaded by `helm template`, then explicit valueFiles from the
+// Application's spec.source.helm.valueFiles are applied in order, then any
+// inline values from spec.source.helm.values / valuesObject as the final
+// override. The inline file is only added when it exists on disk so that
+// Applications without inline values do not crash on a missing path.
+//
 // The context can be used to cancel the rendering or set a timeout.
 func (g RealHelmChartProcessor) RenderAppSource(ctx context.Context, cmdRunner ports.CmdRunner, req ports.ChartRenderRequest) error {
 	g.Log.Debugf("Rendering [%s] chart's version [%s] templates using release name [%s]",
@@ -276,16 +311,33 @@ func (g RealHelmChartProcessor) RenderAppSource(ctx context.Context, cmdRunner p
 		ui.Cyan(req.ChartVersion),
 		ui.Cyan(req.ReleaseName))
 
-	_, stderr, err := cmdRunner.Run(ctx,
-		"helm",
+	chartDir := fmt.Sprintf("%s/charts/%s/%s", req.TmpDir, req.TargetType, req.ChartName)
+
+	args := []string{
 		"template",
 		"--release-name", req.ReleaseName,
-		fmt.Sprintf("%s/charts/%s/%s", req.TmpDir, req.TargetType, req.ChartName),
+		chartDir,
 		"--output-dir", fmt.Sprintf("%s/templates/%s", req.TmpDir, req.TargetType),
-		"--values", fmt.Sprintf("%s/charts/%s/%s/values.yaml", req.TmpDir, req.TargetType, req.ChartName),
-		"--values", fmt.Sprintf("%s/%s-values-%s.yaml", req.TmpDir, req.ChartName, req.TargetType),
-		"--namespace", req.Namespace,
-	)
+	}
+
+	for _, vf := range req.ValueFiles {
+		if err := validateValueFile(vf); err != nil {
+			return err
+		}
+		args = append(args, "--values", filepath.Join(chartDir, vf))
+	}
+
+	inlineValuesPath := fmt.Sprintf("%s/%s-values-%s.yaml", req.TmpDir, req.ChartName, req.TargetType)
+	if _, err := os.Stat(inlineValuesPath); err == nil || !errors.Is(err, fs.ErrNotExist) {
+		if err != nil {
+			return fmt.Errorf("check inline values file %q: %w", inlineValuesPath, err)
+		}
+		args = append(args, "--values", inlineValuesPath)
+	}
+
+	args = append(args, "--namespace", req.Namespace)
+
+	_, stderr, err := cmdRunner.Run(ctx, "helm", args...)
 
 	if len(stderr) > 0 {
 		// Helm may emit warnings via stderr even on success; log them for visibility.

--- a/cmd/argo-compare/utils/helm_chart_processor_test.go
+++ b/cmd/argo-compare/utils/helm_chart_processor_test.go
@@ -361,55 +361,204 @@ func TestExtractHelmChart(t *testing.T) {
 }
 
 func TestRenderAppSource(t *testing.T) {
+	t.Run("inline values file present, no valueFiles", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockCmdRunner := mocks.NewMockCmdRunner(ctrl)
+		helmChartProcessor := RealHelmChartProcessor{Log: logger.New("test")}
+
+		tmpDir := t.TempDir()
+		inlinePath := filepath.Join(tmpDir, "my-chart-values-src.yaml")
+		assert.NoError(t, os.WriteFile(inlinePath, []byte("key: value"), 0o644))
+
+		req := ports.ChartRenderRequest{
+			ReleaseName:  "my-release",
+			ChartName:    "my-chart",
+			ChartVersion: "1.2.3",
+			TmpDir:       tmpDir,
+			TargetType:   "src",
+			Namespace:    "my-namespace",
+		}
+
+		mockCmdRunner.EXPECT().Run(gomock.Any(), "helm",
+			"template",
+			"--release-name", "my-release",
+			fmt.Sprintf("%s/charts/src/my-chart", tmpDir),
+			"--output-dir", fmt.Sprintf("%s/templates/src", tmpDir),
+			"--values", inlinePath,
+			"--namespace", "my-namespace").Return("", "", nil)
+
+		assert.NoError(t, helmChartProcessor.RenderAppSource(context.Background(), mockCmdRunner, req))
+	})
+
+	t.Run("no inline values, no valueFiles - relies on chart's auto-loaded values.yaml", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockCmdRunner := mocks.NewMockCmdRunner(ctrl)
+		helmChartProcessor := RealHelmChartProcessor{Log: logger.New("test")}
+
+		tmpDir := t.TempDir()
+		req := ports.ChartRenderRequest{
+			ReleaseName:  "my-release",
+			ChartName:    "my-chart",
+			ChartVersion: "1.2.3",
+			TmpDir:       tmpDir,
+			TargetType:   "src",
+			Namespace:    "my-namespace",
+		}
+
+		mockCmdRunner.EXPECT().Run(gomock.Any(), "helm",
+			"template",
+			"--release-name", "my-release",
+			fmt.Sprintf("%s/charts/src/my-chart", tmpDir),
+			"--output-dir", fmt.Sprintf("%s/templates/src", tmpDir),
+			"--namespace", "my-namespace").Return("", "", nil)
+
+		assert.NoError(t, helmChartProcessor.RenderAppSource(context.Background(), mockCmdRunner, req))
+	})
+
+	t.Run("valueFiles applied in order before inline values", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockCmdRunner := mocks.NewMockCmdRunner(ctrl)
+		helmChartProcessor := RealHelmChartProcessor{Log: logger.New("test")}
+
+		tmpDir := t.TempDir()
+		inlinePath := filepath.Join(tmpDir, "my-chart-values-src.yaml")
+		assert.NoError(t, os.WriteFile(inlinePath, []byte("override: true"), 0o644))
+
+		req := ports.ChartRenderRequest{
+			ReleaseName:  "my-release",
+			ChartName:    "my-chart",
+			ChartVersion: "1.2.3",
+			TmpDir:       tmpDir,
+			TargetType:   "src",
+			Namespace:    "my-namespace",
+			ValueFiles:   []string{"values.yaml", "environment.yaml", "worker.yaml"},
+		}
+
+		chartDir := fmt.Sprintf("%s/charts/src/my-chart", tmpDir)
+		mockCmdRunner.EXPECT().Run(gomock.Any(), "helm",
+			"template",
+			"--release-name", "my-release",
+			chartDir,
+			"--output-dir", fmt.Sprintf("%s/templates/src", tmpDir),
+			"--values", fmt.Sprintf("%s/values.yaml", chartDir),
+			"--values", fmt.Sprintf("%s/environment.yaml", chartDir),
+			"--values", fmt.Sprintf("%s/worker.yaml", chartDir),
+			"--values", inlinePath,
+			"--namespace", "my-namespace").Return("", "", nil)
+
+		assert.NoError(t, helmChartProcessor.RenderAppSource(context.Background(), mockCmdRunner, req))
+	})
+
+	t.Run("valueFiles without inline values", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockCmdRunner := mocks.NewMockCmdRunner(ctrl)
+		helmChartProcessor := RealHelmChartProcessor{Log: logger.New("test")}
+
+		tmpDir := t.TempDir()
+		req := ports.ChartRenderRequest{
+			ReleaseName:  "my-release",
+			ChartName:    "my-chart",
+			ChartVersion: "1.2.3",
+			TmpDir:       tmpDir,
+			TargetType:   "src",
+			Namespace:    "my-namespace",
+			ValueFiles:   []string{"production.yaml"},
+		}
+
+		chartDir := fmt.Sprintf("%s/charts/src/my-chart", tmpDir)
+		mockCmdRunner.EXPECT().Run(gomock.Any(), "helm",
+			"template",
+			"--release-name", "my-release",
+			chartDir,
+			"--output-dir", fmt.Sprintf("%s/templates/src", tmpDir),
+			"--values", fmt.Sprintf("%s/production.yaml", chartDir),
+			"--namespace", "my-namespace").Return("", "", nil)
+
+		assert.NoError(t, helmChartProcessor.RenderAppSource(context.Background(), mockCmdRunner, req))
+	})
+
+	t.Run("failed render surfaces error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockCmdRunner := mocks.NewMockCmdRunner(ctrl)
+		helmChartProcessor := RealHelmChartProcessor{Log: logger.New("test")}
+
+		tmpDir := t.TempDir()
+		req := ports.ChartRenderRequest{
+			ReleaseName:  "my-release",
+			ChartName:    "my-chart",
+			ChartVersion: "1.2.3",
+			TmpDir:       tmpDir,
+			TargetType:   "src",
+			Namespace:    "my-namespace",
+		}
+
+		osErr := &exec.ExitError{ProcessState: &os.ProcessState{}}
+		mockCmdRunner.EXPECT().Run(gomock.Any(), "helm",
+			"template",
+			"--release-name", "my-release",
+			fmt.Sprintf("%s/charts/src/my-chart", tmpDir),
+			"--output-dir", fmt.Sprintf("%s/templates/src", tmpDir),
+			"--namespace", "my-namespace").Return("", "", osErr)
+
+		assert.Error(t, helmChartProcessor.RenderAppSource(context.Background(), mockCmdRunner, req))
+	})
+}
+
+func TestValidateValueFile(t *testing.T) {
+	t.Run("valid relative paths pass", func(t *testing.T) {
+		assert.NoError(t, validateValueFile("values.yaml"))
+		assert.NoError(t, validateValueFile("environment.yaml"))
+		assert.NoError(t, validateValueFile("config/override.yaml"))
+	})
+
+	t.Run("empty path is rejected", func(t *testing.T) {
+		err := validateValueFile("")
+		assert.ErrorIs(t, err, ErrInvalidValueFile)
+	})
+
+	t.Run("absolute path is rejected", func(t *testing.T) {
+		err := validateValueFile("/etc/passwd")
+		assert.ErrorIs(t, err, ErrInvalidValueFile)
+	})
+
+	t.Run("parent traversal is rejected", func(t *testing.T) {
+		for _, p := range []string{"../escape.yaml", "../../etc/passwd", "../values.yaml"} {
+			err := validateValueFile(p)
+			assert.ErrorIs(t, err, ErrInvalidValueFile, "expected ErrInvalidValueFile for %q", p)
+		}
+	})
+
+	t.Run("traversal inside a subpath is rejected", func(t *testing.T) {
+		err := validateValueFile("safe/../../../etc/passwd")
+		assert.ErrorIs(t, err, ErrInvalidValueFile)
+	})
+}
+
+func TestRenderAppSource_ValueFileValidation(t *testing.T) {
+	helmChartProcessor := RealHelmChartProcessor{Log: logger.New("test")}
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-
-	helmChartProcessor := RealHelmChartProcessor{Log: logger.New("test")}
-
-	// Create an instance of the mock CmdRunner
 	mockCmdRunner := mocks.NewMockCmdRunner(ctrl)
 
 	tmpDir := t.TempDir()
 
-	req := ports.ChartRenderRequest{
-		ReleaseName:  "my-release",
-		ChartName:    "my-chart",
-		ChartVersion: "1.2.3",
-		TmpDir:       tmpDir,
-		TargetType:   "src",
-		Namespace:    "my-namespace",
+	for _, vf := range []string{"../escape.yaml", "/etc/passwd", ""} {
+		req := ports.ChartRenderRequest{
+			ReleaseName: "my-release",
+			ChartName:   "my-chart",
+			TmpDir:      tmpDir,
+			TargetType:  "src",
+			Namespace:   "my-namespace",
+			ValueFiles:  []string{vf},
+		}
+		err := helmChartProcessor.RenderAppSource(context.Background(), mockCmdRunner, req)
+		assert.ErrorIs(t, err, ErrInvalidValueFile, "expected rejection of valueFile %q", vf)
 	}
-
-	// Test case 1: Successful render
-	mockCmdRunner.EXPECT().Run(gomock.Any(), "helm",
-		"template",
-		"--release-name", gomock.Any(),
-		gomock.Any(),
-		"--output-dir", gomock.Any(),
-		"--values", gomock.Any(),
-		"--values", gomock.Any(),
-		"--namespace", gomock.Any()).Return("", "", nil)
-
-	// Call the function under test
-	err := helmChartProcessor.RenderAppSource(context.Background(), mockCmdRunner, req)
-	assert.NoError(t, err, "expected no error, got %v", err)
-
-	// Test case 2: Failed render
-	osErr := &exec.ExitError{
-		ProcessState: &os.ProcessState{},
-	}
-	mockCmdRunner.EXPECT().Run(gomock.Any(), "helm",
-		"template",
-		"--release-name", gomock.Any(),
-		gomock.Any(),
-		"--output-dir", gomock.Any(),
-		"--values", gomock.Any(),
-		"--values", gomock.Any(),
-		"--namespace", gomock.Any()).Return("", "", osErr)
-
-	err = helmChartProcessor.RenderAppSource(context.Background(), mockCmdRunner, req)
-	assert.Error(t, err, "expected error, got nil")
-	assert.Errorf(t, err, "expected error, got %v", err)
 }
 
 func TestResolveCredentials(t *testing.T) {

--- a/docs/anchored-repositories.md
+++ b/docs/anchored-repositories.md
@@ -28,6 +28,7 @@ A worked example lives under [`examples/anchor/`](../examples/anchor).
 ## Limits in this version
 
 - Only Helm sources are supported (`spec.source.chart` or `spec.source.path`). Kustomize / plain-YAML sources are not handled.
+- For path-based sources, `spec.source.helm.valueFiles`, `spec.source.helm.values`, and `spec.source.helm.valuesObject` are all honoured and applied in the same order ArgoCD uses (valueFiles first, inline values on top). A chart without a `values.yaml` and an Application without inline values are both valid.
 - For path-based Applications, `spec.source.repoURL` must identify the local repository — chart sources living in a _third_ repo are out of scope.
 - A multi-source Application must use one kind consistently; mixing `chart` and `path` entries is rejected.
 - The anchored Application is read at the configured branch tip; commit-pinning is not supported.

--- a/internal/app/target.go
+++ b/internal/app/target.go
@@ -75,13 +75,25 @@ func (t *Target) parse() error {
 // The chart name used for the values file derives from effectiveChartName so
 // registry-based (chart) and Git-path-based (path) sources both produce
 // stably-named values files for the downstream render step to find.
+//
+// Sources that declare no inline values (no helm.values and no helm.valuesObject)
+// skip the generation entirely — the renderer detects the missing file and
+// omits the corresponding --values flag. This supports Applications that rely
+// solely on helm.valueFiles or on the chart's own defaults.
 func (t *Target) generateValuesFiles() error {
 	if t.App.Spec.MultiSource {
 		for _, source := range t.App.Spec.Sources {
+			if !hasInlineValues(source) {
+				continue
+			}
 			if err := t.HelmProcessor.GenerateValuesFile(effectiveChartName(source), t.TmpDir, t.Type, source.Helm.Values, source.Helm.ValuesObject); err != nil {
 				return err
 			}
 		}
+		return nil
+	}
+
+	if !hasInlineValues(t.App.Spec.Source) {
 		return nil
 	}
 
@@ -92,6 +104,21 @@ func (t *Target) generateValuesFiles() error {
 		t.App.Spec.Source.Helm.Values,
 		t.App.Spec.Source.Helm.ValuesObject,
 	)
+}
+
+// hasInlineValues reports whether the source carries inline values that must
+// be rendered into a temporary file (helm.values raw YAML, or helm.valuesObject
+// structured form). helm.valueFiles are handled separately as paths into the
+// chart directory and do not count as inline.
+//
+// The nil check on ValuesObject mirrors GenerateValuesFile's guard; both treat
+// a non-nil but empty map as "has values" to produce consistent behaviour with
+// the existing YAML marshalling path.
+func hasInlineValues(source *models.Source) bool {
+	if source == nil {
+		return false
+	}
+	return source.Helm.Values != "" || source.Helm.ValuesObject != nil
 }
 
 // ensureHelmCharts downloads required Helm charts into the configured cache.
@@ -161,6 +188,9 @@ func (t *Target) extractCharts(ctx context.Context) error {
 }
 
 // renderAppSources runs Helm template rendering for each application source.
+// Application.spec.source.helm.valueFiles flow through to the renderer so that
+// charts relying on extra values files (not just inline helm.values) render
+// correctly.
 // The context can be used to cancel rendering or set a timeout.
 func (t *Target) renderAppSources(ctx context.Context) error {
 	if t.App.Spec.MultiSource {
@@ -176,6 +206,7 @@ func (t *Target) renderAppSources(ctx context.Context) error {
 				TmpDir:       t.TmpDir,
 				TargetType:   t.Type,
 				Namespace:    t.App.Spec.Destination.Namespace,
+				ValueFiles:   source.Helm.ValueFiles,
 			}
 			if err := t.HelmProcessor.RenderAppSource(ctx, t.CmdRunner, req); err != nil {
 				return err
@@ -195,6 +226,7 @@ func (t *Target) renderAppSources(ctx context.Context) error {
 		TmpDir:       t.TmpDir,
 		TargetType:   t.Type,
 		Namespace:    t.App.Spec.Destination.Namespace,
+		ValueFiles:   t.App.Spec.Source.Helm.ValueFiles,
 	}
 	return t.HelmProcessor.RenderAppSource(ctx, t.CmdRunner, req)
 }

--- a/internal/app/target_test.go
+++ b/internal/app/target_test.go
@@ -20,6 +20,7 @@ type recordingHelmProcessor struct {
 	downloadCalls       int
 	extractCalls        int
 	renderCalls         int
+	renderRequests      []ports.ChartRenderRequest
 }
 
 func (r *recordingHelmProcessor) GenerateValuesFile(chartName, tmpDir, targetType, values string, valuesObject map[string]interface{}) error {
@@ -37,8 +38,9 @@ func (r *recordingHelmProcessor) ExtractHelmChart(_ context.Context, _ ports.Hel
 	return nil
 }
 
-func (r *recordingHelmProcessor) RenderAppSource(_ context.Context, _ ports.CmdRunner, _ ports.ChartRenderRequest) error {
+func (r *recordingHelmProcessor) RenderAppSource(_ context.Context, _ ports.CmdRunner, req ports.ChartRenderRequest) error {
 	r.renderCalls++
+	r.renderRequests = append(r.renderRequests, req)
 	return nil
 }
 
@@ -123,4 +125,189 @@ func TestTargetMultiSourceInvokesHelmPerSource(t *testing.T) {
 	assert.Equal(t, 2, processor.downloadCalls)
 	assert.Equal(t, 2, processor.extractCalls)
 	assert.Equal(t, 2, processor.renderCalls)
+}
+
+// TestTargetSkipsValuesGenerationWhenInlineEmpty verifies that sources without
+// inline values (no helm.values and no helm.valuesObject) skip
+// GenerateValuesFile entirely. Applications that rely solely on
+// helm.valueFiles or on the chart's own defaults must not crash on the
+// "either 'values' or 'valuesObject' must be provided" guard.
+func TestTargetSkipsValuesGenerationWhenInlineEmpty(t *testing.T) {
+	processor := &recordingHelmProcessor{}
+
+	target := Target{
+		HelmProcessor: processor,
+		Log:           logger.New("target-test"),
+		Type:          TargetTypeSource,
+		App: models.Application{
+			Spec: struct {
+				Source      *models.Source      `yaml:"source"`
+				Sources     []*models.Source    `yaml:"sources"`
+				MultiSource bool                `yaml:"-"`
+				Destination *models.Destination `yaml:"destination"`
+			}{
+				Source: &models.Source{
+					RepoURL: "ssh://git@example.com/repo.git",
+					Path:    "cms-2/staging",
+					Helm: struct {
+						ReleaseName  string                 `yaml:"releaseName,omitempty"`
+						Values       string                 `yaml:"values,omitempty"`
+						ValueFiles   []string               `yaml:"valueFiles,omitempty"`
+						ValuesObject map[string]interface{} `yaml:"valuesObject,omitempty"`
+					}{
+						ValueFiles: []string{"values.yaml", "environment.yaml"},
+					},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, target.generateValuesFiles())
+	assert.Equal(t, 0, processor.generateValuesCalls, "no inline values means no values file must be generated")
+}
+
+// TestTargetPropagatesValueFiles verifies that helm.valueFiles entries flow
+// through to ChartRenderRequest.ValueFiles in declared order. This is the
+// hand-off point between target.go and helm_chart_processor.go for the
+// valueFiles flag.
+func TestTargetPropagatesValueFiles(t *testing.T) {
+	processor := &recordingHelmProcessor{}
+
+	target := Target{
+		CmdRunner:     portstest.NoopCmdRunner{},
+		HelmProcessor: processor,
+		Log:           logger.New("target-test"),
+		Type:          TargetTypeSource,
+		App: models.Application{
+			Spec: struct {
+				Source      *models.Source      `yaml:"source"`
+				Sources     []*models.Source    `yaml:"sources"`
+				MultiSource bool                `yaml:"-"`
+				Destination *models.Destination `yaml:"destination"`
+			}{
+				Source: &models.Source{
+					RepoURL: "ssh://git@example.com/repo.git",
+					Path:    "cms-2/staging",
+					Helm: struct {
+						ReleaseName  string                 `yaml:"releaseName,omitempty"`
+						Values       string                 `yaml:"values,omitempty"`
+						ValueFiles   []string               `yaml:"valueFiles,omitempty"`
+						ValuesObject map[string]interface{} `yaml:"valuesObject,omitempty"`
+					}{
+						ValueFiles: []string{"values.yaml", "environment.yaml", "worker.yaml"},
+					},
+				},
+				Destination: &models.Destination{Namespace: "demo"},
+			},
+		},
+	}
+
+	require.NoError(t, target.renderAppSources(context.Background()))
+	require.Len(t, processor.renderRequests, 1)
+	assert.Equal(t, []string{"values.yaml", "environment.yaml", "worker.yaml"}, processor.renderRequests[0].ValueFiles)
+}
+
+// TestTargetMultiSourceSkipsValuesGenerationForEmptySources verifies that in a
+// multi-source Application, only sources with inline values trigger
+// GenerateValuesFile. Sources that rely solely on valueFiles or chart defaults
+// must not cause the "either values or valuesObject must be provided" error.
+func TestTargetMultiSourceSkipsValuesGenerationForEmptySources(t *testing.T) {
+	processor := &recordingHelmProcessor{}
+
+	target := Target{
+		HelmProcessor: processor,
+		Log:           logger.New("target-test"),
+		Type:          TargetTypeSource,
+		App: models.Application{
+			Spec: struct {
+				Source      *models.Source      `yaml:"source"`
+				Sources     []*models.Source    `yaml:"sources"`
+				MultiSource bool                `yaml:"-"`
+				Destination *models.Destination `yaml:"destination"`
+			}{
+				Sources: []*models.Source{
+					{
+						Chart: "chartA",
+						Helm: struct {
+							ReleaseName  string                 `yaml:"releaseName,omitempty"`
+							Values       string                 `yaml:"values,omitempty"`
+							ValueFiles   []string               `yaml:"valueFiles,omitempty"`
+							ValuesObject map[string]interface{} `yaml:"valuesObject,omitempty"`
+						}{
+							Values: "replicaCount: 2",
+						},
+					},
+					{
+						Chart: "chartB",
+						Helm: struct {
+							ReleaseName  string                 `yaml:"releaseName,omitempty"`
+							Values       string                 `yaml:"values,omitempty"`
+							ValueFiles   []string               `yaml:"valueFiles,omitempty"`
+							ValuesObject map[string]interface{} `yaml:"valuesObject,omitempty"`
+						}{
+							ValueFiles: []string{"extra.yaml"},
+						},
+					},
+				},
+				MultiSource: true,
+			},
+		},
+	}
+
+	require.NoError(t, target.generateValuesFiles())
+	assert.Equal(t, 1, processor.generateValuesCalls, "only the source with inline values must generate a values file")
+}
+
+// TestTargetMultiSourcePropagatesValueFiles verifies that each source's
+// helm.valueFiles flow through to the corresponding ChartRenderRequest so that
+// the renderer receives the correct per-source file list.
+func TestTargetMultiSourcePropagatesValueFiles(t *testing.T) {
+	processor := &recordingHelmProcessor{}
+
+	target := Target{
+		CmdRunner:     portstest.NoopCmdRunner{},
+		HelmProcessor: processor,
+		Log:           logger.New("target-test"),
+		Type:          TargetTypeSource,
+		App: models.Application{
+			Spec: struct {
+				Source      *models.Source      `yaml:"source"`
+				Sources     []*models.Source    `yaml:"sources"`
+				MultiSource bool                `yaml:"-"`
+				Destination *models.Destination `yaml:"destination"`
+			}{
+				Sources: []*models.Source{
+					{
+						Chart: "chartA",
+						Helm: struct {
+							ReleaseName  string                 `yaml:"releaseName,omitempty"`
+							Values       string                 `yaml:"values,omitempty"`
+							ValueFiles   []string               `yaml:"valueFiles,omitempty"`
+							ValuesObject map[string]interface{} `yaml:"valuesObject,omitempty"`
+						}{
+							ValueFiles: []string{"a-values.yaml"},
+						},
+					},
+					{
+						Chart: "chartB",
+						Helm: struct {
+							ReleaseName  string                 `yaml:"releaseName,omitempty"`
+							Values       string                 `yaml:"values,omitempty"`
+							ValueFiles   []string               `yaml:"valueFiles,omitempty"`
+							ValuesObject map[string]interface{} `yaml:"valuesObject,omitempty"`
+						}{
+							ValueFiles: []string{"b-values.yaml", "b-env.yaml"},
+						},
+					},
+				},
+				MultiSource: true,
+				Destination: &models.Destination{Namespace: "demo"},
+			},
+		},
+	}
+
+	require.NoError(t, target.renderAppSources(context.Background()))
+	require.Len(t, processor.renderRequests, 2)
+	assert.Equal(t, []string{"a-values.yaml"}, processor.renderRequests[0].ValueFiles)
+	assert.Equal(t, []string{"b-values.yaml", "b-env.yaml"}, processor.renderRequests[1].ValueFiles)
 }

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -91,6 +91,9 @@ type ChartExtractRequest struct {
 }
 
 // ChartRenderRequest contains the parameters for rendering a Helm chart.
+// ValueFiles lists paths (relative to the chart directory) supplied via
+// Application.spec.source.helm.valueFiles. They are applied in order, before
+// inline values from Application.spec.source.helm.values / valuesObject.
 type ChartRenderRequest struct {
 	ReleaseName  string
 	ChartName    string
@@ -98,6 +101,7 @@ type ChartRenderRequest struct {
 	TmpDir       string
 	TargetType   string
 	Namespace    string
+	ValueFiles   []string
 }
 
 // HelmChartsProcessor coordinates the Helm chart lifecycle required for comparisons.


### PR DESCRIPTION
  ## Summary

  Fixes three rendering crashes for path-based ArgoCD Applications, surfaced when comparing real apps in the `aoi` repo:

  - **`helm template` no longer required to read `<chart>/values.yaml`** — charts without a bundled `values.yaml` (relying on `helm.values`/`valueFiles` only) crashed with `no such file or directory`. Helm auto-loads `values.yaml` when present, so the explicit flag was both redundant
  and brittle.
  - **Applications without inline `helm.values` / `helm.valuesObject` no longer crash** at `generateValuesFiles` — the inline values file is now generated only when there's something to write, and the renderer skips the `--values` flag when the file is absent.
  - **`spec.source.helm.valueFiles` is now honored**, applied in declared order before inline values (matching ArgoCD's precedence). Previously silently dropped.

  `valueFiles` entries are validated to reject empty paths, absolute paths, and `..` traversal before they reach `helm`, preventing a malicious Application YAML from exfiltrating host files through the rendered diff posted to MR comments.

  Docs: `docs/anchored-repositories.md` updated to disclose which `helm.*` fields are supported for path-based sources.