### PR TITLE
fix(helm): keep registry credentials out of helm argv

### DIFF
--- a/cmd/argo-compare/utils/cmdrunner.go
+++ b/cmd/argo-compare/utils/cmdrunner.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"os/exec"
+	"strings"
 )
 
 // RealCmdRunner executes shell commands using the operating system.
@@ -15,6 +16,25 @@ type RealCmdRunner struct{}
 // The context can be used to cancel the command or set a timeout.
 func (r *RealCmdRunner) Run(ctx context.Context, cmd string, args ...string) (string, string, error) {
 	command := exec.CommandContext(ctx, cmd, args...) // #nosec G204 -- callers validate cmd via validateExecutable before invoking Run
+
+	var stdoutBuffer, stderrBuffer bytes.Buffer
+	command.Stdout = &stdoutBuffer
+	command.Stderr = &stderrBuffer
+
+	err := command.Run()
+
+	return stdoutBuffer.String(), stderrBuffer.String(), err
+}
+
+// RunWithStdin executes cmd with args, feeding stdin to the command, and
+// captures stdout and stderr strings. It exists so secrets (e.g. registry
+// passwords) can be piped to commands instead of being passed as argv
+// elements, which are world-readable via /proc/<pid>/cmdline.
+// The context can be used to cancel the command or set a timeout.
+func (r *RealCmdRunner) RunWithStdin(ctx context.Context, stdin, cmd string, args ...string) (string, string, error) {
+	command := exec.CommandContext(ctx, cmd, args...) // #nosec G204 -- callers validate cmd via validateExecutable before invoking Run
+
+	command.Stdin = strings.NewReader(stdin)
 
 	var stdoutBuffer, stderrBuffer bytes.Buffer
 	command.Stdout = &stdoutBuffer

--- a/cmd/argo-compare/utils/cmdrunner_test.go
+++ b/cmd/argo-compare/utils/cmdrunner_test.go
@@ -18,3 +18,24 @@ func TestRealCmdRunner_Run(t *testing.T) {
 	assert.Equal(t, "hello\n", stdout)
 	assert.Equal(t, "", stderr)
 }
+
+func TestRealCmdRunner_RunWithStdin(t *testing.T) {
+	runner := &RealCmdRunner{}
+
+	stdout, stderr, err := runner.RunWithStdin(context.Background(), "piped-input", "cat")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "piped-input", stdout)
+	assert.Equal(t, "", stderr)
+}
+
+func TestRealCmdRunner_RunWithStdinFailure(t *testing.T) {
+	runner := &RealCmdRunner{}
+
+	stdout, stderr, err := runner.RunWithStdin(context.Background(), "x",
+		"sh", "-c", "cat >/dev/null; echo boom >&2; exit 3")
+
+	assert.Error(t, err)
+	assert.Equal(t, "", stdout)
+	assert.Equal(t, "boom\n", stderr)
+}

--- a/cmd/argo-compare/utils/helm_chart_processor.go
+++ b/cmd/argo-compare/utils/helm_chart_processor.go
@@ -230,8 +230,8 @@ func (g RealHelmChartProcessor) pullOCIChart(ctx context.Context, cmdRunner port
 	err := helpers.WithRetry(ctx, retryCfg, func() error {
 		stdout, stderr, runErr := cmdRunner.Run(ctx, "helm",
 			"pull", pullRef,
-			"--destination", chartLocation,
-			"--version", req.TargetRevision)
+			flagDestination, chartLocation,
+			flagVersion, req.TargetRevision)
 
 		g.logOutput(stdout, stderr)
 		return runErr
@@ -247,6 +247,14 @@ func (g RealHelmChartProcessor) pullOCIChart(ctx context.Context, cmdRunner port
 // pullRepoName is the repository entry name used in the temporary
 // repositories.yaml generated for authenticated HTTP chart pulls.
 const pullRepoName = "argo-compare-repo"
+
+// Helm CLI flag names shared by multiple helm invocations in this file.
+const (
+	flagDestination      = "--destination"
+	flagVersion          = "--version"
+	flagRepositoryConfig = "--repository-config"
+	flagRepositoryCache  = "--repository-cache"
+)
 
 // pullHTTPChart downloads a chart from an HTTP/HTTPS Helm repository.
 //
@@ -291,8 +299,8 @@ func (g RealHelmChartProcessor) pullHTTPChart(ctx context.Context, cmdRunner por
 			"pull",
 			"--repo", req.RepoURL,
 			req.ChartName,
-			"--version", req.TargetRevision,
-			"--destination", chartLocation,
+			flagVersion, req.TargetRevision,
+			flagDestination, chartLocation,
 		)
 
 		g.logOutput(stdout, stderr)
@@ -313,8 +321,8 @@ func (g RealHelmChartProcessor) pullHTTPChart(ctx context.Context, cmdRunner por
 func (g RealHelmChartProcessor) pullThroughRepoConfig(ctx context.Context, cmdRunner ports.CmdRunner, req ports.ChartDownloadRequest, chartLocation, repoCfgPath, repoCachePath string) error {
 	stdout, stderr, err := cmdRunner.Run(ctx, "helm",
 		"repo", "update", pullRepoName,
-		"--repository-config", repoCfgPath,
-		"--repository-cache", repoCachePath,
+		flagRepositoryConfig, repoCfgPath,
+		flagRepositoryCache, repoCachePath,
 	)
 	g.logOutput(stdout, stderr)
 	if err != nil {
@@ -323,10 +331,10 @@ func (g RealHelmChartProcessor) pullThroughRepoConfig(ctx context.Context, cmdRu
 
 	stdout, stderr, err = cmdRunner.Run(ctx, "helm",
 		"pull", fmt.Sprintf("%s/%s", pullRepoName, req.ChartName),
-		"--version", req.TargetRevision,
-		"--destination", chartLocation,
-		"--repository-config", repoCfgPath,
-		"--repository-cache", repoCachePath,
+		flagVersion, req.TargetRevision,
+		flagDestination, chartLocation,
+		flagRepositoryConfig, repoCfgPath,
+		flagRepositoryCache, repoCachePath,
 	)
 	g.logOutput(stdout, stderr)
 	return err
@@ -421,8 +429,8 @@ func (g RealHelmChartProcessor) BuildChartDependencies(ctx context.Context, deps
 
 	stdout, stderr, err := deps.CmdRunner.Run(ctx, "helm",
 		"dependency", "build",
-		"--repository-config", repoCfgPath,
-		"--repository-cache", repoCachePath,
+		flagRepositoryConfig, repoCfgPath,
+		flagRepositoryCache, repoCachePath,
 		chartDir,
 	)
 	g.logOutput(stdout, stderr)

--- a/cmd/argo-compare/utils/helm_chart_processor.go
+++ b/cmd/argo-compare/utils/helm_chart_processor.go
@@ -201,17 +201,20 @@ func resolveCredentials(ctx context.Context, log *logger.Logger, providers []por
 }
 
 // pullOCIChart downloads a chart from an OCI registry.
-// If credentials are available, it first runs "helm registry login" before pulling.
+// If credentials are available, it first runs "helm registry login" before
+// pulling. The password is piped to helm via stdin (--password-stdin) so it
+// never appears in argv, where it would be readable by any local user through
+// /proc/<pid>/cmdline.
 func (g RealHelmChartProcessor) pullOCIChart(ctx context.Context, cmdRunner ports.CmdRunner, req ports.ChartDownloadRequest, creds ports.RegistryCredentials, chartLocation string) error {
 	// Authenticate with the OCI registry if credentials are available.
 	if creds.Username != "" && creds.Password != "" {
 		g.Log.Debugf("Logging into OCI registry [%s]...", ui.Cyan(req.RepoURL))
 
-		stdout, stderr, err := cmdRunner.Run(ctx, "helm",
+		stdout, stderr, err := cmdRunner.RunWithStdin(ctx, creds.Password, "helm",
 			"registry", "login",
 			req.RepoURL,
 			"--username", creds.Username,
-			"--password", creds.Password)
+			"--password-stdin")
 
 		g.logOutput(stdout, stderr)
 
@@ -241,24 +244,56 @@ func (g RealHelmChartProcessor) pullOCIChart(ctx context.Context, cmdRunner port
 	return nil
 }
 
+// pullRepoName is the repository entry name used in the temporary
+// repositories.yaml generated for authenticated HTTP chart pulls.
+const pullRepoName = "argo-compare-repo"
+
 // pullHTTPChart downloads a chart from an HTTP/HTTPS Helm repository.
-// Username and password flags are only appended when credentials are non-empty.
+//
+// Without credentials the chart is pulled directly via --repo. With
+// credentials, `helm pull` offers no --password-stdin equivalent and passing
+// --password in argv would expose the secret to any local user through
+// /proc/<pid>/cmdline. Instead, credentials are written to a temporary
+// repositories.yaml and the chart is pulled through that named repo entry
+// (helm resolves repo-entry credentials only for name-based pulls, not for
+// --repo URLs). `helm repo update` is required first because name-based pulls
+// read the repo index from the local cache.
+//
+// The generated repositories.yaml lives in the OS temp directory with
+// owner-only (0600) permissions and is removed by the deferred cleanup.
 func (g RealHelmChartProcessor) pullHTTPChart(ctx context.Context, cmdRunner ports.CmdRunner, req ports.ChartDownloadRequest, creds ports.RegistryCredentials, chartLocation string) error {
+	hasCreds := creds.Username != "" && creds.Password != ""
+
+	var repoCfgPath, repoCachePath string
+	if hasCreds {
+		entry := helmRepoEntry{
+			Name:     pullRepoName,
+			URL:      req.RepoURL,
+			Username: creds.Username,
+			Password: creds.Password,
+		}
+		var cleanup func()
+		var err error
+		repoCfgPath, repoCachePath, cleanup, err = writeRepoEntriesConfig("", []helmRepoEntry{entry})
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+	}
+
 	retryCfg := helpers.DefaultRetryConfig()
 	err := helpers.WithRetry(ctx, retryCfg, func() error {
-		args := []string{
+		if hasCreds {
+			return g.pullThroughRepoConfig(ctx, cmdRunner, req, chartLocation, repoCfgPath, repoCachePath)
+		}
+
+		stdout, stderr, runErr := cmdRunner.Run(ctx, "helm",
 			"pull",
 			"--repo", req.RepoURL,
 			req.ChartName,
 			"--version", req.TargetRevision,
 			"--destination", chartLocation,
-		}
-
-		if creds.Username != "" && creds.Password != "" {
-			args = append(args, "--username", creds.Username, "--password", creds.Password)
-		}
-
-		stdout, stderr, runErr := cmdRunner.Run(ctx, "helm", args...)
+		)
 
 		g.logOutput(stdout, stderr)
 		return runErr
@@ -269,6 +304,32 @@ func (g RealHelmChartProcessor) pullHTTPChart(ctx context.Context, cmdRunner por
 	}
 
 	return nil
+}
+
+// pullThroughRepoConfig refreshes the index cache for the temporary repo entry
+// and pulls the requested chart through it. Both helm invocations reference the
+// isolated repository config and cache so the host helm configuration is never
+// touched and credentials stay inside the generated repositories.yaml.
+func (g RealHelmChartProcessor) pullThroughRepoConfig(ctx context.Context, cmdRunner ports.CmdRunner, req ports.ChartDownloadRequest, chartLocation, repoCfgPath, repoCachePath string) error {
+	stdout, stderr, err := cmdRunner.Run(ctx, "helm",
+		"repo", "update", pullRepoName,
+		"--repository-config", repoCfgPath,
+		"--repository-cache", repoCachePath,
+	)
+	g.logOutput(stdout, stderr)
+	if err != nil {
+		return fmt.Errorf("update repo index for %q: %w", req.RepoURL, err)
+	}
+
+	stdout, stderr, err = cmdRunner.Run(ctx, "helm",
+		"pull", fmt.Sprintf("%s/%s", pullRepoName, req.ChartName),
+		"--version", req.TargetRevision,
+		"--destination", chartLocation,
+		"--repository-config", repoCfgPath,
+		"--repository-cache", repoCachePath,
+	)
+	g.logOutput(stdout, stderr)
+	return err
 }
 
 // logOutput logs stdout and stderr from command execution if non-empty.
@@ -435,6 +496,18 @@ func (g RealHelmChartProcessor) writeRepoConfig(ctx context.Context, helmDeps po
 		entryCount++
 	}
 
+	return writeRepoEntriesConfig(scratchDir, entries)
+}
+
+// writeRepoEntriesConfig writes the given repository entries to a fresh
+// repositories.yaml under scratchDir (the OS default temp directory when
+// empty) and creates a matching repository-cache directory. The file is
+// created by os.CreateTemp with owner-only (0600) permissions, which is the
+// access control for the credentials it may contain. It returns the config
+// file path, the cache directory path, and a cleanup func that removes both.
+// The caller MUST invoke cleanup once the helm invocation that consumes the
+// config returns.
+func writeRepoEntriesConfig(scratchDir string, entries []helmRepoEntry) (string, string, func(), error) {
 	repoCfgFile, err := os.CreateTemp(scratchDir, "argo-compare-helm-repos-*.yaml")
 	if err != nil {
 		return "", "", noopCleanup, fmt.Errorf("create repositories.yaml tempfile: %w", err)

--- a/cmd/argo-compare/utils/helm_chart_processor_test.go
+++ b/cmd/argo-compare/utils/helm_chart_processor_test.go
@@ -94,14 +94,34 @@ func TestDownloadHelmChart_HTTPWithCredentials(t *testing.T) {
 	}
 
 	mockGlobber.EXPECT().Glob(gomock.Any()).Return([]string{}, nil)
+
+	// Credentials must never appear in argv (visible via /proc/<pid>/cmdline);
+	// they are written to a temporary repositories.yaml instead, and the chart
+	// is pulled through the named repo entry.
+	updateCall := mockCmdRunner.EXPECT().Run(gomock.Any(), "helm",
+		"repo", "update", pullRepoName,
+		"--repository-config", gomock.Any(),
+		"--repository-cache", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, args ...string) (string, string, error) {
+			cfg, err := os.ReadFile(args[4])
+			assert.NoError(t, err)
+			assert.Contains(t, string(cfg), "username: user")
+			assert.Contains(t, string(cfg), "password: pass")
+			assert.Contains(t, string(cfg), "url: https://chart.example.com")
+			return "", "", nil
+		})
 	mockCmdRunner.EXPECT().Run(gomock.Any(), "helm",
-		"pull",
-		"--repo", "https://chart.example.com",
-		"ingress-nginx",
+		"pull", pullRepoName+"/ingress-nginx",
 		"--version", "3.34.0",
 		"--destination", gomock.Any(),
-		"--username", "user",
-		"--password", "pass").Return("", "", nil)
+		"--repository-config", gomock.Any(),
+		"--repository-cache", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, args ...string) (string, string, error) {
+			for _, a := range args {
+				assert.NotContains(t, a, "pass", "credentials must not leak into helm pull argv")
+			}
+			return "", "", nil
+		}).After(updateCall)
 
 	req := ports.ChartDownloadRequest{
 		CacheDir:       filepath.Join(cacheDir, "cache"),
@@ -141,6 +161,81 @@ func TestDownloadHelmChart_HTTPWithoutCredentials(t *testing.T) {
 	}
 	err := helmChartProcessor.DownloadHelmChart(context.Background(), deps, req)
 	assert.NoError(t, err)
+}
+
+func TestDownloadHelmChart_HTTPRepoUpdateFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	helmChartProcessor := RealHelmChartProcessor{Log: logger.New("test")}
+	cacheDir := t.TempDir()
+
+	mockGlobber := mocks.NewMockGlobber(ctrl)
+	mockCmdRunner := mocks.NewMockCmdRunner(ctrl)
+
+	staticProvider := NewStaticCredentialProvider([]models.RepoCredentials{
+		{Url: "https://chart.example.com", Username: "user", Password: "pass"},
+	})
+	deps := ports.HelmDeps{
+		CmdRunner:           mockCmdRunner,
+		Globber:             mockGlobber,
+		CredentialProviders: []ports.CredentialProvider{staticProvider},
+	}
+
+	mockGlobber.EXPECT().Glob(gomock.Any()).Return([]string{}, nil)
+	// helm repo update fails on every retry attempt; helm pull must never run
+	// (no expectation is registered for it, so an invocation would fail the test).
+	mockCmdRunner.EXPECT().Run(gomock.Any(), "helm",
+		"repo", "update", pullRepoName,
+		"--repository-config", gomock.Any(),
+		"--repository-cache", gomock.Any()).
+		Return("", "index fetch failed", errors.New("index fetch failed")).Times(3)
+
+	req := ports.ChartDownloadRequest{
+		CacheDir:       filepath.Join(cacheDir, "cache"),
+		RepoURL:        "https://chart.example.com",
+		ChartName:      "ingress-nginx",
+		TargetRevision: "3.34.0",
+	}
+	err := helmChartProcessor.DownloadHelmChart(context.Background(), deps, req)
+	assert.ErrorIs(t, err, ErrFailedToDownloadChart)
+	assert.Contains(t, err.Error(), "update repo index for")
+}
+
+func TestWriteRepoEntriesConfig(t *testing.T) {
+	entry := helmRepoEntry{
+		Name:     "test-repo",
+		URL:      "https://chart.example.com",
+		Username: "user",
+		Password: "pass",
+	}
+
+	cfgPath, cachePath, cleanup, err := writeRepoEntriesConfig("", []helmRepoEntry{entry})
+	assert.NoError(t, err)
+
+	// The config file's owner-only permissions are the access control for the
+	// credentials it carries; anything broader is a regression.
+	info, err := os.Stat(cfgPath)
+	assert.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+
+	content, err := os.ReadFile(cfgPath)
+	assert.NoError(t, err)
+	assert.Contains(t, string(content), "apiVersion: v1")
+	assert.Contains(t, string(content), "name: test-repo")
+	assert.Contains(t, string(content), "url: https://chart.example.com")
+	assert.Contains(t, string(content), "username: user")
+	assert.Contains(t, string(content), "password: pass")
+
+	cacheInfo, err := os.Stat(cachePath)
+	assert.NoError(t, err)
+	assert.True(t, cacheInfo.IsDir())
+
+	cleanup()
+	_, err = os.Stat(cfgPath)
+	assert.True(t, os.IsNotExist(err), "cleanup must remove the credentials file")
+	_, err = os.Stat(cachePath)
+	assert.True(t, os.IsNotExist(err), "cleanup must remove the cache directory")
 }
 
 func TestDownloadHelmChart_HTTPFailedDownload(t *testing.T) {
@@ -194,12 +289,13 @@ func TestDownloadHelmChart_OCIWithCredentials(t *testing.T) {
 
 	mockGlobber.EXPECT().Glob(gomock.Any()).Return([]string{}, nil)
 
-	// Expect helm registry login first.
-	mockCmdRunner.EXPECT().Run(gomock.Any(), "helm",
+	// Expect helm registry login first, with the password piped via stdin so it
+	// never appears in argv (visible via /proc/<pid>/cmdline).
+	mockCmdRunner.EXPECT().RunWithStdin(gomock.Any(), "ecr-token", "helm",
 		"registry", "login",
 		"123456789012.dkr.ecr.us-east-1.amazonaws.com",
 		"--username", "AWS",
-		"--password", "ecr-token").Return("", "", nil)
+		"--password-stdin").Return("", "", nil)
 
 	// Then expect helm pull without --repo, --username, --password.
 	mockCmdRunner.EXPECT().Run(gomock.Any(), "helm",
@@ -1024,11 +1120,11 @@ func TestDownloadHelmChart_OCILoginFailure(t *testing.T) {
 	mockGlobber.EXPECT().Glob(gomock.Any()).Return([]string{}, nil)
 
 	// helm registry login fails.
-	mockCmdRunner.EXPECT().Run(gomock.Any(), "helm",
+	mockCmdRunner.EXPECT().RunWithStdin(gomock.Any(), "ecr-token", "helm",
 		"registry", "login",
 		"123456789012.dkr.ecr.us-east-1.amazonaws.com",
 		"--username", "AWS",
-		"--password", "ecr-token").Return("", "login failed", errors.New("login error"))
+		"--password-stdin").Return("", "login failed", errors.New("login error"))
 
 	// helm pull should NOT be called.
 

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -14,6 +14,10 @@ import (
 // The context can be used for cancellation and timeout control.
 type CmdRunner interface {
 	Run(ctx context.Context, cmd string, args ...string) (stdout string, stderr string, err error)
+	// RunWithStdin behaves like Run but feeds stdin to the command. It exists so
+	// secrets (e.g. registry passwords) can be piped to commands instead of being
+	// passed as argv elements, which are world-readable via /proc/<pid>/cmdline.
+	RunWithStdin(ctx context.Context, stdin, cmd string, args ...string) (stdout string, stderr string, err error)
 }
 
 // OsFs abstracts temporary file creation and removal.

--- a/internal/ports/portstest/portstest.go
+++ b/internal/ports/portstest/portstest.go
@@ -21,6 +21,11 @@ func (NoopCmdRunner) Run(_ context.Context, _ string, _ ...string) (string, stri
 	return "", "", nil
 }
 
+// RunWithStdin returns ("", "", nil) regardless of arguments.
+func (NoopCmdRunner) RunWithStdin(_ context.Context, _, _ string, _ ...string) (string, string, error) {
+	return "", "", nil
+}
+
 // NoopFileReader satisfies ports.FileReader by returning (nil, nil), which the
 // port contract treats as "file absent" (see ports.FileReader docstring).
 type NoopFileReader struct{}


### PR DESCRIPTION
Passwords passed as --password flags were readable by any local user via /proc/<pid>/cmdline while helm ran. OCI registry login now pipes the password through stdin (--password-stdin) via a new CmdRunner.RunWithStdin method. Authenticated HTTP pulls, which have no stdin option, write credentials to a temporary repositories.yaml (0600, removed by deferred cleanup) and pull through a named repo entry, since helm resolves repo-entry credentials only for name-based pulls and those require a prior `helm repo update`.