### PR TITLE
feat(appset): add the ApplicationSet git directory generator

### DIFF
--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -1,0 +1,79 @@
+# Review context for argo-compare
+
+These are deliberate design contracts, not oversights. Findings that ask for
+them to be reversed have been raised and declined before.
+
+## What the tool compares
+
+`argo-compare` reports **what a pull request proposes**, not the current live
+state. `GetChangedFiles` diffs `merge-base..HEAD`:
+
+- the source leg is the branch's HEAD — the proposed post-merge state
+- the target leg is the merge base — the state before the branch diverged
+- commits made only on the target branch after divergence are excluded on
+  purpose, because they are not what the branch is proposing
+
+Nothing the tool prints is live yet. A reported addition means "this is what
+merging will change", so judging output against the target branch's current tip
+misreads the contract.
+
+This is why an ApplicationSet git generator pinned to the branch being compared
+against (`revision: main` when the PR targets `main`) is accepted. After merge,
+that branch contains the change, so ArgoCD reading it does generate the new
+Application. A revision pinning a tag or an unrelated branch is rejected,
+because merging would not change the tree it resolves to.
+
+## Rendering cost is proportional by design
+
+An ApplicationSet generating N Applications produces N comparisons and 2N Helm
+renders. That is the feature working, not unbounded work:
+
+- ArgoCD really does deploy N Applications for that manifest
+- a cap or budget would emit a diff that looks complete while silently omitting
+  Applications, which is worse than a slow job because nothing in the output
+  reveals the omission
+- the same linear cost already exists for a PR touching N Application files,
+  and there has never been a per-run render budget
+
+Each comparison creates its temporary workspace inside the loop and removes it
+in a deferred call on the same iteration, so temporary storage does not grow
+with the number of generated Applications.
+
+## ApplicationSet scope boundaries
+
+Supported: `goTemplate: true` with the `list` generator and the `git`
+generator's `directories`, for a `repoURL` naming the repository under
+comparison.
+
+Everything else — legacy fasttemplate substitution, other generator kinds, git
+`files`/`values`/`pathParamPrefix`, generator-level `template` overrides — is
+**skipped with the reason named at warning level**. It does not fail the run,
+and other manifests in the same diff are still compared. This is the
+established pattern for anything the tool cannot reproduce faithfully.
+
+The template function map is deliberately identical to ArgoCD's: Sprig minus
+`env`, `expandenv` and `getHostByName`. Matching ArgoCD is what makes the
+rendered diff trustworthy, so do not propose removing further functions.
+Allocation-heavy helpers such as `repeat` stay: `helm template` already runs on
+pull-request-controlled charts with the same helpers available, so removing
+them here would break fidelity without closing anything. Rendered output is
+capped at 1 MiB, which bounds the document every later stage carries.
+
+## The repository scan tolerates what it cannot use
+
+Discovery walks the repository for ApplicationSets with git generators, because
+adding or deleting a directory changes what a generator produces while leaving
+the manifest untouched.
+
+That scan visits every YAML in the repository, so a single unreadable file or
+directory must not fail a run it has nothing to do with. Files that name
+`kind: ApplicationSet` and still cannot be loaded are reported at warning
+level; files that do not name the kind are skipped silently, because they are
+simply not manifests this scan wants.
+
+## Conventions
+
+- New code must not add golangci-lint findings. Pre-existing ones are
+  grandfathered and are not fixed opportunistically.
+- Comment runs are capped at four lines, and comments carry the reasoning the
+  code cannot state itself rather than restating it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- ApplicationSet git directory generator. One Application is generated per directory matching the generator's patterns, with `.path.path`, `.path.segments`, `.path.basename` and `.path.basenameNormalized` available to the template. Adding or deleting a directory is detected on its own: `argo-compare` finds the ApplicationSets whose patterns cover a changed directory, so the manifest itself does not have to be edited. Generators reading another repository are skipped with a warning, as are `files` entries.
 - ApplicationSet support. A changed ApplicationSet manifest is expanded into the Applications it generates on both branches, and each generated Application is compared individually, so an Application the change adds or removes is reported as such (gated by `--print-added-manifests` / `--print-removed-manifests`). Covers manifests using `goTemplate: true` with the `list` generator; every other generator and legacy fasttemplate substitution are skipped with a warning naming the reason. See [ApplicationSets](docs/applicationsets.md).
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ See [Installation](docs/installation.md) and [Usage](docs/usage.md) for the full
 ## Current limitations
 
 - The default change-detection flow looks for Application YAMLs in the diff. Repos that store chart content separately from their Application files should use [Anchored repositories](docs/anchored-repositories.md).
-- ApplicationSet support covers `goTemplate: true` manifests using the `list` generator; see [ApplicationSets](docs/applicationsets.md).
+- ApplicationSet support covers `goTemplate: true` manifests using the `list` generator, and the `git` generator's `directories` for the repository being compared; see [ApplicationSets](docs/applicationsets.md).
 
 ## Roadmap
 
@@ -58,7 +58,8 @@ See [Installation](docs/installation.md) and [Usage](docs/usage.md) for the full
 - [x] Add support for posting diff as a comment to MR (GitLab)
 - [ ] Add support for posting diff as a comment to PR (GitHub)
 - [x] Add manifest validation via kubeconform
-- [ ] Add support for the ApplicationSet git generator
+- [x] Add support for the ApplicationSet git directory generator
+- [ ] Add support for the ApplicationSet git file generator
 
 ## Contributing
 

--- a/docs/applicationsets.md
+++ b/docs/applicationsets.md
@@ -12,9 +12,11 @@ plane is never contacted.
 | `goTemplate: true` templating | supported |
 | Legacy (fasttemplate) templating | not supported — the manifest is skipped |
 | `list` generator | supported |
-| `git`, `matrix`, `merge`, `clusters`, `scmProvider`, `pullRequest`, … | not supported — the manifest is skipped |
+| `git` generator, `directories` | supported for this repository — see below |
+| `git` generator, `files` | not supported yet — the manifest is skipped |
+| `matrix`, `merge`, `clusters`, `scmProvider`, `pullRequest`, … | not supported — the manifest is skipped |
 | `goTemplateOptions` | supported (`missingkey=default\|invalid\|zero\|error`) |
-| Generator-level `template` overrides, `elementsYaml` | not supported — the manifest is skipped |
+| Generator-level `template` overrides, `elementsYaml`, git `values`, `pathParamPrefix` | not supported — the manifest is skipped |
 
 A skipped manifest is reported at warning level with the reason. It never
 fails the run, and plain Application manifests in the same diff are still
@@ -32,6 +34,56 @@ The modern engine is Go `text/template` with a documented parameter shape, so
 that is the one implemented. Add `goTemplate: true` to your ApplicationSet —
 ArgoCD [recommends it](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/GoTemplate/)
 and pairs it with `goTemplateOptions: ["missingkey=error"]`.
+
+## The git directory generator
+
+A git generator builds one Application per directory matching its patterns:
+
+```yaml
+generators:
+  - git:
+      repoURL: https://github.com/you/your-repo.git
+      revision: HEAD
+      directories:
+        - path: clusters/*
+        - path: clusters/donotdeploy
+          exclude: true
+```
+
+Available parameters are `.path.path`, `.path.segments`, `.path.basename` and
+`.path.basenameNormalized`. Exclude entries beat including ones no matter what
+order they appear in, and a directory whose name starts with a dot never
+generates an Application.
+
+**Adding or deleting a directory is what usually changes the output**, and that
+leaves the ApplicationSet manifest untouched. So `argo-compare` also scans the
+repository for ApplicationSets with git generators and compares any whose
+patterns cover a directory your change touched. You do not have to edit the
+manifest to see the diff.
+
+### repoURL must be this repository
+
+A generator reading another repository is skipped with a warning. Both sides of
+the comparison would read the same external tree, so the diff could only ever
+reflect edits to the ApplicationSet itself — never the directory changes the
+generator exists for.
+
+### revision must be HEAD or the compared branch
+
+Your branch and the target branch are the two revisions, so `revision: HEAD`
+(or the name of the branch you are comparing against) needs no further
+interpretation and is not consulted.
+
+A revision pinning anything else — a tag, or an unrelated branch — is skipped
+with a warning. ArgoCD would keep generating from that fixed tree, so a
+directory your branch adds changes nothing it deploys, and reporting a new
+Application would be a false positive.
+
+### pathParamPrefix is not supported
+
+It nests the path parameters under a prefix, so a template written for it would
+render against the wrong shape. Such a manifest is skipped rather than rendered
+incorrectly.
 
 ## Template functions
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -69,11 +69,14 @@ contains:
    directly. Driver code lives in `internal/app/app.go`,
    `application_fetcher.go`, `git.go`, `target.go`, `compare.go`.
 
-2. **ApplicationSet flow** — the PR modifies an ApplicationSet manifest.
-   `internal/appset` expands it into the Applications it generates on both
-   branches, and those are matched by name and compared one pair at a time,
-   so an Application the change adds or drops shows up as such. Driver code
-   lives in `internal/app/appset_flow.go`.
+2. **ApplicationSet flow** — the PR modifies an ApplicationSet manifest, or
+   touches a directory a git generator matches. `internal/appset` expands it
+   into the Applications it generates on both branches, and those are matched
+   by name and compared one pair at a time, so an Application the change adds
+   or drops shows up as such. Driver code lives in
+   `internal/app/appset_flow.go`, with directory listing in `appset_dirs.go`
+   and the repository scan that finds generator-affected manifests in
+   `appset_discovery.go`.
 
 3. **Anchor flow** — the PR modifies chart content (e.g. Helm values)
    rather than an Application YAML. `argo-compare` walks up to the

--- a/internal/app/appset_dirs.go
+++ b/internal/app/appset_dirs.go
@@ -1,0 +1,73 @@
+package app
+
+import (
+	"fmt"
+	"path"
+	"sort"
+
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/shini4i/argo-compare/internal/appset"
+	"github.com/shini4i/argo-compare/internal/models"
+)
+
+// assertGitGeneratorsComparable rejects a git generator whose directories the
+// two branch legs cannot stand in for: one reading another repository, or one
+// pinned to a revision that is neither HEAD nor the branch being compared.
+func assertGitGeneratorsComparable(appSet *models.ApplicationSet, originURL, targetBranch string) error {
+	for _, generator := range appSet.Spec.Generators {
+		if generator.Git == nil {
+			continue
+		}
+
+		if !repoIdentityMatches(generator.Git.RepoURL, originURL) {
+			return fmt.Errorf("%w: git generator repoURL %q is not this repository (%q); only same-repository generators are supported",
+				models.ErrUnsupportedAppConfiguration, generator.Git.RepoURL, originURL)
+		}
+
+		// A pinned revision keeps ArgoCD generating from a fixed tree, so a
+		// directory this branch adds would change nothing it deploys.
+		if rev := generator.Git.Revision; rev != "" && rev != "HEAD" && rev != targetBranch {
+			return fmt.Errorf("%w: git generator revision %q is neither HEAD nor the compared branch %q, so the branches cannot stand in for it",
+				models.ErrUnsupportedAppConfiguration, rev, targetBranch)
+		}
+	}
+
+	return nil
+}
+
+// treeLister lists the directories recorded in a Git tree.
+func treeLister(tree *object.Tree) appset.DirectoryLister {
+	return func() ([]string, error) {
+		var files []string
+
+		if err := tree.Files().ForEach(func(file *object.File) error {
+			files = append(files, file.Name)
+			return nil
+		}); err != nil {
+			return nil, fmt.Errorf("list target branch directories: %w", err)
+		}
+
+		return directoriesOf(files), nil
+	}
+}
+
+// directoriesOf derives the directory set implied by a list of file paths.
+// Deriving from files rather than walking directories keeps both legs alike:
+// Git stores no empty directories, so one could never generate an Application.
+func directoriesOf(files []string) []string {
+	seen := make(map[string]bool, len(files))
+
+	for _, file := range files {
+		for dir := path.Dir(file); dir != "." && dir != "/" && !seen[dir]; dir = path.Dir(dir) {
+			seen[dir] = true
+		}
+	}
+
+	dirs := make([]string, 0, len(seen))
+	for dir := range seen {
+		dirs = append(dirs, dir)
+	}
+	sort.Strings(dirs)
+
+	return dirs
+}

--- a/internal/app/appset_dirs_test.go
+++ b/internal/app/appset_dirs_test.go
@@ -1,0 +1,195 @@
+package app
+
+import (
+	"os"
+	"testing"
+
+	"github.com/shini4i/argo-compare/cmd/argo-compare/utils"
+	"github.com/shini4i/argo-compare/cmd/argo-compare/utils/logger"
+	"github.com/shini4i/argo-compare/internal/models"
+	"github.com/shini4i/argo-compare/internal/ports/portstest"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// TestDirectoriesOf pins the shared foundation of both comparison legs. Input
+// is slash-separated repo-relative file paths; callers do the conversion.
+func TestDirectoriesOf(t *testing.T) {
+	tests := []struct {
+		name  string
+		files []string
+		want  []string
+	}{
+		{name: "nil", files: nil, want: []string{}},
+		{name: "file at the repository root implies no directory", files: []string{"README.md"}, want: []string{}},
+		{name: "every ancestor is reported", files: []string{"a/b/c.yaml"}, want: []string{"a", "a/b"}},
+		{
+			name:  "shared ancestors appear once",
+			files: []string{"a/b/one.yaml", "a/b/two.yaml", "a/c/three.yaml"},
+			want:  []string{"a", "a/b", "a/c"},
+		},
+		{name: "empty path", files: []string{""}, want: []string{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, directoriesOf(tt.files))
+		})
+	}
+}
+
+func gitGeneratorAppSet(t *testing.T, repoURL, revision string) *models.ApplicationSet {
+	t.Helper()
+
+	manifest := `
+kind: ApplicationSet
+metadata:
+  name: cluster-addons
+spec:
+  goTemplate: true
+  generators:
+    - git:
+        repoURL: ` + repoURL + `
+        revision: ` + revision + `
+        directories:
+          - path: clusters/*
+  template:
+    metadata:
+      name: '{{ .path.basename }}'
+`
+
+	var appSet models.ApplicationSet
+	require.NoError(t, yaml.Unmarshal([]byte(manifest), &appSet))
+
+	return &appSet
+}
+
+func TestAssertGitGeneratorsComparableAcceptsLocalRepository(t *testing.T) {
+	const origin = "https://github.com/shini4i/argo-compare.git"
+
+	tests := []struct {
+		name     string
+		repoURL  string
+		revision string
+	}{
+		{name: "identical url", repoURL: origin, revision: "HEAD"},
+		{name: "scp form of the same repository", repoURL: "git@github.com:shini4i/argo-compare.git", revision: "HEAD"},
+		{name: "without the git suffix", repoURL: "https://github.com/shini4i/argo-compare", revision: "HEAD"},
+		{name: "empty revision", repoURL: origin, revision: `""`},
+		{name: "revision naming the compared branch", repoURL: origin, revision: "main"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			appSet := gitGeneratorAppSet(t, tt.repoURL, tt.revision)
+			assert.NoError(t, assertGitGeneratorsComparable(appSet, origin, "main"))
+		})
+	}
+}
+
+func TestAssertGitGeneratorsComparableRejects(t *testing.T) {
+	const origin = "https://github.com/shini4i/argo-compare.git"
+
+	tests := []struct {
+		name       string
+		repoURL    string
+		revision   string
+		wantErrMsg string
+	}{
+		{
+			name:       "another repository",
+			repoURL:    "https://github.com/someone/elsewhere.git",
+			revision:   "HEAD",
+			wantErrMsg: "elsewhere.git",
+		},
+		{
+			name:       "revision pinned to a tag",
+			repoURL:    origin,
+			revision:   "v1.2.3",
+			wantErrMsg: `revision "v1.2.3"`,
+		},
+		{
+			name:       "revision naming an unrelated branch",
+			repoURL:    origin,
+			revision:   "release",
+			wantErrMsg: `revision "release"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			appSet := gitGeneratorAppSet(t, tt.repoURL, tt.revision)
+
+			err := assertGitGeneratorsComparable(appSet, origin, "main")
+			assert.ErrorIs(t, err, models.ErrUnsupportedAppConfiguration)
+			assert.Contains(t, err.Error(), tt.wantErrMsg)
+		})
+	}
+}
+
+// TestAssertGitGeneratorsComparableIgnoresOtherGenerators keeps the check from
+// touching manifests that declare no git generator at all.
+func TestAssertGitGeneratorsComparableIgnoresOtherGenerators(t *testing.T) {
+	var appSet models.ApplicationSet
+	require.NoError(t, yaml.Unmarshal([]byte(`
+kind: ApplicationSet
+metadata:
+  name: guestbook
+spec:
+  goTemplate: true
+  generators:
+    - list:
+        elements:
+          - cluster: dev
+  template:
+    metadata:
+      name: '{{ .cluster }}'
+`), &appSet))
+
+	assert.NoError(t, assertGitGeneratorsComparable(&appSet, "https://example.com/repo.git", "main"))
+	assert.NoError(t, assertGitGeneratorsComparable(&models.ApplicationSet{}, "", "main"))
+}
+
+// TestTreeListerReadsCommittedDirectories proves the lister both legs share
+// reports exactly the directories Git records, and nothing from the working
+// tree that Git does not track.
+func TestTreeListerReadsCommittedDirectories(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip integration test in short mode")
+	}
+
+	seedAppSetRepoState(t,
+		branchState{manifest: applicationSetYAML([][2]string{{"dev", "1.0.0"}}), files: map[string]string{
+			"clusters/dev/values.yaml": "replicaCount: 1\n",
+		}},
+		branchState{manifest: applicationSetYAML([][2]string{{"dev", "1.0.0"}}), files: map[string]string{
+			"clusters/dev/values.yaml":         "replicaCount: 1\n",
+			"clusters/prod/addons/values.yaml": "replicaCount: 2\n",
+		}})
+
+	repoInstance, err := NewGitRepo(afero.NewOsFs(), portstest.NoopCmdRunner{}, utils.OsFileReader{}, logger.New("tree-lister-test"))
+	require.NoError(t, err)
+
+	headTree, err := repoInstance.HeadTree()
+	require.NoError(t, err)
+	headDirs, err := treeLister(headTree)()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"apps", "clusters", "clusters/dev", "clusters/prod", "clusters/prod/addons"}, headDirs)
+
+	baseTree, err := repoInstance.MergeBaseTreeFor("main")
+	require.NoError(t, err)
+	baseDirs, err := treeLister(baseTree)()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"apps", "clusters", "clusters/dev"}, baseDirs)
+
+	// An untracked directory must not reach either leg.
+	require.NoError(t, os.MkdirAll("untracked/build", 0o755))
+	require.NoError(t, os.WriteFile("untracked/build/out.yaml", []byte("x: 1\n"), 0o644))
+
+	headDirs, err = treeLister(headTree)()
+	require.NoError(t, err)
+	assert.NotContains(t, headDirs, "untracked")
+	assert.NotContains(t, headDirs, "untracked/build")
+}

--- a/internal/app/appset_discovery.go
+++ b/internal/app/appset_discovery.go
@@ -27,15 +27,15 @@ const maxManifestBytes = 1 << 20
 // directory the diff touched. A git generator's Applications change when
 // directories appear or disappear, which leaves the manifest itself untouched,
 // so those changes would otherwise never reach the ApplicationSet flow.
-func DiscoverApplicationSets(filesystem afero.Fs, fileReader ports.FileReader, repoRoot, originURL, targetBranch string, changedFiles []string) ([]string, error) {
+func DiscoverApplicationSets(filesystem afero.Fs, fileReader ports.FileReader, repoRoot, originURL, targetBranch string, changedFiles []string) ([]string, []string, error) {
 	touched := touchedDirectories(changedFiles)
 	if len(touched) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 
-	candidates, err := findApplicationSets(filesystem, fileReader, repoRoot)
+	candidates, unusable, err := findApplicationSets(filesystem, fileReader, repoRoot)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var matched []string
@@ -51,8 +51,9 @@ func DiscoverApplicationSets(filesystem afero.Fs, fileReader ports.FileReader, r
 	}
 
 	sort.Strings(matched)
+	sort.Strings(unusable)
 
-	return matched, nil
+	return matched, unusable, nil
 }
 
 // discoveredAppSet pairs a parsed manifest with its repo-relative path.
@@ -102,12 +103,9 @@ func touchedDirectories(changedFiles []string) []string {
 }
 
 // findApplicationSets walks the working tree for expandable ApplicationSet
-// manifests that declare a git generator. Manifests that fail to parse or are
-// unsupported are skipped: a changed one is reported by discovery already, and
-// an unchanged one is not this run's concern.
-func findApplicationSets(filesystem afero.Fs, fileReader ports.FileReader, repoRoot string) ([]discoveredAppSet, error) {
-	var found []discoveredAppSet
-
+// manifests. It also returns the files that name the kind but could not be read
+// or parsed, so the caller can report them instead of losing them silently.
+func findApplicationSets(filesystem afero.Fs, fileReader ports.FileReader, repoRoot string) (found []discoveredAppSet, unusable []string, err error) {
 	walkErr := afero.Walk(filesystem, repoRoot, func(fullPath string, info fs.FileInfo, err error) error {
 		// An unreadable entry is skipped, not fatal: this scan visits the whole
 		// repository, and one directory it cannot enter is not this run.
@@ -129,17 +127,21 @@ func findApplicationSets(filesystem afero.Fs, fileReader ports.FileReader, repoR
 			return nil
 		}
 
-		if appSet := readApplicationSet(fileReader, fullPath, rel); appSet != nil {
+		appSet, readErr := readApplicationSet(fileReader, fullPath, rel)
+		switch {
+		case readErr != nil:
+			unusable = append(unusable, fmt.Sprintf("%s (%s)", rel, readErr))
+		case appSet != nil:
 			found = append(found, discoveredAppSet{path: rel, appSet: appSet})
 		}
 
 		return nil
 	})
 	if walkErr != nil {
-		return nil, fmt.Errorf("scan for ApplicationSet manifests: %w", walkErr)
+		return nil, nil, fmt.Errorf("scan for ApplicationSet manifests: %w", walkErr)
 	}
 
-	return found, nil
+	return found, unusable, nil
 }
 
 // discoverGeneratorApplicationSets finds ApplicationSets a directory change
@@ -153,9 +155,15 @@ func (g *GitRepo) discoverGeneratorApplicationSets(repoRoot, targetBranch string
 		return nil, err
 	}
 
-	matched, err := DiscoverApplicationSets(g.fs, g.fileReader, repoRoot, originURL, targetBranch, changed)
+	matched, unusable, err := DiscoverApplicationSets(g.fs, g.fileReader, repoRoot, originURL, targetBranch, changed)
 	if err != nil {
 		return nil, err
+	}
+
+	// A manifest naming the kind but failing to load may well be one this
+	// change affects, so say so rather than dropping it without a word.
+	for _, file := range unusable {
+		g.log.Warningf("Skipping unreadable ApplicationSet manifest during discovery: %s", file)
 	}
 
 	matched = filterIgnored(matched, filesToIgnore)
@@ -184,26 +192,32 @@ func mergePaths(base, extra []string) []string {
 	return base
 }
 
-// readApplicationSet returns the expandable ApplicationSet at fullPath, or nil
-// when the file is not one. A read or parse failure yields nil rather than an
-// error: this scan visits every YAML in the repository, and one it cannot use
-// is not this run's concern.
-func readApplicationSet(fileReader ports.FileReader, fullPath, rel string) *models.ApplicationSet {
+// readApplicationSet returns the expandable ApplicationSet at fullPath, nil when
+// the file is not one, or an error when a file that looks like one cannot be
+// used. The caller reports that rather than failing, so a single broken
+// manifest does not stop a run it may have nothing to do with.
+func readApplicationSet(fileReader ports.FileReader, fullPath, rel string) (*models.ApplicationSet, error) {
 	if ext := path.Ext(rel); ext != ".yaml" && ext != ".yml" {
-		return nil
+		return nil, nil
 	}
 
 	content, err := fileReader.ReadFile(fullPath)
-	if err != nil || !bytes.Contains(content, appSetKindMarker) {
-		return nil
+	if err != nil {
+		return nil, err
+	}
+
+	// Only a file naming the kind is worth reporting on; every other YAML in
+	// the repository is simply not a manifest this scan wants.
+	if !bytes.Contains(content, appSetKindMarker) {
+		return nil, nil
 	}
 
 	appSet, err := parseApplicationSetContent(content)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 
-	return appSet
+	return appSet, nil
 }
 
 // skipUnreadable abandons an entry the walk could not stat, descending no

--- a/internal/app/appset_discovery.go
+++ b/internal/app/appset_discovery.go
@@ -1,0 +1,227 @@
+package app
+
+import (
+	"bytes"
+	"fmt"
+	"io/fs"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/shini4i/argo-compare/internal/appset"
+	"github.com/shini4i/argo-compare/internal/models"
+	"github.com/shini4i/argo-compare/internal/ports"
+	"github.com/spf13/afero"
+)
+
+// appSetKindMarker is the cheap pre-filter that keeps the repository scan from
+// parsing every YAML file it finds.
+var appSetKindMarker = []byte("ApplicationSet")
+
+// maxManifestBytes bounds what the scan reads. An ApplicationSet manifest is a
+// few kilobytes; anything larger is generated output, not one to expand.
+const maxManifestBytes = 1 << 20
+
+// DiscoverApplicationSets returns the manifests whose git generators cover a
+// directory the diff touched. A git generator's Applications change when
+// directories appear or disappear, which leaves the manifest itself untouched,
+// so those changes would otherwise never reach the ApplicationSet flow.
+func DiscoverApplicationSets(filesystem afero.Fs, fileReader ports.FileReader, repoRoot, originURL, targetBranch string, changedFiles []string) ([]string, error) {
+	touched := touchedDirectories(changedFiles)
+	if len(touched) == 0 {
+		return nil, nil
+	}
+
+	candidates, err := findApplicationSets(filesystem, fileReader, repoRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	var matched []string
+	for _, candidate := range candidates {
+		// A generator naming another repository cannot be expanded here, so
+		// enqueueing it would only warn about a manifest nobody touched.
+		if assertGitGeneratorsComparable(candidate.appSet, originURL, targetBranch) != nil {
+			continue
+		}
+		if coversAnyDirectory(candidate.appSet, touched) {
+			matched = append(matched, candidate.path)
+		}
+	}
+
+	sort.Strings(matched)
+
+	return matched, nil
+}
+
+// discoveredAppSet pairs a parsed manifest with its repo-relative path.
+type discoveredAppSet struct {
+	path   string
+	appSet *models.ApplicationSet
+}
+
+// coversAnyDirectory reports whether a git generator in appSet would generate
+// an Application for one of the supplied directories.
+func coversAnyDirectory(appSet *models.ApplicationSet, dirs []string) bool {
+	for _, generator := range appSet.Spec.Generators {
+		if generator.Git == nil {
+			continue
+		}
+		for _, dir := range dirs {
+			if appset.Matches(generator.Git, dir) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// touchedDirectories returns every ancestor directory of the changed files,
+// because a generator may match any level of the path, not only the deepest.
+func touchedDirectories(changedFiles []string) []string {
+	seen := make(map[string]bool, len(changedFiles))
+
+	for _, file := range changedFiles {
+		if file == "" {
+			continue
+		}
+		for dir := path.Dir(filepath.ToSlash(file)); dir != "." && dir != "/" && !seen[dir]; dir = path.Dir(dir) {
+			seen[dir] = true
+		}
+	}
+
+	dirs := make([]string, 0, len(seen))
+	for dir := range seen {
+		dirs = append(dirs, dir)
+	}
+	sort.Strings(dirs)
+
+	return dirs
+}
+
+// findApplicationSets walks the working tree for expandable ApplicationSet
+// manifests that declare a git generator. Manifests that fail to parse or are
+// unsupported are skipped: a changed one is reported by discovery already, and
+// an unchanged one is not this run's concern.
+func findApplicationSets(filesystem afero.Fs, fileReader ports.FileReader, repoRoot string) ([]discoveredAppSet, error) {
+	var found []discoveredAppSet
+
+	walkErr := afero.Walk(filesystem, repoRoot, func(fullPath string, info fs.FileInfo, err error) error {
+		// An unreadable entry is skipped, not fatal: this scan visits the whole
+		// repository, and one directory it cannot enter is not this run.
+		if err != nil {
+			return skipUnreadable(info)
+		}
+
+		rel, relErr := filepath.Rel(repoRoot, fullPath)
+		if relErr != nil {
+			return relErr
+		}
+		rel = filepath.ToSlash(rel)
+
+		if info.IsDir() {
+			return skipHiddenDir(rel, info)
+		}
+
+		if info.Size() > maxManifestBytes {
+			return nil
+		}
+
+		if appSet := readApplicationSet(fileReader, fullPath, rel); appSet != nil {
+			found = append(found, discoveredAppSet{path: rel, appSet: appSet})
+		}
+
+		return nil
+	})
+	if walkErr != nil {
+		return nil, fmt.Errorf("scan for ApplicationSet manifests: %w", walkErr)
+	}
+
+	return found, nil
+}
+
+// discoverGeneratorApplicationSets finds ApplicationSets a directory change
+// affects and reports them, so a run that touches no manifest still compares
+// the Applications a git generator adds or drops.
+func (g *GitRepo) discoverGeneratorApplicationSets(repoRoot, targetBranch string, found, removed, filesToIgnore []string) ([]string, error) {
+	changed := filterIgnored(append(append([]string{}, found...), removed...), filesToIgnore)
+
+	originURL, err := g.OriginURL()
+	if err != nil {
+		return nil, err
+	}
+
+	matched, err := DiscoverApplicationSets(g.fs, g.fileReader, repoRoot, originURL, targetBranch, changed)
+	if err != nil {
+		return nil, err
+	}
+
+	matched = filterIgnored(matched, filesToIgnore)
+	for _, file := range matched {
+		g.log.Debugf("Directory change affects ApplicationSet [%s]", file)
+	}
+
+	return matched, nil
+}
+
+// mergePaths appends the paths of extra that base does not already carry,
+// preserving base's order so the reported list stays stable.
+func mergePaths(base, extra []string) []string {
+	seen := make(map[string]bool, len(base))
+	for _, file := range base {
+		seen[file] = true
+	}
+
+	for _, file := range extra {
+		if !seen[file] {
+			base = append(base, file)
+			seen[file] = true
+		}
+	}
+
+	return base
+}
+
+// readApplicationSet returns the expandable ApplicationSet at fullPath, or nil
+// when the file is not one. A read or parse failure yields nil rather than an
+// error: this scan visits every YAML in the repository, and one it cannot use
+// is not this run's concern.
+func readApplicationSet(fileReader ports.FileReader, fullPath, rel string) *models.ApplicationSet {
+	if ext := path.Ext(rel); ext != ".yaml" && ext != ".yml" {
+		return nil
+	}
+
+	content, err := fileReader.ReadFile(fullPath)
+	if err != nil || !bytes.Contains(content, appSetKindMarker) {
+		return nil
+	}
+
+	appSet, err := parseApplicationSetContent(content)
+	if err != nil {
+		return nil
+	}
+
+	return appSet
+}
+
+// skipUnreadable abandons an entry the walk could not stat, descending no
+// further when it is a directory.
+func skipUnreadable(info fs.FileInfo) error {
+	if info != nil && info.IsDir() {
+		return filepath.SkipDir
+	}
+
+	return nil
+}
+
+// skipHiddenDir prunes dot directories, which hold no manifest worth expanding
+// and would otherwise make the scan walk the whole .git object store.
+func skipHiddenDir(rel string, info fs.FileInfo) error {
+	if rel != "." && strings.HasPrefix(info.Name(), ".") {
+		return filepath.SkipDir
+	}
+
+	return nil
+}

--- a/internal/app/appset_discovery_test.go
+++ b/internal/app/appset_discovery_test.go
@@ -1,7 +1,9 @@
 package app
 
 import (
+	"errors"
 	"path"
+	"strings"
 	"testing"
 
 	"github.com/shini4i/argo-compare/cmd/argo-compare/utils"
@@ -110,7 +112,7 @@ spec:
 func TestDiscoverApplicationSetsMatchesTouchedDirectory(t *testing.T) {
 	filesystem, root := seedDiscoveryTree(t)
 
-	matched, err := DiscoverApplicationSets(filesystem, utils.OsFileReader{}, root, discoveryOrigin, "main",
+	matched, _, err := DiscoverApplicationSets(filesystem, utils.OsFileReader{}, root, discoveryOrigin, "main",
 		[]string{"clusters/staging/values.yaml"})
 
 	require.NoError(t, err)
@@ -122,17 +124,17 @@ func TestDiscoverApplicationSetsIgnoresUnmatchedChanges(t *testing.T) {
 	reader := utils.OsFileReader{}
 
 	// Excluded by the generator itself.
-	matched, err := DiscoverApplicationSets(filesystem, reader, root, discoveryOrigin, "main", []string{"clusters/donotdeploy/values.yaml"})
+	matched, _, err := DiscoverApplicationSets(filesystem, reader, root, discoveryOrigin, "main", []string{"clusters/donotdeploy/values.yaml"})
 	require.NoError(t, err)
 	assert.Empty(t, matched)
 
 	// Outside every pattern.
-	matched, err = DiscoverApplicationSets(filesystem, reader, root, discoveryOrigin, "main", []string{"docs/readme.yaml"})
+	matched, _, err = DiscoverApplicationSets(filesystem, reader, root, discoveryOrigin, "main", []string{"docs/readme.yaml"})
 	require.NoError(t, err)
 	assert.Empty(t, matched)
 
 	// A repository-root file touches no directory at all.
-	matched, err = DiscoverApplicationSets(filesystem, reader, root, discoveryOrigin, "main", []string{"README.md"})
+	matched, _, err = DiscoverApplicationSets(filesystem, reader, root, discoveryOrigin, "main", []string{"README.md"})
 	require.NoError(t, err)
 	assert.Empty(t, matched)
 }
@@ -142,10 +144,56 @@ func TestDiscoverApplicationSetsIgnoresUnmatchedChanges(t *testing.T) {
 func TestDiscoverApplicationSetsSkipsNonCandidates(t *testing.T) {
 	filesystem, root := seedDiscoveryTree(t)
 
-	matched, err := DiscoverApplicationSets(filesystem, utils.OsFileReader{}, root, discoveryOrigin, "main",
+	matched, _, err := DiscoverApplicationSets(filesystem, utils.OsFileReader{}, root, discoveryOrigin, "main",
 		[]string{"clusters/dev/values.yaml"})
 
 	require.NoError(t, err)
 	// The list-generator, plain, broken, non-YAML and hidden manifests are all absent.
 	assert.Equal(t, []string{"apps/addons.yaml"}, matched)
+}
+
+// failingReader fails on one path and delegates the rest, standing in for a
+// manifest the scan cannot read. chmod would be a no-op when tests run as root.
+type failingReader struct {
+	failPath string
+}
+
+func (r failingReader) ReadFile(file string) ([]byte, error) {
+	if strings.HasSuffix(file, r.failPath) {
+		return nil, errors.New("boom")
+	}
+	return utils.OsFileReader{}.ReadFile(file)
+}
+
+// TestDiscoverApplicationSetsReportsUnusableManifests keeps a manifest that
+// names the kind but cannot be loaded from vanishing without a word — it may be
+// exactly the one the change affects.
+func TestDiscoverApplicationSetsReportsUnusableManifests(t *testing.T) {
+	filesystem, root := seedDiscoveryTree(t)
+
+	matched, unusable, err := DiscoverApplicationSets(filesystem, failingReader{failPath: "apps/addons.yaml"},
+		root, discoveryOrigin, "main", []string{"clusters/dev/values.yaml"})
+
+	require.NoError(t, err)
+	assert.Empty(t, matched, "the unreadable manifest cannot be matched")
+
+	// The seeded tree also holds an unparseable manifest, so both are reported.
+	joined := strings.Join(unusable, "\n")
+	assert.Contains(t, joined, "apps/addons.yaml")
+	assert.Contains(t, joined, "boom")
+	assert.Contains(t, joined, "apps/broken.yaml")
+}
+
+// TestDiscoverApplicationSetsReportsUnparseableManifests covers the other half:
+// the file reads, names the kind, and fails to decode.
+func TestDiscoverApplicationSetsReportsUnparseableManifests(t *testing.T) {
+	filesystem, root := seedDiscoveryTree(t)
+
+	_, unusable, err := DiscoverApplicationSets(filesystem, utils.OsFileReader{},
+		root, discoveryOrigin, "main", []string{"clusters/dev/values.yaml"})
+
+	require.NoError(t, err)
+	require.Len(t, unusable, 1)
+	assert.Contains(t, unusable[0], "apps/broken.yaml")
+	assert.Contains(t, unusable[0], "did not find expected key")
 }

--- a/internal/app/appset_discovery_test.go
+++ b/internal/app/appset_discovery_test.go
@@ -1,0 +1,151 @@
+package app
+
+import (
+	"path"
+	"testing"
+
+	"github.com/shini4i/argo-compare/cmd/argo-compare/utils"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTouchedDirectories(t *testing.T) {
+	// Every ancestor is reported, since a generator may match any level.
+	assert.Equal(t,
+		[]string{"clusters", "clusters/dev", "clusters/dev/addons"},
+		touchedDirectories([]string{"clusters/dev/addons/values.yaml"}))
+
+	assert.Equal(t,
+		[]string{"apps", "clusters", "clusters/dev"},
+		touchedDirectories([]string{"clusters/dev/values.yaml", "apps/x.yaml", "apps/y.yaml"}))
+
+	// A file at the repository root touches no directory.
+	assert.Empty(t, touchedDirectories([]string{"README.md"}))
+	assert.Empty(t, touchedDirectories([]string{""}))
+	assert.Empty(t, touchedDirectories(nil))
+}
+
+func TestMergePaths(t *testing.T) {
+	assert.Equal(t,
+		[]string{"a.yaml", "b.yaml", "c.yaml"},
+		mergePaths([]string{"a.yaml", "b.yaml"}, []string{"b.yaml", "c.yaml"}))
+
+	assert.Equal(t, []string{"a.yaml"}, mergePaths([]string{"a.yaml"}, nil))
+	assert.Equal(t, []string{"c.yaml"}, mergePaths(nil, []string{"c.yaml", "c.yaml"}))
+}
+
+// discoveryOrigin is the repository the seeded manifests name.
+const discoveryOrigin = "https://example.com/repo.git"
+
+const discoverableAppSet = `apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: cluster-addons
+  namespace: argocd
+spec:
+  goTemplate: true
+  generators:
+    - git:
+        repoURL: https://example.com/repo.git
+        directories:
+          - path: clusters/*
+          - path: clusters/donotdeploy
+            exclude: true
+  template:
+    metadata:
+      name: '{{ .path.basename }}'
+    spec:
+      source:
+        repoURL: https://charts.example.com
+        chart: demo
+        targetRevision: 1.0.0
+`
+
+// seedDiscoveryTree writes the manifests a scan should find, alongside files it
+// must ignore: a list-generator ApplicationSet, a plain Application, an
+// unparseable manifest, and one inside a dot directory.
+func seedDiscoveryTree(t *testing.T) (afero.Fs, string) {
+	t.Helper()
+
+	root := t.TempDir()
+	filesystem := afero.NewOsFs()
+
+	write := func(rel, content string) {
+		t.Helper()
+		require.NoError(t, filesystem.MkdirAll(root+"/"+path.Dir(rel), 0o755))
+		require.NoError(t, afero.WriteFile(filesystem, root+"/"+rel, []byte(content), 0o644))
+	}
+
+	write("apps/addons.yaml", discoverableAppSet)
+	write("apps/list.yaml", `apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: listed
+spec:
+  goTemplate: true
+  generators:
+    - list:
+        elements:
+          - cluster: dev
+  template:
+    metadata:
+      name: '{{ .cluster }}'
+    spec:
+      source:
+        repoURL: https://charts.example.com
+        chart: demo
+        targetRevision: 1.0.0
+`)
+	write("apps/plain.yaml", "kind: Application\nmetadata:\n  name: demo\n")
+	write("apps/broken.yaml", "kind: ApplicationSet\nmetadata:\n   bad: indent\n  worse\n")
+	write("apps/notes.txt", "kind: ApplicationSet\n")
+	write(".hidden/addons.yaml", discoverableAppSet)
+
+	return filesystem, root
+}
+
+// TestDiscoverApplicationSetsMatchesTouchedDirectory is the case the feature
+// exists for: a change under clusters/ reaches an ApplicationSet nobody edited.
+func TestDiscoverApplicationSetsMatchesTouchedDirectory(t *testing.T) {
+	filesystem, root := seedDiscoveryTree(t)
+
+	matched, err := DiscoverApplicationSets(filesystem, utils.OsFileReader{}, root, discoveryOrigin, "main",
+		[]string{"clusters/staging/values.yaml"})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"apps/addons.yaml"}, matched)
+}
+
+func TestDiscoverApplicationSetsIgnoresUnmatchedChanges(t *testing.T) {
+	filesystem, root := seedDiscoveryTree(t)
+	reader := utils.OsFileReader{}
+
+	// Excluded by the generator itself.
+	matched, err := DiscoverApplicationSets(filesystem, reader, root, discoveryOrigin, "main", []string{"clusters/donotdeploy/values.yaml"})
+	require.NoError(t, err)
+	assert.Empty(t, matched)
+
+	// Outside every pattern.
+	matched, err = DiscoverApplicationSets(filesystem, reader, root, discoveryOrigin, "main", []string{"docs/readme.yaml"})
+	require.NoError(t, err)
+	assert.Empty(t, matched)
+
+	// A repository-root file touches no directory at all.
+	matched, err = DiscoverApplicationSets(filesystem, reader, root, discoveryOrigin, "main", []string{"README.md"})
+	require.NoError(t, err)
+	assert.Empty(t, matched)
+}
+
+// TestDiscoverApplicationSetsSkipsNonCandidates proves the scan tolerates the
+// other manifests a repository holds without failing or matching them.
+func TestDiscoverApplicationSetsSkipsNonCandidates(t *testing.T) {
+	filesystem, root := seedDiscoveryTree(t)
+
+	matched, err := DiscoverApplicationSets(filesystem, utils.OsFileReader{}, root, discoveryOrigin, "main",
+		[]string{"clusters/dev/values.yaml"})
+
+	require.NoError(t, err)
+	// The list-generator, plain, broken, non-YAML and hidden manifests are all absent.
+	assert.Equal(t, []string{"apps/addons.yaml"}, matched)
+}

--- a/internal/app/appset_flow.go
+++ b/internal/app/appset_flow.go
@@ -27,7 +27,23 @@ type generatedPair struct {
 func (a *App) processChangedApplicationSet(ctx context.Context, repo *GitRepo, file string, srcSet *models.ApplicationSet) (bool, error) {
 	a.logger.Infof("===> Processing changed ApplicationSet: [%s]", ui.Cyan(file))
 
-	srcApps, err := appset.Expand(srcSet)
+	originURL, err := repo.OriginURL()
+	if err != nil {
+		return false, err
+	}
+	// Skipping rather than failing keeps one unsupported manifest from breaking a
+	// run, matching every other unsupported ApplicationSet configuration.
+	if err := assertGitGeneratorsComparable(srcSet, originURL, a.cfg.TargetBranch); err != nil {
+		a.logger.Warning(ui.Yellow(fmt.Sprintf("Skipping %s: %s", file, err)))
+		return false, nil
+	}
+
+	headTree, err := repo.HeadTree()
+	if err != nil {
+		return false, err
+	}
+
+	srcApps, err := appset.Expand(srcSet, treeLister(headTree))
 	if err != nil {
 		return false, fmt.Errorf("expand ApplicationSet %q: %w", file, err)
 	}
@@ -70,7 +86,7 @@ func (a *App) targetApplicationSet(repo *GitRepo, file string) ([]models.Applica
 		return nil, err
 	}
 
-	appSet, err := parseApplicationSetContent(content)
+	appSet, err := a.parseTargetApplicationSet(repo, content)
 	if err != nil {
 		// Adding `goTemplate: true` to an existing manifest is the migration
 		// this feature asks users to make, so an unexpandable baseline reports
@@ -84,12 +100,38 @@ func (a *App) targetApplicationSet(repo *GitRepo, file string) ([]models.Applica
 		return nil, fmt.Errorf("parse ApplicationSet %q from branch %q: %w", file, a.cfg.TargetBranch, err)
 	}
 
-	apps, err := appset.Expand(appSet)
+	tree, err := repo.MergeBaseTreeFor(a.cfg.TargetBranch)
+	if err != nil {
+		return nil, err
+	}
+
+	apps, err := appset.Expand(appSet, treeLister(tree))
 	if err != nil {
 		return nil, fmt.Errorf("expand ApplicationSet %q from branch %q: %w", file, a.cfg.TargetBranch, err)
 	}
 
 	return apps, nil
+}
+
+// parseTargetApplicationSet validates the target-branch manifest, including
+// that its git generators still name this repository. A generator pointing
+// elsewhere would otherwise be matched against the local tree.
+func (a *App) parseTargetApplicationSet(repo *GitRepo, content []byte) (*models.ApplicationSet, error) {
+	appSet, err := parseApplicationSetContent(content)
+	if err != nil {
+		return nil, err
+	}
+
+	originURL, err := repo.OriginURL()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := assertGitGeneratorsComparable(appSet, originURL, a.cfg.TargetBranch); err != nil {
+		return nil, err
+	}
+
+	return appSet, nil
 }
 
 // unexpandable reports whether err means the manifest is one argo-compare

--- a/internal/app/appset_git_integration_test.go
+++ b/internal/app/appset_git_integration_test.go
@@ -1,0 +1,159 @@
+package app
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// gitAppSetYAML is a git directory generator over clusters/*, excluding one
+// directory. repoURL is rewritten per test to point at the seeded origin.
+func gitAppSetYAML(repoURL string) string {
+	return `apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: cluster-addons
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - git:
+        repoURL: ` + repoURL + `
+        revision: HEAD
+        directories:
+          - path: clusters/*
+          - path: clusters/donotdeploy
+            exclude: true
+  template:
+    metadata:
+      name: '{{ .path.basenameNormalized }}-addons'
+      namespace: argocd
+    spec:
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: '{{ .path.basename }}'
+      source:
+        repoURL: fake.repo/charts
+        chart: demo-chart
+        targetRevision: 1.0.0
+        helm:
+          releaseName: '{{ .path.basename }}-addons'
+`
+}
+
+func clusterFile(cluster string) string {
+	return "clusters/" + cluster + "/values.yaml"
+}
+
+// TestAppRunGitGeneratorReportsAddedDirectory is the case the git generator
+// exists for: the branch adds a directory, so the ApplicationSet generates an
+// Application the target branch does not.
+func TestAppRunGitGeneratorReportsAddedDirectory(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip integration test in short mode")
+	}
+
+	manifest := gitAppSetYAML(originPlaceholder)
+
+	seedAppSetRepoState(t,
+		branchState{manifest: manifest, files: map[string]string{
+			clusterFile("dev"):         "replicaCount: 1\n",
+			clusterFile("donotdeploy"): "replicaCount: 1\n",
+		}},
+		branchState{manifest: manifest, files: map[string]string{
+			clusterFile("dev"):         "replicaCount: 1\n",
+			clusterFile("donotdeploy"): "replicaCount: 1\n",
+			clusterFile("staging"):     "replicaCount: 2\n",
+		}})
+
+	runner := newAppSetRunner(t, Config{PrintAddedManifests: true}, nil)
+	require.NoError(t, runner.app.Run(context.Background()))
+
+	output := runner.log.String()
+
+	// dev exists on both branches; staging only on this one; donotdeploy is excluded.
+	assert.Contains(t, output, "Generates 2 Application(s) on this branch and 1 on main; comparing 2")
+	assert.Contains(t, output, "dev-addons")
+	assert.Contains(t, output, "staging-addons")
+	assert.NotContains(t, output, "donotdeploy")
+
+	// dev renders on both legs, staging only on the source leg.
+	assert.Equal(t, 3, runner.helm.callCount("RenderAppSource"))
+
+	runner.assertTempDirsRemoved(t)
+}
+
+// TestAppRunGitGeneratorReportsRemovedDirectory is the mirror case: deleting a
+// directory stops generating its Application.
+func TestAppRunGitGeneratorReportsRemovedDirectory(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip integration test in short mode")
+	}
+
+	manifest := gitAppSetYAML(originPlaceholder)
+
+	seedAppSetRepoState(t,
+		branchState{manifest: manifest, files: map[string]string{
+			clusterFile("dev"):    "replicaCount: 1\n",
+			clusterFile("legacy"): "replicaCount: 1\n",
+		}},
+		branchState{manifest: manifest, files: map[string]string{
+			clusterFile("dev"): "replicaCount: 1\n",
+		}})
+
+	runner := newAppSetRunner(t, Config{}, nil)
+	require.NoError(t, runner.app.Run(context.Background()))
+
+	output := runner.log.String()
+	assert.Contains(t, output, "Skipping removed Application [legacy-addons]")
+	assert.Equal(t, 2, runner.helm.callCount("RenderAppSource"))
+}
+
+// TestAppRunGitGeneratorSkipsForeignRepo pins the deferred scope: a generator
+// reading another repository would list the same tree for both legs, so it is
+// skipped with the reason named rather than matched against the local one.
+func TestAppRunGitGeneratorSkipsForeignRepo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip integration test in short mode")
+	}
+
+	local := gitAppSetYAML(originPlaceholder)
+	foreign := gitAppSetYAML("https://github.com/someone/elsewhere.git")
+
+	seedAppSetRepoState(t,
+		branchState{manifest: local, files: map[string]string{clusterFile("dev"): "replicaCount: 1\n"}},
+		branchState{manifest: foreign, files: map[string]string{clusterFile("dev"): "replicaCount: 1\n"}})
+
+	runner := newAppSetRunner(t, Config{}, nil)
+
+	require.NoError(t, runner.app.Run(context.Background()))
+	assert.Contains(t, runner.log.String(), "elsewhere.git")
+	assert.Zero(t, runner.helm.callCount("RenderAppSource"))
+}
+
+// TestAppRunDiscoveryIgnoresForeignRepoApplicationSet is the blast radius the
+// repository scan introduces: an ApplicationSet nobody edited must not fail a
+// run just because a directory change happens to match its patterns.
+func TestAppRunDiscoveryIgnoresForeignRepoApplicationSet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip integration test in short mode")
+	}
+
+	foreign := gitAppSetYAML("https://github.com/someone/elsewhere.git")
+
+	seedAppSetRepoState(t,
+		branchState{manifest: foreign, files: map[string]string{clusterFile("dev"): "replicaCount: 1\n"}},
+		branchState{manifest: foreign, files: map[string]string{
+			clusterFile("dev"):     "replicaCount: 1\n",
+			clusterFile("staging"): "replicaCount: 2\n",
+		}})
+
+	runner := newAppSetRunner(t, Config{PrintAddedManifests: true}, nil)
+
+	require.NoError(t, runner.app.Run(context.Background()))
+	assert.Zero(t, runner.helm.callCount("RenderAppSource"))
+	assert.NotContains(t, runner.log.String(), "Processing changed ApplicationSet")
+}

--- a/internal/app/appset_integration_test.go
+++ b/internal/app/appset_integration_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/go-git/go-git/v5"
@@ -23,6 +25,10 @@ import (
 )
 
 const appSetPath = "apps/guestbook.yaml"
+
+// originPlaceholder is replaced with the seeded origin path, so a git generator
+// manifest can name the repository before that path exists.
+const originPlaceholder = "ORIGIN_URL"
 
 // legacyAppSet uses fasttemplate substitution, which argo-compare rejects.
 const legacyAppSet = `apiVersion: argoproj.io/v1alpha1
@@ -76,14 +82,35 @@ spec:
 `
 }
 
+// branchState is what one branch holds: the ApplicationSet manifest at
+// appSetPath, plus any extra files whose directories a git generator matches.
+type branchState struct {
+	manifest string
+	files    map[string]string
+}
+
 // seedAppSetRepo builds a repository whose main branch holds mainManifest and
 // whose checked-out feature branch holds featureManifest, both at appSetPath.
-// An empty mainManifest leaves the file absent there. Chdirs into the repo, so
-// tests using this helper can never run in parallel.
+// An empty mainManifest leaves the file absent there.
 func seedAppSetRepo(t *testing.T, mainManifest, featureManifest string) {
 	t.Helper()
 
+	seedAppSetRepoState(t, branchState{manifest: mainManifest}, branchState{manifest: featureManifest})
+}
+
+// seedAppSetRepoState is seedAppSetRepo with extra per-branch files. It chdirs
+// into the repository, so tests using either helper can never run in parallel.
+func seedAppSetRepoState(t *testing.T, main, feature branchState) {
+	t.Helper()
+
 	tempDir := t.TempDir()
+	remoteDir := filepath.Join(tempDir, "origin.git")
+
+	// A git generator names the repository by URL, which is only known once the
+	// origin exists, so manifests carry a placeholder for it.
+	mainManifest := strings.ReplaceAll(main.manifest, originPlaceholder, remoteDir)
+	featureManifest := strings.ReplaceAll(feature.manifest, originPlaceholder, remoteDir)
+
 	workDir := filepath.Join(tempDir, "work")
 	require.NoError(t, os.MkdirAll(filepath.Join(workDir, "apps"), 0o755))
 
@@ -104,11 +131,11 @@ func seedAppSetRepo(t *testing.T, mainManifest, featureManifest string) {
 		_, err = worktree.Add(appSetPath)
 		require.NoError(t, err)
 	}
+	writeBranchFiles(t, worktree, workDir, main.files)
 
 	initialHash, err := worktree.Commit("initial commit", &git.CommitOptions{Author: defaultSignature()})
 	require.NoError(t, err)
 
-	remoteDir := filepath.Join(tempDir, "origin.git")
 	_, err = git.PlainInit(remoteDir, true)
 	require.NoError(t, err)
 	_, err = repo.CreateRemote(&config.RemoteConfig{Name: "origin", URLs: []string{remoteDir}})
@@ -121,6 +148,17 @@ func seedAppSetRepo(t *testing.T, mainManifest, featureManifest string) {
 	require.NoError(t, os.WriteFile(filepath.Join(workDir, appSetPath), []byte(featureManifest), 0o644))
 	_, err = worktree.Add(appSetPath)
 	require.NoError(t, err)
+
+	// Files the branch drops must be removed, not merely left out, or the diff
+	// never records the deletion.
+	for _, name := range sortedKeys(main.files) {
+		if _, kept := feature.files[name]; !kept {
+			_, removeErr := worktree.Remove(name)
+			require.NoError(t, removeErr)
+		}
+	}
+	writeBranchFiles(t, worktree, workDir, feature.files)
+
 	_, err = worktree.Commit("update application set", &git.CommitOptions{Author: defaultSignature()})
 	require.NoError(t, err)
 
@@ -396,4 +434,27 @@ func TestGetChangedFileRaw(t *testing.T) {
 
 	_, err = repoInstance.GetChangedFileRaw("main", "apps/absent.yaml")
 	assert.True(t, errors.Is(err, errGitFileDoesNotExist))
+}
+
+// writeBranchFiles commits the extra files a branch holds, creating any parent
+// directories the git generator will later match.
+func writeBranchFiles(t *testing.T, worktree *git.Worktree, workDir string, files map[string]string) {
+	t.Helper()
+
+	for _, name := range sortedKeys(files) {
+		full := filepath.Join(workDir, filepath.FromSlash(name))
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, []byte(files[name]), 0o644))
+		_, err := worktree.Add(name)
+		require.NoError(t, err)
+	}
+}
+
+func sortedKeys(files map[string]string) []string {
+	names := make([]string, 0, len(files))
+	for name := range files {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }

--- a/internal/app/git.go
+++ b/internal/app/git.go
@@ -148,6 +148,12 @@ func (g *GitRepo) GetChangedFiles(targetBranch string, filesToIgnore []string, a
 	}
 	filtered := filterIgnored(applications, filesToIgnore)
 
+	generated, err := g.discoverGeneratorApplicationSets(repoRoot, targetBranch, foundFiles, removedFiles, filesToIgnore)
+	if err != nil {
+		return ChangedFilesResult{}, err
+	}
+	filtered = mergePaths(filtered, generated)
+
 	var anchorGroups []AnchorGroup
 	if anchorFileName != "" {
 		anchorChanged := filterIgnored(foundFiles, filesToIgnore)
@@ -522,4 +528,27 @@ func filterIgnored(files, ignored []string) []string {
 	}
 
 	return filtered
+}
+
+// HeadTree returns the tree of the commit at HEAD. Directory listing reads it
+// rather than the filesystem so both comparison legs see the same universe:
+// the working tree also holds untracked and ignored files, which Git does not
+// record and ArgoCD would never deploy.
+func (g *GitRepo) HeadTree() (*object.Tree, error) {
+	headRef, err := g.repo.Head()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get HEAD: %w", err)
+	}
+
+	headCommit, err := g.repo.CommitObject(headRef.Hash())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get commit object for current branch: %w", err)
+	}
+
+	tree, err := headCommit.Tree()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get tree for head commit: %w", err)
+	}
+
+	return tree, nil
 }

--- a/internal/appset/expand.go
+++ b/internal/appset/expand.go
@@ -8,9 +8,10 @@ import (
 )
 
 // Expand renders every Application an ApplicationSet generates, in generator
-// and element order. Only manifests accepted by ApplicationSet.Validate can be
-// expanded; anything else is returned as an error rather than a partial result.
-func Expand(appSet *models.ApplicationSet) ([]models.Application, error) {
+// and element order. Manifests Validate rejects are returned as an error, never
+// as a partial result. lister supplies the directories a git generator matches
+// against, and is called only when the manifest declares one.
+func Expand(appSet *models.ApplicationSet, lister DirectoryLister) ([]models.Application, error) {
 	if err := appSet.Validate(); err != nil {
 		return nil, err
 	}
@@ -20,10 +21,15 @@ func Expand(appSet *models.ApplicationSet) ([]models.Application, error) {
 		return nil, fmt.Errorf("marshal spec.template: %w", err)
 	}
 
+	parameters, err := collectParameters(appSet, lister)
+	if err != nil {
+		return nil, err
+	}
+
 	var apps []models.Application
 	seen := make(map[string]bool)
 
-	for i, params := range collectParameters(appSet) {
+	for i, params := range parameters {
 		app, err := renderApplication(string(text), params, appSet.Spec.GoTemplateOptions)
 		if err != nil {
 			return nil, fmt.Errorf("generator element %d: %w", i, err)
@@ -42,17 +48,42 @@ func Expand(appSet *models.ApplicationSet) ([]models.Application, error) {
 }
 
 // collectParameters flattens every generator into the parameter sets that each
-// produce one Application.
-func collectParameters(appSet *models.ApplicationSet) []map[string]any {
-	var params []map[string]any
+// produce one Application. Directories are listed once and shared by every git
+// generator, since they all read the same tree.
+func collectParameters(appSet *models.ApplicationSet, lister DirectoryLister) ([]map[string]any, error) {
+	var (
+		params []map[string]any
+		dirs   []string
+		listed bool
+	)
 
 	for _, generator := range appSet.Spec.Generators {
 		if generator.List != nil {
 			params = append(params, generator.List.Elements...)
 		}
+
+		if generator.Git == nil {
+			continue
+		}
+
+		if lister == nil {
+			return nil, fmt.Errorf("%w: git generators need a repository to list", models.ErrUnsupportedAppConfiguration)
+		}
+
+		if !listed {
+			var err error
+			if dirs, err = lister(); err != nil {
+				return nil, fmt.Errorf("list directories for git generator: %w", err)
+			}
+			listed = true
+		}
+
+		for _, dir := range matchDirectories(dirs, generator.Git.Directories) {
+			params = append(params, directoryParams(dir))
+		}
 	}
 
-	return params
+	return params, nil
 }
 
 // renderApplication turns one parameter set into a validated Application.

--- a/internal/appset/expand_test.go
+++ b/internal/appset/expand_test.go
@@ -48,7 +48,7 @@ spec:
         targetRevision: '{{.revision}}'
 `)
 
-	apps, err := Expand(appSet)
+	apps, err := Expand(appSet, nil)
 	require.NoError(t, err)
 	require.Len(t, apps, 2)
 
@@ -85,7 +85,7 @@ spec:
         targetRevision: 1.0.0
 `)
 
-	apps, err := Expand(appSet)
+	apps, err := Expand(appSet, nil)
 	require.NoError(t, err)
 	require.Len(t, apps, 2)
 	assert.Equal(t, "dev", apps[0].Metadata.Name)
@@ -114,7 +114,7 @@ spec:
         targetRevision: 1.0.0
 `)
 
-	_, err := Expand(appSet)
+	_, err := Expand(appSet, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "duplicate")
 }
@@ -141,7 +141,7 @@ spec:
         targetRevision: 1.0.0
 `)
 
-	_, err := Expand(appSet)
+	_, err := Expand(appSet, nil)
 	assert.ErrorIs(t, err, models.ErrUnsupportedAppConfiguration)
 }
 
@@ -160,7 +160,7 @@ spec:
       name: '{{cluster}}'
 `)
 
-	_, err := Expand(appSet)
+	_, err := Expand(appSet, nil)
 	assert.ErrorIs(t, err, models.ErrUnsupportedAppConfiguration)
 }
 
@@ -189,7 +189,7 @@ spec:
         targetRevision: 1.0.0
 `)
 
-	_, err := Expand(appSet)
+	_, err := Expand(appSet, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing")
 }
@@ -215,7 +215,7 @@ spec:
         targetRevision: '{{ default "1.0.0" .revision }}'
 `)
 
-	apps, err := Expand(appSet)
+	apps, err := Expand(appSet, nil)
 	require.NoError(t, err)
 	require.Len(t, apps, 1)
 	assert.Equal(t, "feature-abc-123", apps[0].Metadata.Name)
@@ -249,7 +249,7 @@ spec:
         targetRevision: 1.0.0
 `)
 
-			_, err := Expand(appSet)
+			_, err := Expand(appSet, nil)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "not defined")
 		})
@@ -277,7 +277,7 @@ spec:
         targetRevision: 1.0.0
 `)
 
-	_, err := Expand(appSet)
+	_, err := Expand(appSet, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "decode generated Application")
 }
@@ -306,7 +306,7 @@ spec:
         targetRevision: 1.0.0
 `)
 
-	_, err := Expand(appSet)
+	_, err := Expand(appSet, nil)
 	assert.ErrorIs(t, err, models.ErrUnsupportedAppConfiguration)
 	assert.Contains(t, err.Error(), "missingkey=bogus")
 }
@@ -329,7 +329,7 @@ spec:
       name: '{{.cluster}}'
 `)
 
-	apps, err := Expand(appSet)
+	apps, err := Expand(appSet, nil)
 	require.NoError(t, err)
 	assert.Empty(t, apps)
 }
@@ -358,7 +358,7 @@ spec:
         targetRevision: 1.0.0
 `)
 
-	_, err := Expand(appSet)
+	_, err := Expand(appSet, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "generator element 1")
 }

--- a/internal/appset/git.go
+++ b/internal/appset/git.go
@@ -1,0 +1,88 @@
+package appset
+
+import (
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/shini4i/argo-compare/internal/models"
+)
+
+// DirectoryLister returns every directory in the tree being expanded, as paths
+// relative to the repository root and separated by "/". It is called only when
+// the ApplicationSet declares a git generator.
+type DirectoryLister func() ([]string, error)
+
+// matchDirectories selects the directories a git generator generates an
+// Application for, sorted so the generated order is stable. A directory is
+// selected when it matches an including entry and no excluding one; ArgoCD
+// gives exclude the higher priority regardless of the order entries appear in.
+func matchDirectories(dirs []string, entries []models.GitDirectory) []string {
+	var matched []string
+
+	for _, dir := range dirs {
+		if hasDotSegment(dir) || !matchesAny(dir, entries, false) || matchesAny(dir, entries, true) {
+			continue
+		}
+		matched = append(matched, dir)
+	}
+
+	sort.Strings(matched)
+
+	return matched
+}
+
+// Matches reports whether a git generator would generate an Application for
+// dir. It tests the patterns directly rather than a directory listing, so a
+// directory a change deleted still matches.
+func Matches(gitGen *models.GitGenerator, dir string) bool {
+	// path.Match("*", "") reports a match, so the empty string is rejected
+	// outright rather than standing in for the repository root.
+	if gitGen == nil || dir == "" || hasDotSegment(dir) {
+		return false
+	}
+
+	return matchesAny(dir, gitGen.Directories, false) && !matchesAny(dir, gitGen.Directories, true)
+}
+
+// matchesAny reports whether dir matches an entry whose Exclude equals exclude.
+// A malformed pattern cannot match, so path.Match's error is not a failure.
+func matchesAny(dir string, entries []models.GitDirectory, exclude bool) bool {
+	for _, entry := range entries {
+		if entry.Exclude != exclude {
+			continue
+		}
+		if ok, err := path.Match(entry.Path, dir); err == nil && ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+// hasDotSegment reports whether any segment of dir starts with a dot, which is
+// how ArgoCD keeps .git and its neighbours from generating Applications.
+func hasDotSegment(dir string) bool {
+	for _, segment := range strings.Split(dir, "/") {
+		if strings.HasPrefix(segment, ".") {
+			return true
+		}
+	}
+
+	return false
+}
+
+// directoryParams builds the parameter set one matched directory renders with,
+// nested so goTemplate reaches it as .path.path, .path.basename and the rest.
+func directoryParams(dir string) map[string]any {
+	basename := path.Base(dir)
+
+	return map[string]any{
+		"path": map[string]any{
+			"path":               dir,
+			"segments":           strings.Split(dir, "/"),
+			"basename":           basename,
+			"basenameNormalized": normalize(basename),
+		},
+	}
+}

--- a/internal/appset/git_test.go
+++ b/internal/appset/git_test.go
@@ -1,0 +1,441 @@
+package appset
+
+import (
+	"testing"
+
+	"github.com/shini4i/argo-compare/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func include(path string) models.GitDirectory {
+	return models.GitDirectory{Path: path}
+}
+
+func exclude(path string) models.GitDirectory {
+	return models.GitDirectory{Path: path, Exclude: true}
+}
+
+func TestMatchDirectories(t *testing.T) {
+	dirs := []string{
+		"apps",
+		"apps/guestbook",
+		"apps/kustomize",
+		"clusters",
+		"clusters/dev",
+		"clusters/prod",
+		"clusters/prod/addons",
+		".github",
+		".github/workflows",
+	}
+
+	tests := []struct {
+		name    string
+		entries []models.GitDirectory
+		want    []string
+	}{
+		{
+			name:    "single level wildcard",
+			entries: []models.GitDirectory{include("clusters/*")},
+			want:    []string{"clusters/dev", "clusters/prod"},
+		},
+		{
+			name:    "root wildcard matches top level only",
+			entries: []models.GitDirectory{include("*")},
+			want:    []string{"apps", "clusters"},
+		},
+		{
+			name:    "exact path",
+			entries: []models.GitDirectory{include("apps/guestbook")},
+			want:    []string{"apps/guestbook"},
+		},
+		{
+			name:    "exclude beats include",
+			entries: []models.GitDirectory{include("clusters/*"), exclude("clusters/prod")},
+			want:    []string{"clusters/dev"},
+		},
+		{
+			name:    "exclude by pattern",
+			entries: []models.GitDirectory{include("apps/*"), exclude("apps/k*")},
+			want:    []string{"apps/guestbook"},
+		},
+		{
+			name:    "exclude wins regardless of order",
+			entries: []models.GitDirectory{exclude("clusters/prod"), include("clusters/*")},
+			want:    []string{"clusters/dev"},
+		},
+		{
+			name:    "several includes are unioned and stay sorted",
+			entries: []models.GitDirectory{include("apps/*"), include("clusters/dev")},
+			want:    []string{"apps/guestbook", "apps/kustomize", "clusters/dev"},
+		},
+		{
+			name:    "no match yields nothing",
+			entries: []models.GitDirectory{include("missing/*")},
+			want:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, matchDirectories(dirs, tt.entries))
+		})
+	}
+}
+
+// TestMatchDirectoriesSkipsDotDirectories pins ArgoCD's behaviour: a directory
+// whose name starts with a dot never generates an Application, so `.git` and
+// `.github` cannot become one.
+func TestMatchDirectoriesSkipsDotDirectories(t *testing.T) {
+	dirs := []string{".github", ".github/workflows", "apps", ".git", ".git/refs"}
+
+	// A root wildcard sees only the ordinary directory.
+	assert.Equal(t, []string{"apps"}, matchDirectories(dirs, []models.GitDirectory{include("*")}))
+
+	// Naming a dot directory outright still does not select it.
+	assert.Empty(t, matchDirectories(dirs, []models.GitDirectory{include(".github")}))
+	assert.Empty(t, matchDirectories(dirs, []models.GitDirectory{include(".github/*")}))
+	assert.Empty(t, matchDirectories(dirs, []models.GitDirectory{include(".git/refs")}))
+}
+
+func TestDirectoryParams(t *testing.T) {
+	params := directoryParams("clusters/eu-west-1/Prod_Cluster")
+
+	path, ok := params["path"].(map[string]any)
+	require.True(t, ok, "path must be a nested map for goTemplate access")
+
+	assert.Equal(t, "clusters/eu-west-1/Prod_Cluster", path["path"])
+	assert.Equal(t, []string{"clusters", "eu-west-1", "Prod_Cluster"}, path["segments"])
+	assert.Equal(t, "Prod_Cluster", path["basename"])
+	assert.Equal(t, "prod-cluster", path["basenameNormalized"])
+}
+
+func TestDirectoryParamsAtRepositoryRoot(t *testing.T) {
+	params := directoryParams("guestbook")
+
+	path, ok := params["path"].(map[string]any)
+	require.True(t, ok, "path must be a nested map for goTemplate access")
+	assert.Equal(t, "guestbook", path["path"])
+	assert.Equal(t, []string{"guestbook"}, path["segments"])
+	assert.Equal(t, "guestbook", path["basename"])
+}
+
+const gitAppSet = `
+kind: ApplicationSet
+metadata:
+  name: cluster-addons
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - git:
+        repoURL: https://github.com/shini4i/argo-compare.git
+        revision: HEAD
+        directories:
+          - path: clusters/*
+          - path: clusters/donotdeploy
+            exclude: true
+  template:
+    metadata:
+      name: '{{ .path.basenameNormalized }}'
+    spec:
+      source:
+        repoURL: https://charts.example.com
+        chart: guestbook
+        targetRevision: 1.0.0
+        helm:
+          valueFiles:
+            - '{{ .path.path }}/values.yaml'
+`
+
+func TestExpandGitDirectoryGenerator(t *testing.T) {
+	appSet := mustParse(t, gitAppSet)
+
+	apps, err := Expand(appSet, func() ([]string, error) {
+		return []string{"clusters", "clusters/dev", "clusters/prod", "clusters/donotdeploy", "apps/other"}, nil
+	})
+	require.NoError(t, err)
+	require.Len(t, apps, 2)
+
+	assert.Equal(t, "dev", apps[0].Metadata.Name)
+	assert.Equal(t, []string{"clusters/dev/values.yaml"}, apps[0].Spec.Source.Helm.ValueFiles)
+	assert.Equal(t, "prod", apps[1].Metadata.Name)
+}
+
+// TestExpandListsDirectoriesOnceForSeveralGitGenerators keeps a manifest with
+// two git generators from walking the tree twice; both read the same tree.
+func TestExpandListsDirectoriesOnceForSeveralGitGenerators(t *testing.T) {
+	appSet := mustParse(t, `
+kind: ApplicationSet
+metadata:
+  name: cluster-addons
+spec:
+  goTemplate: true
+  generators:
+    - git:
+        repoURL: https://example.com/repo.git
+        directories:
+          - path: apps/*
+    - git:
+        repoURL: https://example.com/repo.git
+        directories:
+          - path: clusters/*
+  template:
+    metadata:
+      name: '{{ .path.basename }}'
+    spec:
+      source:
+        repoURL: https://charts.example.com
+        chart: guestbook
+        targetRevision: 1.0.0
+`)
+
+	calls := 0
+	apps, err := Expand(appSet, func() ([]string, error) {
+		calls++
+		return []string{"apps/one", "clusters/two"}, nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+	require.Len(t, apps, 2)
+	assert.Equal(t, "one", apps[0].Metadata.Name)
+	assert.Equal(t, "two", apps[1].Metadata.Name)
+}
+
+func TestExpandRequiresAListerForGitGenerators(t *testing.T) {
+	appSet := mustParse(t, gitAppSet)
+
+	_, err := Expand(appSet, nil)
+	assert.ErrorIs(t, err, models.ErrUnsupportedAppConfiguration)
+}
+
+func TestExpandPropagatesListerErrors(t *testing.T) {
+	appSet := mustParse(t, gitAppSet)
+
+	_, err := Expand(appSet, func() ([]string, error) {
+		return nil, assert.AnError
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "list directories for git generator")
+}
+
+// TestExpandDoesNotListForListGenerators keeps a list-only manifest from
+// paying for a tree walk it has no use for.
+func TestExpandDoesNotListForListGenerators(t *testing.T) {
+	appSet := mustParse(t, `
+kind: ApplicationSet
+metadata:
+  name: guestbook
+spec:
+  goTemplate: true
+  generators:
+    - list:
+        elements:
+          - cluster: dev
+  template:
+    metadata:
+      name: '{{ .cluster }}'
+    spec:
+      source:
+        repoURL: https://charts.example.com
+        chart: guestbook
+        targetRevision: 1.0.0
+`)
+
+	called := false
+	_, err := Expand(appSet, func() ([]string, error) {
+		called = true
+		return nil, nil
+	})
+
+	require.NoError(t, err)
+	assert.False(t, called)
+}
+
+// TestMatches covers the gate that decides whether a directory change reaches
+// the comparison at all. A regression here drops ApplicationSets silently.
+func TestMatches(t *testing.T) {
+	tests := []struct {
+		name   string
+		gitGen *models.GitGenerator
+		dir    string
+		want   bool
+	}{
+		{name: "nil generator", gitGen: nil, dir: "clusters/dev"},
+		{name: "no entries", gitGen: &models.GitGenerator{}, dir: "clusters/dev"},
+		{
+			name:   "wildcard matches one level",
+			gitGen: &models.GitGenerator{Directories: []models.GitDirectory{include("clusters/*")}},
+			dir:    "clusters/dev",
+			want:   true,
+		},
+		{
+			name:   "wildcard does not cross a separator",
+			gitGen: &models.GitGenerator{Directories: []models.GitDirectory{include("clusters/*")}},
+			dir:    "clusters/prod/addons",
+		},
+		{
+			name:   "exact path with no wildcard",
+			gitGen: &models.GitGenerator{Directories: []models.GitDirectory{include("apps/guestbook")}},
+			dir:    "apps/guestbook",
+			want:   true,
+		},
+		{
+			name:   "exact path does not match a child",
+			gitGen: &models.GitGenerator{Directories: []models.GitDirectory{include("apps/guestbook")}},
+			dir:    "apps/guestbook/sub",
+		},
+		{
+			name:   "exclude wins",
+			gitGen: &models.GitGenerator{Directories: []models.GitDirectory{include("clusters/*"), exclude("clusters/prod")}},
+			dir:    "clusters/prod",
+		},
+		{
+			name:   "exclude wins regardless of order",
+			gitGen: &models.GitGenerator{Directories: []models.GitDirectory{exclude("clusters/prod"), include("clusters/*")}},
+			dir:    "clusters/prod",
+		},
+		{
+			name:   "exclude only never matches",
+			gitGen: &models.GitGenerator{Directories: []models.GitDirectory{exclude("clusters/prod")}},
+			dir:    "clusters/dev",
+		},
+		{
+			name:   "dot segment is never generated",
+			gitGen: &models.GitGenerator{Directories: []models.GitDirectory{include(".github")}},
+			dir:    ".github",
+		},
+		{
+			name:   "dot segment anywhere in the path",
+			gitGen: &models.GitGenerator{Directories: []models.GitDirectory{include("apps/*/x")}},
+			dir:    "apps/.hidden/x",
+		},
+		{
+			name:   "empty directory",
+			gitGen: &models.GitGenerator{Directories: []models.GitDirectory{include("*")}},
+			dir:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, Matches(tt.gitGen, tt.dir))
+		})
+	}
+}
+
+// TestMatchDirectoriesPatternShapes pins the shapes users most often get wrong.
+func TestMatchDirectoriesPatternShapes(t *testing.T) {
+	dirs := []string{"apps", "apps/guestbook", "apps/kustomize", "clusters", "clusters/dev", "clusters/prod", "clusters/prod/addons"}
+
+	tests := []struct {
+		name    string
+		entries []models.GitDirectory
+		want    []string
+	}{
+		{
+			// `**` is not recursive: path.Match gives it the same meaning as `*`.
+			name:    "double star is not recursive",
+			entries: []models.GitDirectory{include("clusters/**")},
+			want:    []string{"clusters/dev", "clusters/prod"},
+		},
+		{
+			name:    "trailing slash matches nothing",
+			entries: []models.GitDirectory{include("clusters/*/")},
+			want:    nil,
+		},
+		{
+			name:    "malformed include matches nothing",
+			entries: []models.GitDirectory{include("clusters/[")},
+			want:    nil,
+		},
+		{
+			// A malformed exclude cannot exclude, so the includes stand.
+			name:    "malformed exclude excludes nothing",
+			entries: []models.GitDirectory{include("clusters/*"), exclude("clusters/[")},
+			want:    []string{"clusters/dev", "clusters/prod"},
+		},
+		{
+			name:    "overlapping includes yield each directory once",
+			entries: []models.GitDirectory{include("apps/*"), include("apps/guestbook")},
+			want:    []string{"apps/guestbook", "apps/kustomize"},
+		},
+		{
+			name:    "no entries",
+			entries: nil,
+			want:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, matchDirectories(dirs, tt.entries))
+		})
+	}
+}
+
+// TestExpandRejectsDuplicateNamesFromGitDirectories covers the collision the
+// idiomatic `{{ .path.basename }}` name template invites.
+func TestExpandRejectsDuplicateNamesFromGitDirectories(t *testing.T) {
+	appSet := mustParse(t, `
+kind: ApplicationSet
+metadata:
+  name: cluster-addons
+spec:
+  goTemplate: true
+  generators:
+    - git:
+        repoURL: https://example.com/repo.git
+        directories:
+          - path: apps/*
+          - path: clusters/*
+  template:
+    metadata:
+      name: '{{ .path.basename }}'
+    spec:
+      source:
+        repoURL: https://charts.example.com
+        chart: guestbook
+        targetRevision: 1.0.0
+`)
+
+	_, err := Expand(appSet, func() ([]string, error) {
+		return []string{"apps/dev", "clusters/dev"}, nil
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate")
+}
+
+// TestExpandRejectsNormalizationCollisions proves basenameNormalized collapses
+// distinct directories into one name, which must still be caught.
+func TestExpandRejectsNormalizationCollisions(t *testing.T) {
+	appSet := mustParse(t, `
+kind: ApplicationSet
+metadata:
+  name: cluster-addons
+spec:
+  goTemplate: true
+  generators:
+    - git:
+        repoURL: https://example.com/repo.git
+        directories:
+          - path: clusters/*
+  template:
+    metadata:
+      name: '{{ .path.basenameNormalized }}'
+    spec:
+      source:
+        repoURL: https://charts.example.com
+        chart: guestbook
+        targetRevision: 1.0.0
+`)
+
+	_, err := Expand(appSet, func() ([]string, error) {
+		return []string{"clusters/eu-west-1", "clusters/eu_west_1"}, nil
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate")
+}

--- a/internal/models/applicationset.go
+++ b/internal/models/applicationset.go
@@ -19,6 +19,7 @@ var ErrNotApplicationSet = errors.New("file is not an ApplicationSet")
 // access this tool deliberately does not have.
 var supportedGenerators = map[string]bool{
 	"list": true,
+	"git":  true,
 }
 
 // ApplicationSet models the subset of ArgoCD ApplicationSet fields needed to
@@ -47,6 +48,32 @@ type ApplicationSetSpec struct {
 type Generator struct {
 	Kinds []string
 	List  *ListGenerator
+	Git   *GitGenerator
+}
+
+// GitGenerator mirrors the git generator. Files and Values are decoded only to
+// be rejected: both add parameters, so ignoring them would produce a diff that
+// does not match ArgoCD.
+type GitGenerator struct {
+	RepoURL         string            `yaml:"repoURL"`
+	Revision        string            `yaml:"revision"`
+	Directories     []GitDirectory    `yaml:"directories"`
+	PathParamPrefix string            `yaml:"pathParamPrefix"`
+	Files           []GitFile         `yaml:"files"`
+	Values          map[string]string `yaml:"values"`
+	Template        yaml.Node         `yaml:"template"`
+}
+
+// GitDirectory is one entry of a git generator's directories list. Exclude
+// entries take priority over the including ones, matching ArgoCD.
+type GitDirectory struct {
+	Path    string `yaml:"path"`
+	Exclude bool   `yaml:"exclude"`
+}
+
+// GitFile is one entry of a git generator's files list.
+type GitFile struct {
+	Path string `yaml:"path"`
 }
 
 // ListGenerator mirrors the static list generator. ElementsYaml and Template
@@ -68,12 +95,19 @@ func (g *Generator) UnmarshalYAML(value *yaml.Node) error {
 		key := value.Content[i].Value
 		g.Kinds = append(g.Kinds, key)
 
-		if key == "list" {
+		switch key {
+		case "list":
 			var list ListGenerator
 			if err := value.Content[i+1].Decode(&list); err != nil {
 				return fmt.Errorf("decode list generator: %w", err)
 			}
 			g.List = &list
+		case "git":
+			var gitGen GitGenerator
+			if err := value.Content[i+1].Decode(&gitGen); err != nil {
+				return fmt.Errorf("decode git generator: %w", err)
+			}
+			g.Git = &gitGen
 		}
 	}
 
@@ -118,19 +152,58 @@ func (appSet *ApplicationSet) validateGenerators() error {
 	}
 
 	for _, generator := range appSet.Spec.Generators {
-		if len(generator.Kinds) != 1 {
-			return fmt.Errorf("%w: each entry of spec.generators must declare exactly one generator, got [%s]",
-				ErrUnsupportedAppConfiguration, strings.Join(generator.Kinds, ", "))
+		if err := validateGenerator(generator); err != nil {
+			return err
 		}
+	}
 
-		if kind := generator.Kinds[0]; !supportedGenerators[kind] {
-			return fmt.Errorf("%w: generator %q is not supported", ErrUnsupportedAppConfiguration, kind)
-		}
+	return nil
+}
 
-		if generator.List != nil {
-			if err := validateListGenerator(generator.List); err != nil {
-				return err
-			}
+// validateGenerator checks one spec.generators entry: exactly one kind, a
+// supported one, and no field of it that argo-compare cannot reproduce.
+func validateGenerator(generator Generator) error {
+	if len(generator.Kinds) != 1 {
+		return fmt.Errorf("%w: each entry of spec.generators must declare exactly one generator, got [%s]",
+			ErrUnsupportedAppConfiguration, strings.Join(generator.Kinds, ", "))
+	}
+
+	if kind := generator.Kinds[0]; !supportedGenerators[kind] {
+		return fmt.Errorf("%w: generator %q is not supported", ErrUnsupportedAppConfiguration, kind)
+	}
+
+	if generator.List != nil {
+		return validateListGenerator(generator.List)
+	}
+
+	if generator.Git != nil {
+		return validateGitGenerator(generator.Git)
+	}
+
+	return nil
+}
+
+// validateGitGenerator accepts a directory generator and rejects the fields
+// that would change the generated Applications without being reproduced here.
+func validateGitGenerator(gitGen *GitGenerator) error {
+	switch {
+	case gitGen.RepoURL == "":
+		return fmt.Errorf("%w: git generator requires repoURL", ErrUnsupportedAppConfiguration)
+	case len(gitGen.Files) > 0:
+		return fmt.Errorf("%w: git generator field 'files' is not supported yet; only 'directories' is", ErrUnsupportedAppConfiguration)
+	case len(gitGen.Directories) == 0:
+		return fmt.Errorf("%w: git generator requires at least one 'directories' entry", ErrUnsupportedAppConfiguration)
+	case len(gitGen.Values) > 0:
+		return fmt.Errorf("%w: git generator field 'values' is not supported", ErrUnsupportedAppConfiguration)
+	case gitGen.PathParamPrefix != "":
+		return fmt.Errorf("%w: git generator field 'pathParamPrefix' is not supported; it would nest the path parameters", ErrUnsupportedAppConfiguration)
+	case !gitGen.Template.IsZero():
+		return fmt.Errorf("%w: generator-level template overrides are not supported", ErrUnsupportedAppConfiguration)
+	}
+
+	for _, dir := range gitGen.Directories {
+		if dir.Path == "" {
+			return fmt.Errorf("%w: every git generator 'directories' entry requires a path", ErrUnsupportedAppConfiguration)
 		}
 	}
 

--- a/internal/models/applicationset_test.go
+++ b/internal/models/applicationset_test.go
@@ -240,3 +240,173 @@ spec:
 		})
 	}
 }
+
+func TestApplicationSetValidateAcceptsGitDirectoryGenerator(t *testing.T) {
+	appSet := parseAppSet(t, `
+kind: ApplicationSet
+metadata:
+  name: cluster-addons
+spec:
+  goTemplate: true
+  generators:
+    - git:
+        repoURL: https://github.com/shini4i/argo-compare.git
+        revision: HEAD
+        directories:
+          - path: clusters/*
+          - path: clusters/donotdeploy
+            exclude: true
+  template:
+    metadata:
+      name: '{{ .path.basename }}'
+    spec:
+      source:
+        repoURL: https://charts.example.com
+        chart: guestbook
+        targetRevision: 1.0.0
+`)
+
+	require.NoError(t, appSet.Validate())
+
+	gitGen := appSet.Spec.Generators[0].Git
+	require.NotNil(t, gitGen)
+	require.Len(t, gitGen.Directories, 2)
+	assert.Equal(t, "clusters/*", gitGen.Directories[0].Path)
+	assert.False(t, gitGen.Directories[0].Exclude)
+	assert.True(t, gitGen.Directories[1].Exclude)
+}
+
+func TestApplicationSetValidateRejectsUnsupportedGitFields(t *testing.T) {
+	tests := []struct {
+		name       string
+		generator  string
+		wantErrMsg string
+	}{
+		{
+			name: "files",
+			generator: `
+        repoURL: https://example.com/repo.git
+        files:
+          - path: "clusters/**/config.json"`,
+			wantErrMsg: "'files' is not supported yet",
+		},
+		{
+			name: "pathParamPrefix",
+			generator: `
+        repoURL: https://example.com/repo.git
+        directories:
+          - path: 'clusters/*'
+        pathParamPrefix: mycluster`,
+			wantErrMsg: "'pathParamPrefix' is not supported",
+		},
+		{
+			name: "values",
+			generator: `
+        repoURL: https://example.com/repo.git
+        directories:
+          - path: 'clusters/*'
+        values:
+          base_dir: "{{ .path.path }}"`,
+			wantErrMsg: "'values' is not supported",
+		},
+		{
+			name: "missing repoURL",
+			generator: `
+        directories:
+          - path: 'clusters/*'`,
+			wantErrMsg: "requires repoURL",
+		},
+		{
+			name: "no directories",
+			generator: `
+        repoURL: https://example.com/repo.git`,
+			wantErrMsg: "at least one 'directories' entry",
+		},
+		{
+			name: "directory without a path",
+			generator: `
+        repoURL: https://example.com/repo.git
+        directories:
+          - exclude: true`,
+			wantErrMsg: "requires a path",
+		},
+		{
+			name: "generator level template override",
+			generator: `
+        repoURL: https://example.com/repo.git
+        directories:
+          - path: 'clusters/*'
+        template:
+          metadata:
+            name: override`,
+			wantErrMsg: "generator-level template",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			appSet := parseAppSet(t, `
+kind: ApplicationSet
+metadata:
+  name: cluster-addons
+spec:
+  goTemplate: true
+  generators:
+    - git:`+tt.generator+`
+  template:
+    metadata:
+      name: '{{ .path.basename }}'
+`)
+
+			err := appSet.Validate()
+			assert.ErrorIs(t, err, ErrUnsupportedAppConfiguration)
+			assert.Contains(t, err.Error(), tt.wantErrMsg)
+		})
+	}
+}
+
+// TestApplicationSetGitGeneratorDecodeError pins that a malformed git generator
+// is a decode error, not the warn-and-skip an unsupported one gets.
+func TestApplicationSetGitGeneratorDecodeError(t *testing.T) {
+	var appSet ApplicationSet
+	err := yaml.Unmarshal([]byte(`
+kind: ApplicationSet
+spec:
+  generators:
+    - git: "not-a-mapping"
+`), &appSet)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decode git generator")
+	assert.NotErrorIs(t, err, ErrUnsupportedAppConfiguration)
+}
+
+// TestApplicationSetKeepsGitRevision proves revision survives decoding. Whether
+// a given revision can be compared is decided in the app layer, which knows the
+// target branch; see assertGitGeneratorsComparable.
+func TestApplicationSetKeepsGitRevision(t *testing.T) {
+	appSet := parseAppSet(t, `
+kind: ApplicationSet
+metadata:
+  name: cluster-addons
+spec:
+  goTemplate: true
+  generators:
+    - git:
+        repoURL: https://example.com/repo.git
+        revision: v1.2.3
+        directories:
+          - path: 'clusters/*'
+  template:
+    metadata:
+      name: '{{ .path.basename }}'
+    spec:
+      source:
+        repoURL: https://charts.example.com
+        chart: demo
+        targetRevision: 1.0.0
+`)
+
+	require.NoError(t, appSet.Validate())
+	assert.Equal(t, "v1.2.3", appSet.Spec.Generators[0].Git.Revision)
+}


### PR DESCRIPTION
Adds the git directory generator. Second PR of the stack — based on `feat/applicationset-support` (#161), not on `main`.

## What it does

A git generator makes one Application per directory matching its patterns:

```yaml
generators:
  - git:
      repoURL: https://github.com/you/your-repo.git
      revision: HEAD
      directories:
        - path: clusters/*
        - path: clusters/donotdeploy
          exclude: true
```

Templates get `.path.path`, `.path.segments`, `.path.basename` and `.path.basenameNormalized`. Exclude entries beat including ones whatever order they appear in. Directories starting with a dot never generate an Application.

## Directory changes are detected on their own

Adding or deleting a directory is what usually changes the output. That leaves the ApplicationSet manifest untouched, so waiting for a manifest edit would mean the generator almost never fires.

argo-compare now scans the repository for ApplicationSets with git generators and compares any whose patterns cover a directory the change touched. Nobody has to edit the manifest.

Matching tests the patterns directly, not a directory listing. A deleted directory is gone from the tree, so a listing-based check would miss every removal.

## Both legs read a Git tree

The branch leg lists the HEAD tree, the target leg the merge-base tree.

An earlier version listed the working tree for the branch leg. That counts untracked and gitignored directories, which Git does not record — `bin/` or a local scratch directory would have been reported as a new Application that ArgoCD would never create.

## What is refused

Each of these is skipped with the reason named. The run still succeeds and other manifests are still compared.

- `repoURL` naming another repository. Both legs would read the same external tree, so only edits to the ApplicationSet itself could ever show up.
- `revision` pinning anything but HEAD or the compared branch. ArgoCD keeps generating from that fixed tree, so a directory this branch adds changes nothing it deploys — reporting a new Application would be a false positive.
- `files`, `values`, `pathParamPrefix`. `files` is the next PR; the other two change the parameter shape.

## Cost

The scan reads every YAML in the repository once per run, behind a byte-level filter and a 1 MiB size bound, skipping dot directories. An unreadable file or directory is skipped rather than failing the run.