### PR TITLE
fix(app): treat newly added anchored chart as new Application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+
+- Anchored (path-based) Applications whose chart directory is added for the first time on the current branch no longer fail with `directory not found`. The chart is now treated as a new Application — the comparison is skipped by default, or rendered as all-added with `--print-added-manifests`.
+- Helm chart templates (files under a chart's `templates/` directory) are no longer misparsed as ArgoCD Applications, which previously failed the compare job when charts live alongside cluster config in the same repository.
+
+### Security
+
+- Registry credentials are no longer passed to Helm as command-line arguments, keeping them out of the process argument list where they could be observed by other users on the same host.
+
+[Unreleased]: https://github.com/shini4i/argo-compare/compare/v0.9.1...HEAD

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ A comparison tool for displaying the differences between applications in differe
 ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/shini4i/argo-compare)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/shini4i/argo-compare)
 [![codecov](https://codecov.io/gh/shini4i/argo-compare/branch/main/graph/badge.svg?token=48E1OZHLPY)](https://codecov.io/gh/shini4i/argo-compare)
-[![Go Report Card](https://goreportcard.com/badge/github.com/shini4i/argo-compare)](https://goreportcard.com/report/github.com/shini4i/argo-compare)
 ![GitHub](https://img.shields.io/github/license/shini4i/argo-compare)
 
 <img src="https://raw.githubusercontent.com/shini4i/assets/main/src/argo-compare/demo.png" alt="Showcase" height="441" width="620">

--- a/docs/anchored-repositories.md
+++ b/docs/anchored-repositories.md
@@ -37,7 +37,8 @@ A worked example lives under [`examples/anchor/`](../examples/anchor).
 - For path-based Applications, `spec.source.repoURL` must identify the local repository — chart sources living in a _third_ repo are out of scope.
 - A multi-source Application must use one kind consistently; mixing `chart` and `path` entries is rejected.
 - The anchored Application is read at the configured branch tip; commit-pinning is not supported.
-- Any failure to fetch, parse, or validate an anchored Application is a hard error — partial output would silently hide a broken configuration.
+- If the anchored chart directory does not exist in the target branch (it was added for the first time on the current branch), the Application is treated as new rather than failing: the comparison is skipped, or with `--print-added-manifests` the current branch's manifests render as all-added. This mirrors the standard flow's handling of a newly added Application file.
+- Any other failure to fetch, parse, or validate an anchored Application is a hard error — partial output would silently hide a broken configuration.
 
 ## Configuration
 

--- a/internal/app/anchor_flow.go
+++ b/internal/app/anchor_flow.go
@@ -94,11 +94,12 @@ func (a *App) processAnchorGroup(ctx context.Context, repo *GitRepo, group Ancho
 
 	validationResults := make(map[string]ports.ValidationResult)
 
-	if err = a.renderAnchorLeg(ctx, app, tmpDir, TargetTypeSource, repo, repoRoot, validationResults); err != nil {
+	proceed, err := a.renderAnchorLegs(ctx, app, group, tmpDir, repo, repoRoot, validationResults)
+	if err != nil {
 		return false, err
 	}
-	if err = a.renderAnchorLeg(ctx, app, tmpDir, TargetTypeDestination, repo, repoRoot, validationResults); err != nil {
-		return false, err
+	if !proceed {
+		return false, nil
 	}
 
 	if err = a.runComparison(ctx, tmpDir, group.Anchor.Application.Path, validationResults); err != nil {
@@ -112,6 +113,32 @@ func (a *App) processAnchorGroup(ctx context.Context, repo *GitRepo, group Ancho
 		}
 	}
 	return validationFailed, nil
+}
+
+// renderAnchorLegs renders the source and then the destination leg for an
+// anchor group. It returns proceed=false when the comparison should be
+// skipped: the anchored chart directory is absent from the merge-base tree
+// (the Application is being added on this branch) and --print-added-manifests
+// is off, so there is no baseline and nothing meaningful to show. With
+// --print-added-manifests the source-only render is kept so the diff surfaces
+// as all-added, mirroring the registry-chart flow's new-Application handling.
+func (a *App) renderAnchorLegs(ctx context.Context, app models.Application, group AnchorGroup, tmpDir string, repo *GitRepo, repoRoot string, validationResults map[string]ports.ValidationResult) (bool, error) {
+	if err := a.renderAnchorLeg(ctx, app, tmpDir, TargetTypeSource, repo, repoRoot, validationResults); err != nil {
+		return false, err
+	}
+
+	destErr := a.renderAnchorLeg(ctx, app, tmpDir, TargetTypeDestination, repo, repoRoot, validationResults)
+	switch {
+	case destErr == nil:
+		return true, nil
+	case errors.Is(destErr, ErrChartPathNotInTree):
+		a.logger.Warning(ui.Yellow(fmt.Sprintf(
+			"The anchored chart for [%s] does not exist in target branch %s, assuming it is a new Application",
+			group.Dir, a.cfg.TargetBranch)))
+		return a.cfg.PrintAddedManifests, nil
+	default:
+		return false, destErr
+	}
 }
 
 // renderAnchorLeg prepares the chart directory for one leg (src or dst) and

--- a/internal/app/anchor_flow_integration_test.go
+++ b/internal/app/anchor_flow_integration_test.go
@@ -165,6 +165,159 @@ spec:
 	return os.WriteFile(filepath.Join(chartDir, ".argo-compare.yml"), []byte("application:\n  path: apps/demo.yaml\n"), 0o644)
 }
 
+// runNewAnchorScenario sets up a same-repo anchor scenario where the anchored
+// chart directory is added for the first time on the feature branch: baseline
+// main carries only the Application manifest (so the manifest is unchanged and
+// never dedups the anchor group), while the merge-base tree lacks charts/demo.
+// The source leg materializes from the working tree fine; the destination leg
+// has no such directory in the merge-base tree. It runs App.Run with the given
+// PrintAddedManifests setting, asserts the run succeeds, and returns the helm
+// stub and captured log output for the caller to assert against.
+func runNewAnchorScenario(t *testing.T, printAdded bool) (*stubHelmProcessor, string) {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	cacheDir := filepath.Join(tempDir, "cache")
+	tmpBase := filepath.Join(tempDir, "tmp")
+	require.NoError(t, os.MkdirAll(tmpBase, 0o755))
+
+	remoteDir := filepath.Join(tempDir, "origin.git")
+	bareRepo, err := git.PlainInit(remoteDir, true)
+	require.NoError(t, err)
+	require.NoError(t, bareRepo.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.NewBranchReferenceName("main"))))
+
+	workDir := filepath.Join(tempDir, "work")
+	repo, err := git.PlainInit(workDir, false)
+	require.NoError(t, err)
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.NewBranchReferenceName("main"))))
+
+	originURL := "file://" + remoteDir
+
+	require.NoError(t, os.MkdirAll(filepath.Join(workDir, "apps"), 0o755))
+	app := `apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: demo
+  namespace: argocd
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: demo
+  source:
+    repoURL: ` + originURL + `
+    path: charts/demo
+    targetRevision: HEAD
+    helm:
+      releaseName: demo
+`
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "apps", "demo.yaml"), []byte(app), 0o644))
+
+	worktree, err := repo.Worktree()
+	require.NoError(t, err)
+	_, err = worktree.Add("apps/demo.yaml")
+	require.NoError(t, err)
+	initialHash, err := worktree.Commit("initial", &git.CommitOptions{Author: defaultSignature()})
+	require.NoError(t, err)
+
+	_, err = repo.CreateRemote(&config.RemoteConfig{Name: "origin", URLs: []string{originURL}})
+	require.NoError(t, err)
+	require.NoError(t, repo.Push(&git.PushOptions{
+		RemoteName: "origin",
+		RefSpecs:   []config.RefSpec{"refs/heads/main:refs/heads/main"},
+	}))
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName("refs/remotes/origin/main"), initialHash)))
+
+	// Feature branch adds the chart directory (and its anchor file) for the
+	// first time.
+	require.NoError(t, worktree.Checkout(&git.CheckoutOptions{
+		Branch: plumbing.NewBranchReferenceName("feature/new-anchor"),
+		Create: true,
+	}))
+	chartDir := filepath.Join(workDir, "charts", "demo")
+	require.NoError(t, os.MkdirAll(filepath.Join(chartDir, "templates"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(chartDir, "Chart.yaml"), []byte("apiVersion: v2\nname: demo\nversion: 0.0.1\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(chartDir, "values.yaml"), []byte("replicaCount: 1\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(chartDir, "templates", "dep.yaml"), []byte("kind: Deployment\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(chartDir, ".argo-compare.yml"), []byte("application:\n  path: apps/demo.yaml\n"), 0o644))
+	_, err = worktree.Add("charts/demo")
+	require.NoError(t, err)
+	_, err = worktree.Commit("add new anchored chart", &git.CommitOptions{Author: defaultSignature()})
+	require.NoError(t, err)
+
+	oldWD, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(workDir))
+	t.Cleanup(func() { require.NoError(t, os.Chdir(oldWD)) })
+
+	var logBuffer bytes.Buffer
+	logger.RedirectForTest(t, &logBuffer)
+	appLogger := logger.New("app-anchor-new-test")
+
+	helmStub := newStubHelmProcessor(t)
+	cfg := Config{
+		TargetBranch:        "main",
+		CacheDir:            cacheDir,
+		TempDirBase:         tmpBase,
+		PrintAddedManifests: printAdded,
+		Version:             "test",
+		AnchorFileName:      DefaultAnchorFileName,
+	}
+	appInstance, err := New(cfg, Dependencies{
+		FS:            afero.NewOsFs(),
+		CmdRunner:     portstest.NoopCmdRunner{},
+		FileReader:    utils.OsFileReader{},
+		HelmProcessor: helmStub,
+		Globber:       utils.CustomGlobber{},
+		Logger:        appLogger,
+	})
+	require.NoError(t, err)
+
+	// A brand-new anchored chart directory (absent from the merge-base tree)
+	// must be treated as a new Application and succeed instead of failing with
+	// go-git's "directory not found".
+	require.NoError(t, appInstance.Run(context.Background()))
+
+	return helmStub, logBuffer.String()
+}
+
+// TestAppRunAnchorFlow_NewApplication_PrintAdded covers a brand-new anchored
+// chart with --print-added-manifests ON: the flow keeps the source-only render
+// and surfaces it through the comparison as all-added.
+func TestAppRunAnchorFlow_NewApplication_PrintAdded(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip integration test in short mode")
+	}
+
+	helmStub, logOutput := runNewAnchorScenario(t, true)
+
+	// Only the source leg renders — the destination is a new Application with
+	// no baseline to materialize.
+	assert.Equal(t, 1, helmStub.callCount("RenderAppSource"), "only the source leg renders for a new anchored app")
+	assert.Contains(t, logOutput, "new Application")
+	// With --print-added-manifests, the comparison runs and the source
+	// manifests surface as added.
+	assert.Contains(t, logOutput, "would be added")
+}
+
+// TestAppRunAnchorFlow_NewApplication_Default covers the default configuration
+// (--print-added-manifests OFF) — the exact scenario from the bug report. The
+// flow must short-circuit before the comparison, log the new-Application
+// warning, and never emit an added-manifests section.
+func TestAppRunAnchorFlow_NewApplication_Default(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip integration test in short mode")
+	}
+
+	helmStub, logOutput := runNewAnchorScenario(t, false)
+
+	// Source leg renders; destination is skipped as a new Application.
+	assert.Equal(t, 1, helmStub.callCount("RenderAppSource"), "only the source leg renders for a new anchored app")
+	assert.Contains(t, logOutput, "new Application")
+	// Without --print-added-manifests the run short-circuits before diffing,
+	// so no added-manifests section is emitted.
+	assert.NotContains(t, logOutput, "would be added")
+}
+
 func TestDedupAnchorGroups(t *testing.T) {
 	groups := []AnchorGroup{
 		{Dir: "/repo/charts/foo", Anchor: dedupAnchor("apps/foo.yaml", "")},

--- a/internal/app/target_path.go
+++ b/internal/app/target_path.go
@@ -23,6 +23,15 @@ import (
 // Application use the same kind, so the renderer can pick a single code path.
 var ErrMixedMultiSource = errors.New("multi-source Application mixes chart-based and path-based sources; mixed sources are not supported")
 
+// ErrChartPathNotInTree is returned by MaterializeChartFromTree when a
+// path-based source's chart directory does not exist in the provided Git tree.
+// This happens when the chart is added for the first time on the current
+// branch: the working tree has it (source leg) but the merge-base tree does
+// not (destination leg). The anchor flow treats this as a newly added
+// Application with no baseline to diff against, mirroring errGitFileDoesNotExist
+// in the registry-chart flow.
+var ErrChartPathNotInTree = errors.New("chart path does not exist in target tree")
+
 // effectiveChartName returns a non-empty chart name suitable for naming the
 // extracted/materialized chart directory and the per-source values file.
 // Registry sources use Source.Chart directly; path-based sources fall back to
@@ -138,10 +147,18 @@ func resolveRepoPath(repoRoot, rel string) (string, error) {
 // path-based source from tree into TmpDir/charts/<TargetType>/<ChartName>.
 // It is the destination-side counterpart of MaterializeChartFromWorkingTree
 // and uses MaterializeTreeDir under the hood for the actual walk.
+//
+// A source whose path is absent from tree yields ErrChartPathNotInTree (wrapped
+// with the offending path) rather than go-git's opaque ErrDirectoryNotFound, so
+// the anchor flow can recognize a newly added chart and treat it as a new
+// Application instead of failing the run.
 func (t *Target) MaterializeChartFromTree(ctx context.Context, fs afero.Fs, tree *object.Tree) error {
 	for _, src := range t.pathSources() {
 		dest := filepath.Join(t.TmpDir, "charts", t.Type, effectiveChartName(src))
 		if err := MaterializeTreeDir(ctx, fs, tree, src.Path, dest); err != nil {
+			if errors.Is(err, object.ErrDirectoryNotFound) {
+				return fmt.Errorf("%w: %s", ErrChartPathNotInTree, src.Path)
+			}
 			return fmt.Errorf("materialize chart %q from tree: %w", src.Path, err)
 		}
 	}

--- a/internal/app/target_path_test.go
+++ b/internal/app/target_path_test.go
@@ -144,6 +144,66 @@ func TestMaterializeChartFromWorkingTree(t *testing.T) {
 	}
 }
 
+func TestMaterializeChartFromTree_MissingPathReturnsSentinel(t *testing.T) {
+	// A newly added anchored chart: the chart directory exists in the working
+	// tree but not in the baseline (merge-base) tree. MaterializeChartFromTree
+	// must surface ErrChartPathNotInTree so the anchor flow can treat it as a
+	// new Application instead of hard-failing with go-git's "directory not
+	// found".
+	tree := commitTreeWith(t, map[string]string{
+		"README.md": "baseline only\n",
+	})
+
+	tmpDir := t.TempDir()
+	tgt := Target{
+		TmpDir: tmpDir,
+		Type:   TargetTypeDestination,
+		Log:    logger.New("target-path-missing-test"),
+		App: models.Application{Spec: struct {
+			Source      *models.Source      `yaml:"source"`
+			Sources     []*models.Source    `yaml:"sources"`
+			MultiSource bool                `yaml:"-"`
+			Destination *models.Destination `yaml:"destination"`
+		}{Source: &models.Source{Path: "charts/foo"}}},
+	}
+
+	err := tgt.MaterializeChartFromTree(context.Background(), afero.NewOsFs(), tree)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrChartPathNotInTree)
+}
+
+func TestMaterializeChartFromTree_MultiSourceMissingNonFirst(t *testing.T) {
+	// Multi-source path-based Application where the FIRST source exists in the
+	// baseline tree but a LATER one is newly added and absent. The sentinel
+	// must still fire (and name the offending path), guarding against a
+	// loop-ordering regression that only checks the first source.
+	tree := commitTreeWith(t, map[string]string{
+		fooChartYAML:  "name: foo\n",
+		fooValuesYAML: "replicaCount: 1\n",
+	})
+
+	tmpDir := t.TempDir()
+	tgt := Target{
+		TmpDir: tmpDir,
+		Type:   TargetTypeDestination,
+		Log:    logger.New("target-path-multi-missing-test"),
+		App: models.Application{Spec: struct {
+			Source      *models.Source      `yaml:"source"`
+			Sources     []*models.Source    `yaml:"sources"`
+			MultiSource bool                `yaml:"-"`
+			Destination *models.Destination `yaml:"destination"`
+		}{
+			Sources:     []*models.Source{{Path: "charts/foo"}, {Path: "charts/bar"}},
+			MultiSource: true,
+		}},
+	}
+
+	err := tgt.MaterializeChartFromTree(context.Background(), afero.NewOsFs(), tree)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrChartPathNotInTree)
+	assert.Contains(t, err.Error(), "charts/bar", "sentinel must name the offending path")
+}
+
 func TestResolveRepoPath(t *testing.T) {
 	repoRoot := "/repo/root"
 	cases := []struct {


### PR DESCRIPTION
  ## Problem

  Running `argo-compare branch <target>` on an anchored (path-based) Application whose chart directory is **added for 
  the first time on the branch** fails the job:

  Error: materialize chart "<path>" from tree: resolve subpath "<path>" in tree: directory not found

  The chart directory exists in the working tree (source leg) but not in the merge-base tree of the target branch
  (destination leg), so the destination-side materialization surfaces go-git's opaque `directory not found` and aborts
  the run.

  ## Root cause

  The registry-chart flow already tolerates a brand-new Application — when the manifest is absent from the target branch
  it logs "assuming it is a new Application" and renders with no baseline. The anchored/path-based flow had no
  equivalent: `MaterializeChartFromTree` propagated `object.ErrDirectoryNotFound` straight up as a terminal error.

  ## Fix

  - Introduce the `ErrChartPathNotInTree` sentinel. `MaterializeChartFromTree` translates go-git's
  `ErrDirectoryNotFound` into it (naming the offending path).
  - The anchor flow treats that sentinel as a newly added Application: the comparison is skipped by default, or the
  source renders as all-added with `--print-added-manifests` — mirroring the standard flow's existing new-Application
  handling.

  Behavior for existing anchored charts is unchanged; any other fetch/parse/validate failure remains a hard error.

  ## Also included

  - New `CHANGELOG.md` (Keep a Changelog) capturing user-facing changes since v0.9.1.
  - Removed the deprecated Go Report Card badge from the README.