### PR TITLE
fix(app): skip anchor file's own changes in anchor discovery

### DIFF
--- a/docs/anchored-repositories.md
+++ b/docs/anchored-repositories.md
@@ -2,7 +2,7 @@
 
 The default flow assumes the modified file in a PR _is_ the Application YAML. Some repositories split things up: the ArgoCD Application points at a chart directory inside the same repo (`spec.source.path`), or lives in a different repo that consumes a chart from this one. In both cases a PR typically touches chart values rather than the Application itself, so there is no `kind: Application` in the diff and the default flow finds nothing to compare.
 
-To bridge that gap, drop a `.argo-compare.yml` file into any directory where chart content is changed. Argo Compare walks up from each changed file, picks the nearest enclosing anchor, and uses it to find the Application affected by the change:
+To bridge that gap, drop a `.argo-compare.yml` file into any directory that holds chart content. Argo Compare walks up from each changed file (excluding the anchor file itself), picks the nearest enclosing anchor, and uses it to find the Application affected by the change:
 
 ```yaml
 # .argo-compare.yml — universal schema
@@ -15,6 +15,8 @@ application:
   # Optional. Defaults to the remote's default branch.
   branch: main
 ```
+
+Changes that only touch `.argo-compare.yml` — adding the marker during onboarding or editing it later — do not trigger a comparison on their own. A comparison runs only when the same PR also changes real chart content in the anchored directory.
 
 ## Supported layouts
 

--- a/examples/anchor/README.md
+++ b/examples/anchor/README.md
@@ -40,8 +40,10 @@ repo just hosts the chart content the Application consumes. See
 
 ## How the anchor flow uses these files
 
-When a PR touches a file under `charts/myapp/`, argo-compare walks up
-to the nearest `.argo-compare.yml`, fetches the named Application
+When a PR touches a non-anchor file under `charts/myapp/`
+(changes to `.argo-compare.yml` itself are skipped — the marker is not
+chart content), argo-compare walks up to the nearest
+`.argo-compare.yml`, fetches the named Application
 (reading from the local working tree for same-repo, or via an
 in-memory clone for cross-repo), and renders the chart twice — once
 against the working tree (post-PR state) and once against the

--- a/internal/app/anchor_discovery.go
+++ b/internal/app/anchor_discovery.go
@@ -29,8 +29,10 @@ type AnchorGroup struct {
 //
 // Files with no enclosing anchor inside repoRoot are silently dropped:
 // they belong to the existing changed-Application flow, not the anchor
-// flow. A malformed anchor file is a hard error so the caller can fail
-// loudly; partial results would silently hide a broken configuration.
+// flow. Changes to the anchor file itself are skipped: it is a marker,
+// not application content, so a marker-only change seeds no group. A
+// malformed anchor file is a hard error so the caller can fail loudly;
+// partial results would silently hide a broken configuration.
 //
 // The returned slice is sorted by Dir for deterministic downstream logs
 // and comments.
@@ -41,6 +43,13 @@ func DiscoverAnchors(repoRoot string, changedFiles []string, fs afero.Fs, anchor
 	files := map[string][]string{}
 
 	for _, rel := range changedFiles {
+		// The anchor file is a marker, not application content. A change to the
+		// marker itself must never seed or extend a group: onboarding hundreds
+		// of `.argo-compare.yml` files would otherwise trigger comparisons with
+		// no real changes. Real content alongside the marker still forms a group.
+		if filepath.Base(rel) == filepath.Base(anchorFileName) {
+			continue
+		}
 		dir, err := findAnchorDir(fs, repoRoot, filepath.Dir(filepath.Join(repoRoot, rel)), anchorFileName)
 		if err != nil {
 			return nil, err

--- a/internal/app/anchor_discovery_test.go
+++ b/internal/app/anchor_discovery_test.go
@@ -104,13 +104,77 @@ func TestDiscoverAnchors_AnchorFileItselfChanged(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	writeAnchor(t, fs, "/repo/charts/foo", "apps/foo.yaml")
 
+	// The anchor file is a marker, not application content. Adding or editing
+	// it on its own must not seed a group, otherwise bulk-onboarding hundreds
+	// of `.argo-compare.yml` files would trigger comparisons with no real
+	// changes.
 	groups, err := DiscoverAnchors("/repo", []string{
 		"charts/foo/.argo-compare.yml",
 	}, fs, anchorFileName)
 	require.NoError(t, err)
+	assert.Empty(t, groups, "a marker-only change must not seed an anchor group")
+}
+
+func TestDiscoverAnchors_AnchorFileChangedAlongsideRealFile(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	writeAnchor(t, fs, "/repo/charts/foo", "apps/foo.yaml")
+
+	// When real content changes alongside the marker, the group still forms
+	// from the real files and the marker is excluded from ChangedFiles.
+	groups, err := DiscoverAnchors("/repo", []string{
+		"charts/foo/.argo-compare.yml",
+		fooValuesYAML,
+	}, fs, anchorFileName)
+	require.NoError(t, err)
 	require.Len(t, groups, 1)
 	assert.Equal(t, "/repo/charts/foo", groups[0].Dir)
-	assert.Equal(t, []string{"charts/foo/.argo-compare.yml"}, groups[0].ChangedFiles)
+	assert.Equal(t, []string{fooValuesYAML}, groups[0].ChangedFiles)
+}
+
+func TestDiscoverAnchors_RepoRootMarkerOnlyChanged(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	writeAnchor(t, fs, "/repo", "apps/root.yaml")
+
+	// The repo root is the structural boundary where findAnchorDir stops
+	// walking. The marker-skip guard must fire even here, so a marker-only
+	// change at the root seeds no group.
+	groups, err := DiscoverAnchors("/repo", []string{
+		".argo-compare.yml",
+	}, fs, anchorFileName)
+	require.NoError(t, err)
+	assert.Empty(t, groups, "a marker-only change at the repo root must not seed a group")
+}
+
+func TestDiscoverAnchors_NestedMarkersOnlyChanged(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	writeAnchor(t, fs, "/repo/charts", "apps/outer.yaml")
+	writeAnchor(t, fs, "/repo/charts/foo", "apps/foo.yaml")
+
+	// Both the outer and inner markers changed with no real content. Neither
+	// may seed a group, regardless of the nearest-anchor walk.
+	groups, err := DiscoverAnchors("/repo", []string{
+		"charts/.argo-compare.yml",
+		"charts/foo/.argo-compare.yml",
+	}, fs, anchorFileName)
+	require.NoError(t, err)
+	assert.Empty(t, groups, "marker-only changes in a nested layout must not seed groups")
+}
+
+func TestDiscoverAnchors_MultipleAnchorsOneMarkerOnly(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	writeAnchor(t, fs, "/repo/charts/foo", "apps/foo.yaml")
+	writeAnchor(t, fs, "/repo/charts/bar", "apps/bar.yaml")
+
+	// foo's marker changed on its own (skipped); bar has real content. Only
+	// bar forms a group — skipping the marker must not suppress unrelated ones.
+	groups, err := DiscoverAnchors("/repo", []string{
+		"charts/foo/.argo-compare.yml",
+		"charts/bar/values.yaml",
+	}, fs, anchorFileName)
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+	assert.Equal(t, "/repo/charts/bar", groups[0].Dir)
+	assert.Equal(t, []string{"charts/bar/values.yaml"}, groups[0].ChangedFiles)
 }
 
 func TestDiscoverAnchors_RepoRootAnchor(t *testing.T) {


### PR DESCRIPTION
DiscoverAnchors treated a changed .argo-compare.yml as a triggering change, so adding the marker during onboarding (no real chart changes) seeded an anchor group and ran a needless comparison. Bulk-onboarding hundreds of anchors turned this into widespread noise.

The anchor file is a marker, not application content. Skip changed files whose basename matches the anchor file's basename: a marker-only change seeds no group, while a marker changed alongside real content still forms a group from the real files, with the marker excluded.

Update the anchored-repositories and example docs accordingly.