### PR TITLE
fix(app): skip Helm chart templates in Application discovery

### DIFF
--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,6 +1,6 @@
 # How it works
 
-1. `argo-compare` checks which Application files the source branch has modified since it diverged from the target branch (the merge-base is the baseline, so commits made only on the target branch after divergence are ignored).
+1. `argo-compare` checks which Application files the source branch has modified since it diverged from the target branch (the merge-base is the baseline, so commits made only on the target branch after divergence are ignored). Files under a Helm chart's `templates/` directory (any directory containing `Chart.yaml`) are recognized as chart templates and skipped from this Application discovery — their `{{ }}` syntax is not valid YAML, so they are never parsed as manifests. This matters when charts live alongside cluster config in the same repo.
 2. It fetches the content of the changed Application files from the target branch.
 3. For path-based sources, if `Chart.yaml` declares subchart dependencies, `helm dependency build` runs to populate `charts/` before rendering.
 4. It renders manifests using `helm template` against both source and target branch values, applying `spec.source.helm.parameters` and any `.argocd-source[-<appName>].yaml` override files committed next to the chart (the files argo-watcher / Argo CD Image Updater write for image tag bumps).

--- a/internal/app/git.go
+++ b/internal/app/git.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/shini4i/argo-compare/cmd/argo-compare/utils/logger"
 
@@ -136,15 +137,19 @@ func (g *GitRepo) GetChangedFiles(targetBranch string, filesToIgnore []string, a
 
 	g.printChangeFile(foundFiles, removedFiles)
 
-	applications, invalid := g.sortChangedFiles(foundFiles)
+	repoRoot, err := GetGitRepoRoot()
+	if err != nil {
+		return ChangedFilesResult{}, fmt.Errorf("resolve repo root: %w", err)
+	}
+
+	applications, invalid, err := g.sortChangedFiles(foundFiles, repoRoot)
+	if err != nil {
+		return ChangedFilesResult{}, err
+	}
 	filtered := filterIgnored(applications, filesToIgnore)
 
 	var anchorGroups []AnchorGroup
 	if anchorFileName != "" {
-		repoRoot, rootErr := GetGitRepoRoot()
-		if rootErr != nil {
-			return ChangedFilesResult{}, fmt.Errorf("resolve repo root for anchor discovery: %w", rootErr)
-		}
 		anchorChanged := filterIgnored(foundFiles, filesToIgnore)
 		anchorGroups, err = DiscoverAnchors(repoRoot, anchorChanged, g.fs, anchorFileName)
 		if err != nil {
@@ -339,10 +344,23 @@ func (g *GitRepo) printChangeFile(addedFiles, removed []string) {
 	}
 }
 
-// sortChangedFiles filters diff results to include only valid Application manifests.
-func (g *GitRepo) sortChangedFiles(files []string) (applications []string, invalid []string) {
+// sortChangedFiles filters diff results to include only valid Application
+// manifests. Helm chart templates are excluded up front: a file under a
+// chart's `templates/` directory is a template by Helm's own definition, and
+// its `{{ }}` actions are not valid YAML — parsing it as an Application would
+// misreport it as an invalid manifest and fail the run (issue #153).
+func (g *GitRepo) sortChangedFiles(files []string, repoRoot string) (applications []string, invalid []string, err error) {
 	for _, file := range files {
 		if filepath.Ext(file) != ".yaml" {
+			continue
+		}
+
+		isTemplate, tmplErr := isHelmTemplate(g.fs, repoRoot, file)
+		if tmplErr != nil {
+			return nil, nil, fmt.Errorf("check whether %q is a Helm template: %w", file, tmplErr)
+		}
+		if isTemplate {
+			g.log.Debugf("Skipping Helm chart template [%s]", file)
 			continue
 		}
 
@@ -368,7 +386,35 @@ func (g *GitRepo) sortChangedFiles(files []string) (applications []string, inval
 		}
 	}
 
-	return applications, invalid
+	return applications, invalid, nil
+}
+
+// isHelmTemplate reports whether relFile is a Helm chart template — a file that
+// lives under a chart's `templates/` directory, where a chart is any directory
+// containing Chart.yaml. This mirrors Helm's own definition: everything under
+// `templates/` is handed to the rendering engine, and detection is purely by
+// location, never by content. Such files are never standalone ArgoCD
+// Application manifests, so callers exclude them from Application discovery
+// rather than parsing their (invalid-as-YAML) templating syntax.
+//
+// relFile is a repo-relative, slash-separated path as emitted by the Git diff;
+// repoRoot anchors the Chart.yaml lookup to the local worktree.
+func isHelmTemplate(fs afero.Fs, repoRoot, relFile string) (bool, error) {
+	parts := strings.Split(filepath.ToSlash(filepath.Dir(relFile)), "/")
+	for i, part := range parts {
+		if part != "templates" {
+			continue
+		}
+		chartRoot := filepath.Join(append([]string{repoRoot}, parts[:i]...)...)
+		exists, err := afero.Exists(fs, filepath.Join(chartRoot, "Chart.yaml"))
+		if err != nil {
+			return false, fmt.Errorf("check Chart.yaml at %q: %w", chartRoot, err)
+		}
+		if exists {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // checkIfApp determines whether the provided path points to a valid Application manifest.

--- a/internal/app/git_test.go
+++ b/internal/app/git_test.go
@@ -468,6 +468,196 @@ func TestGitRepoGetChangedFilesNoAnchorDiscoveryWhenDisabled(t *testing.T) {
 	require.Empty(t, result.AnchorGroups, "anchor discovery must be skipped when anchorFileName is empty")
 }
 
+// TestIsHelmTemplate verifies Helm's own definition of a template: a file
+// living under a chart's `templates/` directory, where a chart is any
+// directory containing Chart.yaml. Detection is purely by location — matching
+// how Helm decides what to render — never by content.
+func TestIsHelmTemplate(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	repoRoot := "/repo"
+	// A chart nested under cluster config.
+	require.NoError(t, afero.WriteFile(fs, "/repo/charts/foo/Chart.yaml", []byte("name: foo\n"), 0o644))
+	// A chart at the repository root.
+	require.NoError(t, afero.WriteFile(fs, "/repo/Chart.yaml", []byte("name: root\n"), 0o644))
+	// A stray templates/ directory with no Chart.yaml alongside it.
+	require.NoError(t, afero.WriteFile(fs, "/repo/config/templates/marker", []byte(""), 0o644))
+	// A subchart: only the leaf directory carries a Chart.yaml.
+	require.NoError(t, afero.WriteFile(fs, "/repo/charts/foo/charts/bar/Chart.yaml", []byte("name: bar\n"), 0o644))
+	// A genuine chart living below an unrelated outer `templates/` directory.
+	require.NoError(t, afero.WriteFile(fs, "/repo/config/templates/charts/baz/Chart.yaml", []byte("name: baz\n"), 0o644))
+
+	cases := []struct {
+		name string
+		file string
+		want bool
+	}{
+		{"template under nested chart", "charts/foo/templates/deployment.yaml", true},
+		{"template in nested subdir", "charts/foo/templates/rbac/role.yaml", true},
+		{"template under root chart", "templates/deployment.yaml", true},
+		{"chart values are not a template", "charts/foo/values.yaml", false},
+		{"Chart.yaml itself is not a template", "charts/foo/Chart.yaml", false},
+		{"application manifest is not a template", "apps/demo.yaml", false},
+		{"templates dir without a chart", "config/templates/service.yaml", false},
+		// Multi-segment paths: the loop must keep scanning past a `templates`
+		// segment whose parent has no Chart.yaml to reach the real chart.
+		{"subchart template", "charts/foo/charts/bar/templates/role.yaml", true},
+		{"chart below an unrelated outer templates dir", "config/templates/charts/baz/templates/x.yaml", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := isHelmTemplate(fs, repoRoot, tc.file)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestGitRepoGetChangedFilesSkipsHelmTemplates covers issue #153: a Helm chart
+// stored alongside cluster config. When a chart template changes, its `{{ }}`
+// actions are not valid YAML, so the tool previously flagged it as an invalid
+// manifest and failed the job. The template must instead be skipped, while a
+// genuinely malformed manifest outside `templates/` still lands in Invalid.
+func TestGitRepoGetChangedFilesSkipsHelmTemplates(t *testing.T) {
+	tempDir := t.TempDir()
+	workDir := filepath.Join(tempDir, "repo")
+	require.NoError(t, os.MkdirAll(workDir, 0o755))
+
+	repo, err := git.PlainInit(workDir, false)
+	require.NoError(t, err)
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.NewBranchReferenceName("main"))))
+
+	chartDir := filepath.Join(workDir, "charts", "foo")
+	require.NoError(t, os.MkdirAll(chartDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(chartDir, "Chart.yaml"), []byte("apiVersion: v2\nname: foo\nversion: 0.0.1\n"), 0o644))
+
+	worktree, err := repo.Worktree()
+	require.NoError(t, err)
+	_, err = worktree.Add("charts/foo/Chart.yaml")
+	require.NoError(t, err)
+	commitHash, err := worktree.Commit("initial", &git.CommitOptions{Author: defaultSignature()})
+	require.NoError(t, err)
+
+	remotePath := filepath.Join(tempDir, "origin.git")
+	_, err = git.PlainInit(remotePath, true)
+	require.NoError(t, err)
+	_, err = repo.CreateRemote(&config.RemoteConfig{Name: "origin", URLs: []string{remotePath}})
+	require.NoError(t, err)
+	require.NoError(t, repo.Push(&git.PushOptions{RemoteName: "origin", RefSpecs: []config.RefSpec{"refs/heads/main:refs/heads/main"}}))
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName("refs/remotes/origin/main"), commitHash)))
+
+	require.NoError(t, worktree.Checkout(&git.CheckoutOptions{Branch: plumbing.NewBranchReferenceName("feature"), Create: true}))
+
+	// A Helm template whose `{{ }}` actions are not valid YAML.
+	templatesDir := filepath.Join(chartDir, "templates")
+	require.NoError(t, os.MkdirAll(templatesDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(templatesDir, "deployment.yaml"),
+		[]byte("apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: {{ .Values.name }}\n"), 0o644))
+	// A syntactically valid Application manifest that happens to live under
+	// templates/ (an app-of-apps template). Detection is by location, not
+	// content, so it must be skipped despite parsing cleanly as an Application.
+	require.NoError(t, os.WriteFile(filepath.Join(templatesDir, "app-of-apps.yaml"),
+		[]byte("apiVersion: argoproj.io/v1alpha1\nkind: Application\nmetadata:\n  name: child\n  namespace: argocd\nspec:\n  destination:\n    server: https://kubernetes.default.svc\n    namespace: demo\n  source:\n    repoURL: fake.repo/charts\n    chart: child\n    targetRevision: 1.0.0\n"), 0o644))
+	// A genuinely malformed manifest that is NOT a chart template.
+	appsDir := filepath.Join(workDir, "apps")
+	require.NoError(t, os.MkdirAll(appsDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(appsDir, "broken.yaml"),
+		[]byte("apiVersion: argoproj.io/v1alpha1\nkind: Application\nmetadata:\n  name: broken\n   bad: indent\n"), 0o644))
+
+	_, err = worktree.Add("charts/foo/templates/deployment.yaml")
+	require.NoError(t, err)
+	_, err = worktree.Add("charts/foo/templates/app-of-apps.yaml")
+	require.NoError(t, err)
+	_, err = worktree.Add("apps/broken.yaml")
+	require.NoError(t, err)
+	_, err = worktree.Commit("add template and broken manifest", &git.CommitOptions{Author: defaultSignature()})
+	require.NoError(t, err)
+
+	originalWD, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(workDir))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(originalWD))
+	})
+
+	log := logger.New("git-test-helm-template")
+	repoInstance, err := NewGitRepo(afero.NewOsFs(), portstest.NoopCmdRunner{}, utils.OsFileReader{}, log)
+	require.NoError(t, err)
+
+	result, err := repoInstance.GetChangedFiles("main", nil, "")
+	require.NoError(t, err)
+
+	require.Empty(t, result.Applications)
+	require.Equal(t, []string{"apps/broken.yaml"}, result.Invalid,
+		"the chart template must be skipped; only the non-template malformed manifest is invalid")
+}
+
+// TestGitRepoGetChangedFilesSkipsHelmTemplatesUnderAnchor proves the two code
+// paths stay independent: when an anchored chart's template changes, the
+// template is skipped from Application discovery (never flagged Invalid) while
+// anchor discovery still groups the change for the anchor flow to render.
+func TestGitRepoGetChangedFilesSkipsHelmTemplatesUnderAnchor(t *testing.T) {
+	tempDir := t.TempDir()
+	workDir := filepath.Join(tempDir, "repo")
+	require.NoError(t, os.MkdirAll(workDir, 0o755))
+
+	repo, err := git.PlainInit(workDir, false)
+	require.NoError(t, err)
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.NewBranchReferenceName("main"))))
+
+	chartDir := filepath.Join(workDir, "charts", "foo")
+	require.NoError(t, os.MkdirAll(chartDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(chartDir, ".argo-compare.yml"), []byte("application:\n  path: apps/foo.yaml\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(chartDir, "Chart.yaml"), []byte("apiVersion: v2\nname: foo\nversion: 0.0.1\n"), 0o644))
+	templatesDir := filepath.Join(chartDir, "templates")
+	require.NoError(t, os.MkdirAll(templatesDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(templatesDir, "deployment.yaml"),
+		[]byte("apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: foo\n"), 0o644))
+
+	worktree, err := repo.Worktree()
+	require.NoError(t, err)
+	_, err = worktree.Add("charts/foo")
+	require.NoError(t, err)
+	commitHash, err := worktree.Commit("initial", &git.CommitOptions{Author: defaultSignature()})
+	require.NoError(t, err)
+
+	remotePath := filepath.Join(tempDir, "origin.git")
+	_, err = git.PlainInit(remotePath, true)
+	require.NoError(t, err)
+	_, err = repo.CreateRemote(&config.RemoteConfig{Name: "origin", URLs: []string{remotePath}})
+	require.NoError(t, err)
+	require.NoError(t, repo.Push(&git.PushOptions{RemoteName: "origin", RefSpecs: []config.RefSpec{"refs/heads/main:refs/heads/main"}}))
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName("refs/remotes/origin/main"), commitHash)))
+
+	require.NoError(t, worktree.Checkout(&git.CheckoutOptions{Branch: plumbing.NewBranchReferenceName("feature"), Create: true}))
+	// Change the template so its `{{ }}` syntax makes it invalid YAML.
+	require.NoError(t, os.WriteFile(filepath.Join(templatesDir, "deployment.yaml"),
+		[]byte("apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: {{ .Values.name }}\n"), 0o644))
+	_, err = worktree.Add("charts/foo/templates/deployment.yaml")
+	require.NoError(t, err)
+	_, err = worktree.Commit("edit template", &git.CommitOptions{Author: defaultSignature()})
+	require.NoError(t, err)
+
+	originalWD, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(workDir))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(originalWD))
+	})
+
+	log := logger.New("git-test-helm-template-anchor")
+	repoInstance, err := NewGitRepo(afero.NewOsFs(), portstest.NoopCmdRunner{}, utils.OsFileReader{}, log)
+	require.NoError(t, err)
+
+	result, err := repoInstance.GetChangedFiles("main", nil, ".argo-compare.yml")
+	require.NoError(t, err)
+
+	require.Empty(t, result.Applications)
+	require.Empty(t, result.Invalid, "the anchored chart template must be skipped, not flagged invalid")
+	require.Len(t, result.AnchorGroups, 1, "the template change must still seed the anchor flow")
+	require.Equal(t, []string{"charts/foo/templates/deployment.yaml"}, result.AnchorGroups[0].ChangedFiles)
+}
+
 func writeExtraApplication(t *testing.T, repoDir, name, version string, replicas int) {
 	t.Helper()
 	content := []byte(`apiVersion: argoproj.io/v1alpha1


### PR DESCRIPTION
Files under a chart's templates/ directory (any ancestor dir containing Chart.yaml) are Helm templates by Helm's own location-based definition; their {{ }} syntax is not valid YAML. sortChangedFiles parsed every changed .yaml as an ArgoCD Application, so a changed template landed in the invalid list and failed the compare job when charts live alongside cluster config in the same repo.

Exclude such files from Application discovery. Anchor discovery is unchanged, so anchored charts still render.

Closes #153