### PR TITLE
feat(appset): compare ApplicationSets named by an anchor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- A `.argo-compare.yml` anchor may point at an ApplicationSet, not only an Application. Each Application it generates is compared in turn, added and removed ones included. Only the generated Applications rendering a chart from this repository are compared; a registry chart or a source in another repository is skipped with the reason named. This is the only way to reach an ApplicationSet stored in a different repository, which the repository scan cannot see. See [Anchored repositories](docs/anchored-repositories.md).
 - The ApplicationSet template functions ArgoCD adds on top of Sprig: `slugify`, `toYaml`, `fromYaml` and `fromYamlArray`, alongside the existing `normalize`. A manifest using one no longer fails with `function "…" not defined`.
 - ApplicationSet templates are now rendered field by field, the way ArgoCD does it, instead of over the manifest as a whole. A rendered value can therefore contain quotes, newlines or indentation without altering how the Application parses; `toYaml` needs no `nindent` ceremony, and `nindent` means the column you wrote.
 - ApplicationSet git **file** generator. One Application per file matching the generator's patterns, with the file's own contents as parameters, plus `.path.filename` and `.path.filenameNormalized`. A file holding a list generates one Application per element, and JSON files work as well as YAML. File patterns match with `doublestar`, so `**` recurses — unlike a `directories` pattern. Editing a config file is detected on its own, without the manifest changing.
@@ -20,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Manifests skipped for an unsupported configuration now log why they were skipped, instead of only naming the file.
 - Cross-repo anchored Applications now fail with a clear, actionable error when the pull request restructures a chart's values files (for example splitting one `values.yaml` into several) but the Application — read from the anchored repo's branch tip — still references the old layout. Previously this surfaced as an opaque `helm template` "no such file" error. See `docs/anchored-repositories.md` for the workaround.
+
+### Fixed
+
+- Several chart directories anchored to the same Application are now compared once rather than once per anchor, which previously repeated the whole diff and posted a duplicate merge request comment for it.
 
 ## [0.9.2] - 2026-07-08
 

--- a/docs/anchored-repositories.md
+++ b/docs/anchored-repositories.md
@@ -1,6 +1,6 @@
 # Anchored repositories (path-based sources)
 
-The default flow assumes the modified file in a PR _is_ the Application YAML. Some repositories split things up: the ArgoCD Application points at a chart directory inside the same repo (`spec.source.path`), or lives in a different repo that consumes a chart from this one. In both cases a PR typically touches chart values rather than the Application itself, so there is no `kind: Application` in the diff and the default flow finds nothing to compare.
+The default flow assumes the modified file in a PR _is_ the Application YAML. Some repositories split things up: the ArgoCD Application points at a chart directory inside the same repo (`spec.source.path`), or lives in a different repo that consumes a chart from this one. In both cases a PR typically touches chart values rather than the Application itself, so there is no `kind: Application` in the diff and the default flow finds nothing to compare. The same is true when an ApplicationSet stands in for the Application.
 
 To bridge that gap, drop a `.argo-compare.yml` file into any directory that holds chart content. Argo Compare walks up from each changed file (excluding the anchor file itself), picks the nearest enclosing anchor, and uses it to find the Application affected by the change:
 
@@ -10,7 +10,7 @@ application:
   # Optional. Omit when the Application lives in this same repo.
   # Prefer https:// so the same anchor works in CI (PAT auth — see below).
   repo: https://example.com/group/apps.git
-  # Required. Path to the Application YAML inside that repo.
+  # Required. Path to the Application or ApplicationSet YAML inside that repo.
   path: cluster-state/myapp/myapp.yaml
   # Optional. Defaults to the remote's default branch.
   branch: main
@@ -22,10 +22,24 @@ Changes that only touch `.argo-compare.yml` — adding the marker during onboard
 
 Two layouts work out of the box:
 
-- **Same-repo / all-in-one** — Application and chart live in the same repo. Drop a `.argo-compare.yml` next to the chart, omit `repo`, and point `path` at the Application YAML inside this repo.
-- **Manifest-only repo** — chart content lives here, Application lives elsewhere. Drop a `.argo-compare.yml` next to the chart, set `repo` to the apps repo, and point `path` at the Application YAML inside it.
+- **Same-repo / all-in-one** — Application and chart live in the same repo. Drop a `.argo-compare.yml` next to the chart, omit `repo`, and point `path` at the Application or ApplicationSet YAML inside this repo.
+- **Manifest-only repo** — chart content lives here, Application lives elsewhere. Drop a `.argo-compare.yml` next to the chart, set `repo` to the apps repo, and point `path` at the Application or ApplicationSet YAML inside it.
 
 A worked example lives under [`examples/anchor/`](../examples/anchor).
+
+## Anchoring an ApplicationSet
+
+`path` may name an ApplicationSet instead of an Application. Argo Compare then expands it into the Applications it generates and compares each one, exactly as the [ApplicationSet flow](applicationsets.md) does for a changed manifest — added and removed Applications included.
+
+The manifest is read once, at the anchor's branch tip: an anchor exists because the *chart* changed, not the manifest. Each comparison leg still expands that manifest against its own tree, so a directory a git generator picks up — or a file it takes parameters from — is read from this branch for one leg and from the merge-base for the other.
+
+This matters most for a cross-repo anchor. Argo Compare scans the local repository for ApplicationSets whose git generators cover a changed directory, but it cannot scan a repository it does not have; an anchor is the only way to reach an ApplicationSet that lives elsewhere.
+
+Because expansion reads the two local branch legs, a git generator must name the repository being compared. One pointing anywhere else is a hard error rather than a skip — an anchor is an explicit pointer, so ignoring it would leave the change it names uncompared with nothing said.
+
+Only the generated Applications that render a chart from this repository are compared. One with a registry chart, or with a `spec.source.path` belonging to a different repository, is skipped with the reason named: neither can be affected by the change under the anchor, and rendering the latter would diff this repository's content against another repository's Application. If no generated Application qualifies, that is an error for the same reason a foreign generator is.
+
+Several chart directories may share one anchored manifest. It is compared once, not once per anchor.
 
 ## Limits in this version
 
@@ -38,8 +52,9 @@ A worked example lives under [`examples/anchor/`](../examples/anchor).
 - A multi-source Application must use one kind consistently; mixing `chart` and `path` entries is rejected.
 - The anchored Application is read at the configured branch tip; commit-pinning is not supported.
 - **Cross-repo anchors cannot see an unmerged Application change.** For a cross-repo anchor (`repo:` set), the chart is read from the pull request's working tree while the Application — including its `spec.source.helm.valueFiles` list — is read from the anchored repo's branch tip. If the same change set restructures the files the Application points at (for example, splitting one `values.yaml` into several), the two halves are out of sync: the working tree has the new layout, but the Application still references the old one. This is inherent — the corrected `valueFiles` list lives in a separate, not-yet-merged change in the anchored repo, which argo-compare cannot see from this repo's PR. When a referenced values file is missing from the working tree, argo-compare fails with an explicit error naming the mismatch rather than an opaque Helm error. **Workaround:** land the Application's `valueFiles` update in the anchored repo first (or in lockstep), so the branch tip and the chart layout agree. Same-repo anchors are unaffected — they read both the chart and the Application from the working tree.
-- If the anchored chart directory does not exist in the target branch (it was added for the first time on the current branch), the Application is treated as new rather than failing: the comparison is skipped, or with `--print-added-manifests` the current branch's manifests render as all-added. This mirrors the standard flow's handling of a newly added Application file.
-- Any other failure to fetch, parse, or validate an anchored Application is a hard error — partial output would silently hide a broken configuration.
+- If the anchored chart directory does not exist in the target branch (it was added for the first time on the current branch), the Application is treated as new rather than failing: the comparison is skipped, or with `--print-added-manifests` the current branch's manifests render as all-added. This mirrors the standard flow's handling of a newly added Application file, and applies to a generated Application the same way.
+- An anchored ApplicationSet is subject to every limit in [ApplicationSets](applicationsets.md): `goTemplate: true` only, `list` and `git` generators only, and no generator-level template overrides.
+- Any other failure to fetch, parse, or validate an anchored Application or ApplicationSet is a hard error — partial output would silently hide a broken configuration.
 
 ## Configuration
 

--- a/docs/anchored-repositories.md
+++ b/docs/anchored-repositories.md
@@ -39,6 +39,8 @@ Because expansion reads the two local branch legs, a git generator must name the
 
 Only the generated Applications that render a chart from this repository are compared. One with a registry chart, or with a `spec.source.path` belonging to a different repository, is skipped with the reason named: neither can be affected by the change under the anchor, and rendering the latter would diff this repository's content against another repository's Application. If no generated Application qualifies, that is an error for the same reason a foreign generator is.
 
+Each branch is judged separately. An Application that moves into this repository on your branch — say from a registry chart to a local path — is still compared on the side that reads the chart here, and reported as added or removed accordingly.
+
 Several chart directories may share one anchored manifest. It is compared once, not once per anchor.
 
 ## Limits in this version

--- a/docs/applicationsets.md
+++ b/docs/applicationsets.md
@@ -116,6 +116,10 @@ output**, and that leaves the ApplicationSet manifest untouched. So
 generators and compares any whose patterns cover a directory or file your
 change touched.
 
+That scan covers only this repository. To reach an ApplicationSet that lives in
+another one, point a `.argo-compare.yml` at it — see
+[Anchoring an ApplicationSet](anchored-repositories.md#anchoring-an-applicationset).
+
 ### repoURL must be this repository
 
 A generator reading another repository is skipped with a warning. Both sides of

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -80,9 +80,11 @@ contains:
 
 3. **Anchor flow** — the PR modifies chart content (e.g. Helm values)
    rather than an Application YAML. `argo-compare` walks up to the
-   nearest `.argo-compare.yml`, resolves the referenced Application, and
-   renders the chart twice (working tree vs. merge-base). Driver code
-   lives in `internal/app/anchor_discovery.go`, `anchor_flow.go`,
+   nearest `.argo-compare.yml` and resolves the manifest it references.
+   An Application is rendered from the chart twice (working tree vs.
+   merge-base); an ApplicationSet is expanded per leg and handed to the
+   ApplicationSet flow's per-Application comparison. Driver code lives in
+   `internal/app/anchor_discovery.go`, `anchor_flow.go`,
    `tree_materialize.go`. The anchor schema itself is in
    `internal/anchor`.
 

--- a/examples/anchor/README.md
+++ b/examples/anchor/README.md
@@ -48,3 +48,7 @@ chart content), argo-compare walks up to the nearest
 in-memory clone for cross-repo), and renders the chart twice — once
 against the working tree (post-PR state) and once against the
 merge-base (pre-PR state) — before producing the diff.
+
+`path` may also name an ApplicationSet, in which case each Application it
+generates is compared in turn. See
+[Anchoring an ApplicationSet](../../docs/anchored-repositories.md#anchoring-an-applicationset).

--- a/internal/app/anchor_appset_integration_test.go
+++ b/internal/app/anchor_appset_integration_test.go
@@ -1,0 +1,577 @@
+package app
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/shini4i/argo-compare/internal/models"
+	"github.com/shini4i/argo-compare/internal/ports"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// anchoredAppSetYAML is a list-generator ApplicationSet whose template renders
+// path-based Applications out of charts/demo, the directory the anchor sits in.
+const anchoredAppSetYAML = `apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: demo
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - list:
+        elements:
+          - cluster: dev
+          - cluster: prod
+  template:
+    metadata:
+      name: '{{ .cluster }}-demo'
+      namespace: argocd
+    spec:
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: '{{ .cluster }}'
+      source:
+        repoURL: ORIGIN_URL
+        path: charts/demo
+        targetRevision: HEAD
+        helm:
+          releaseName: '{{ .cluster }}-demo'
+          values: 'cluster: {{ .cluster }}'
+`
+
+// anchoredChartFiles is the chart the anchored ApplicationSet renders, with the
+// anchor file that points changes under it back at the manifest.
+func anchoredChartFiles(replicas string) map[string]string {
+	return map[string]string{
+		"charts/demo/Chart.yaml":         "apiVersion: v2\nname: demo\nversion: 0.0.1\n",
+		"charts/demo/values.yaml":        "replicaCount: " + replicas + "\n",
+		"charts/demo/templates/dep.yaml": "kind: Deployment\n",
+		"charts/demo/.argo-compare.yml":  "application:\n  path: " + appSetPath + "\n",
+	}
+}
+
+// TestAppRunAnchoredApplicationSet is the gap this flow closes: the change is a
+// chart value, the manifest it feeds is an ApplicationSet, and the anchor is
+// the only thing tying the two together.
+func TestAppRunAnchoredApplicationSet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip integration test in short mode")
+	}
+
+	seedAppSetRepoState(t,
+		branchState{manifest: anchoredAppSetYAML, files: anchoredChartFiles("1")},
+		branchState{manifest: anchoredAppSetYAML, files: anchoredChartFiles("7")})
+
+	runner := newAppSetRunner(t, Config{AnchorFileName: DefaultAnchorFileName}, nil)
+	require.NoError(t, runner.app.Run(context.Background()))
+
+	output := runner.log.String()
+
+	assert.Contains(t, output, "Processing anchored chart")
+	assert.Contains(t, output, "===> Comparing generated Application: [dev-demo]")
+	assert.Contains(t, output, "===> Comparing generated Application: [prod-demo]")
+	// The chart differs only in a value the Helm stub does not read, so the
+	// comparison is expected to report no diff — what is under test is that
+	// each generated Application reaches it at all.
+	assert.Contains(t, output, "No diff was found in rendered manifests!")
+
+	// Both generated Applications exist on both branches, so each renders twice.
+	assert.Equal(t, 4, runner.helm.callCount("RenderAppSource"))
+	assert.Equal(t, 0, runner.helm.callCount("DownloadHelmChart"), "a path-based source must not trigger helm pull")
+
+	runner.assertTempDirsRemoved(t)
+}
+
+// foreignGeneratorAppSetYAML anchors an ApplicationSet whose git generator
+// reads a repository argo-compare has no tree for.
+const foreignGeneratorAppSetYAML = `apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: demo
+  namespace: argocd
+spec:
+  goTemplate: true
+  generators:
+    - git:
+        repoURL: https://elsewhere.example.com/group/other.git
+        revision: HEAD
+        directories:
+          - path: clusters/*
+  template:
+    metadata:
+      name: '{{ .path.basename }}-demo'
+      namespace: argocd
+    spec:
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: demo
+      source:
+        repoURL: ORIGIN_URL
+        path: charts/demo
+        targetRevision: HEAD
+`
+
+// TestAppRunAnchoredApplicationSet_ForeignGenerator proves an anchor naming an
+// ApplicationSet this repository cannot expand fails instead of comparing
+// nothing: the user asked for that manifest explicitly.
+func TestAppRunAnchoredApplicationSet_ForeignGenerator(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip integration test in short mode")
+	}
+
+	seedAppSetRepoState(t,
+		branchState{manifest: foreignGeneratorAppSetYAML, files: anchoredChartFiles("1")},
+		branchState{manifest: foreignGeneratorAppSetYAML, files: anchoredChartFiles("7")})
+
+	runner := newAppSetRunner(t, Config{AnchorFileName: DefaultAnchorFileName}, nil)
+	err := runner.app.Run(context.Background())
+
+	require.ErrorIs(t, err, models.ErrUnsupportedAppConfiguration)
+	assert.Contains(t, err.Error(), "anchored ApplicationSet")
+	assert.Contains(t, err.Error(), appSetPath)
+	// The changed-manifest flow skips this same manifest with a warning; the
+	// anchor flow must not, or the change it names goes uncompared.
+	assert.Zero(t, runner.helm.callCount("RenderAppSource"))
+	assert.NotContains(t, runner.log.String(), "Skipping")
+}
+
+// crossRepoAppSetYAML lives in another repository and generates one path-based
+// Application per cluster directory of the repository being compared.
+func crossRepoAppSetYAML(localOrigin string) string {
+	return `apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: cluster-addons
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - git:
+        repoURL: ` + localOrigin + `
+        revision: HEAD
+        directories:
+          - path: clusters/*
+  template:
+    metadata:
+      name: '{{ .path.basename }}-addons'
+      namespace: argocd
+    spec:
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: '{{ .path.basename }}'
+      source:
+        repoURL: ` + localOrigin + `
+        path: '{{ .path.path }}'
+        targetRevision: HEAD
+        helm:
+          releaseName: '{{ .path.basename }}-addons'
+`
+}
+
+// clusterChart is the per-directory chart a cross-repo generator generates for.
+func clusterChart(cluster string) map[string]string {
+	prefix := "clusters/" + cluster + "/"
+
+	return map[string]string{
+		prefix + "Chart.yaml":         "apiVersion: v2\nname: " + cluster + "\nversion: 0.0.1\n",
+		prefix + "values.yaml":        "replicaCount: 1\n",
+		prefix + "templates/dep.yaml": "kind: Deployment\n",
+	}
+}
+
+// TestAppRunAnchoredApplicationSet_CrossRepo covers what only an anchor can
+// reach: the ApplicationSet lives in another repository, so the local scan
+// never sees it, and adding a cluster directory generates an Application the
+// target branch does not.
+func TestAppRunAnchoredApplicationSet_CrossRepo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip integration test in short mode")
+	}
+
+	tempDir := t.TempDir()
+	localOrigin := filepath.Join(tempDir, "origin.git")
+	appSetRepo := filepath.Join(tempDir, "appsets.git")
+	require.NoError(t, seedBareRepoWithApplication(t, appSetRepo, "main", "apps/addons.yaml", crossRepoAppSetYAML(localOrigin)))
+
+	anchorFile := map[string]string{
+		"clusters/.argo-compare.yml": "application:\n  repo: " + appSetRepo + "\n  path: apps/addons.yaml\n  branch: main\n",
+	}
+
+	mainFiles := mergeFileMaps(anchorFile, clusterChart("dev"))
+	featureFiles := mergeFileMaps(mainFiles, clusterChart("staging"))
+	seedLocalRepo(t, tempDir, localOrigin, mainFiles, featureFiles)
+
+	runner := newAppSetRunner(t, Config{AnchorFileName: DefaultAnchorFileName, PrintAddedManifests: true}, nil)
+	require.NoError(t, runner.app.Run(context.Background()))
+
+	output := runner.log.String()
+
+	assert.Contains(t, output, "Processing anchored chart")
+	assert.Contains(t, output, "generates 2 Application(s) on this branch and 1 on main; comparing 2")
+	assert.Contains(t, output, "===> Comparing generated Application: [dev-addons]")
+	assert.Contains(t, output, "===> Comparing generated Application: [staging-addons]")
+	assert.Contains(t, output, "would be added")
+
+	// dev exists on both branches, staging only on this one.
+	assert.Equal(t, 3, runner.helm.callCount("RenderAppSource"))
+	assert.Equal(t, 0, runner.helm.callCount("DownloadHelmChart"), "a path-based source must not trigger helm pull")
+
+	runner.assertTempDirsRemoved(t)
+}
+
+// mergeFileMaps returns the union of two file maps, with later entries winning.
+func mergeFileMaps(maps ...map[string]string) map[string]string {
+	merged := map[string]string{}
+	for _, m := range maps {
+		for name, content := range m {
+			merged[name] = content
+		}
+	}
+
+	return merged
+}
+
+// seedLocalRepo builds the repository under comparison: main holds mainFiles,
+// and the checked-out feature branch holds featureFiles. It chdirs into the
+// work tree, so tests using it can never run in parallel.
+func seedLocalRepo(t *testing.T, tempDir, originDir string, mainFiles, featureFiles map[string]string) {
+	t.Helper()
+
+	_, err := git.PlainInit(originDir, true)
+	require.NoError(t, err)
+
+	workDir := filepath.Join(tempDir, "work")
+	require.NoError(t, os.MkdirAll(workDir, 0o755))
+
+	repo, err := git.PlainInit(workDir, false)
+	require.NoError(t, err)
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.NewBranchReferenceName("main"))))
+
+	worktree, err := repo.Worktree()
+	require.NoError(t, err)
+	writeBranchFiles(t, worktree, workDir, mainFiles)
+
+	initialHash, err := worktree.Commit("initial commit", &git.CommitOptions{Author: defaultSignature()})
+	require.NoError(t, err)
+
+	_, err = repo.CreateRemote(&config.RemoteConfig{Name: "origin", URLs: []string{originDir}})
+	require.NoError(t, err)
+	require.NoError(t, repo.Push(&git.PushOptions{RemoteName: "origin", RefSpecs: []config.RefSpec{"refs/heads/main:refs/heads/main"}}))
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName("refs/remotes/origin/main"), initialHash)))
+
+	require.NoError(t, worktree.Checkout(&git.CheckoutOptions{Branch: plumbing.NewBranchReferenceName("feature/anchored-appset"), Create: true}))
+	writeBranchFiles(t, worktree, workDir, featureFiles)
+	_, err = worktree.Commit("add a cluster", &git.CommitOptions{Author: defaultSignature()})
+	require.NoError(t, err)
+
+	oldWD, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(workDir))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(oldWD))
+	})
+}
+
+// TestAppRunAnchoredApplicationSet_ValidationFailure proves a schema failure in
+// a generated Application still fails the run through the anchored route.
+func TestAppRunAnchoredApplicationSet_ValidationFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip integration test in short mode")
+	}
+
+	seedAppSetRepoState(t,
+		branchState{manifest: anchoredAppSetYAML, files: anchoredChartFiles("1")},
+		branchState{manifest: anchoredAppSetYAML, files: anchoredChartFiles("7")})
+
+	validator := &stubValidator{result: ports.ValidationResult{Valid: false, ResourceCount: 1, ErrorCount: 1}}
+	runner := newAppSetRunner(t, Config{AnchorFileName: DefaultAnchorFileName}, validator)
+
+	require.ErrorIs(t, runner.app.Run(context.Background()), ErrManifestValidationFailed)
+
+	// Only the source leg is validated, so one call per generated Application.
+	assert.Equal(t, 2, validator.calls)
+	assert.Contains(t, runner.log.String(), "Validation errors found")
+}
+
+// TestAppRunAnchoredApplicationSet_ManifestAlsoChanged proves the changed-file
+// flow owns an ApplicationSet the diff already carries: comparing it again via
+// its anchor would double every generated Application's diff and comment.
+func TestAppRunAnchoredApplicationSet_ManifestAlsoChanged(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip integration test in short mode")
+	}
+
+	featureManifest := strings.Replace(anchoredAppSetYAML,
+		"          - cluster: prod\n",
+		"          - cluster: prod\n          - cluster: staging\n", 1)
+
+	seedAppSetRepoState(t,
+		branchState{manifest: anchoredAppSetYAML, files: anchoredChartFiles("1")},
+		branchState{manifest: featureManifest, files: anchoredChartFiles("7")})
+
+	runner := newAppSetRunner(t, Config{AnchorFileName: DefaultAnchorFileName, PrintAddedManifests: true}, nil)
+	require.NoError(t, runner.app.Run(context.Background()))
+
+	output := runner.log.String()
+
+	assert.Contains(t, output, "Processing changed ApplicationSet: ["+appSetPath+"]")
+	assert.NotContains(t, output, "Processing anchored chart")
+	assert.NotContains(t, output, "Anchored ApplicationSet")
+
+	// dev and prod on both branches, staging only on this one — five renders,
+	// which is one per leg per Application and no repeat from the anchor.
+	assert.Equal(t, 5, runner.helm.callCount("RenderAppSource"))
+
+	runner.assertTempDirsRemoved(t)
+}
+
+// gitDirAnchoredAppSetYAML is anchored *and* reachable by the repository scan,
+// because its generator covers the directory the anchor sits in.
+const gitDirAnchoredAppSetYAML = `apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: demo
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - git:
+        repoURL: ORIGIN_URL
+        revision: HEAD
+        directories:
+          - path: charts/*
+  template:
+    metadata:
+      name: '{{ .path.basename }}-demo'
+      namespace: argocd
+    spec:
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: demo
+      source:
+        repoURL: ORIGIN_URL
+        path: '{{ .path.path }}'
+        targetRevision: HEAD
+        helm:
+          releaseName: '{{ .path.basename }}-demo'
+`
+
+// TestAppRunAnchoredApplicationSet_DiscoveryWins is the second dedup route: the
+// repository scan enqueues the manifest because a generator covers the changed
+// directory, so the anchor group must drop out rather than compare it twice.
+func TestAppRunAnchoredApplicationSet_DiscoveryWins(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip integration test in short mode")
+	}
+
+	seedAppSetRepoState(t,
+		branchState{manifest: gitDirAnchoredAppSetYAML, files: anchoredChartFiles("1")},
+		branchState{manifest: gitDirAnchoredAppSetYAML, files: anchoredChartFiles("7")})
+
+	runner := newAppSetRunner(t, Config{AnchorFileName: DefaultAnchorFileName}, nil)
+	require.NoError(t, runner.app.Run(context.Background()))
+
+	output := runner.log.String()
+
+	assert.Contains(t, output, "Processing changed ApplicationSet: ["+appSetPath+"]")
+	assert.NotContains(t, output, "Processing anchored chart")
+	assert.Equal(t, 2, runner.helm.callCount("RenderAppSource"), "one Application, one render per leg")
+
+	runner.assertTempDirsRemoved(t)
+}
+
+// TestAppRunAnchoredApplicationSet_SharedByTwoAnchors proves two chart
+// directories anchored to one manifest describe a single comparison. Without
+// deduplication every generated Application would be diffed once per anchor.
+func TestAppRunAnchoredApplicationSet_SharedByTwoAnchors(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip integration test in short mode")
+	}
+
+	withSecondAnchor := func(replicas string) map[string]string {
+		files := anchoredChartFiles(replicas)
+		files["charts/other/Chart.yaml"] = "apiVersion: v2\nname: other\nversion: 0.0.1\n"
+		files["charts/other/values.yaml"] = "replicaCount: " + replicas + "\n"
+		files["charts/other/.argo-compare.yml"] = "application:\n  path: ./" + appSetPath + "\n"
+
+		return files
+	}
+
+	seedAppSetRepoState(t,
+		branchState{manifest: anchoredAppSetYAML, files: withSecondAnchor("1")},
+		branchState{manifest: anchoredAppSetYAML, files: withSecondAnchor("7")})
+
+	runner := newAppSetRunner(t, Config{AnchorFileName: DefaultAnchorFileName}, nil)
+	require.NoError(t, runner.app.Run(context.Background()))
+
+	// Two Applications, two legs each — not four renders per Application.
+	assert.Equal(t, 4, runner.helm.callCount("RenderAppSource"))
+	assert.Equal(t, 1, strings.Count(runner.log.String(), "Anchored ApplicationSet"))
+
+	runner.assertTempDirsRemoved(t)
+}
+
+// runNewAnchoredAppSetChart seeds an anchored ApplicationSet whose chart
+// directory is added for the first time on this branch: both branches generate
+// the same Applications, but the baseline tree holds no chart to render.
+func runNewAnchoredAppSetChart(t *testing.T, printAdded bool) *appSetRunner {
+	t.Helper()
+
+	seedAppSetRepoState(t,
+		branchState{manifest: anchoredAppSetYAML},
+		branchState{manifest: anchoredAppSetYAML, files: anchoredChartFiles("1")})
+
+	runner := newAppSetRunner(t, Config{AnchorFileName: DefaultAnchorFileName, PrintAddedManifests: printAdded}, nil)
+	require.NoError(t, runner.app.Run(context.Background()))
+
+	return runner
+}
+
+// TestAppRunAnchoredApplicationSet_NewChart_PrintAdded renders the source leg
+// alone rather than failing on a baseline tree that has no chart.
+func TestAppRunAnchoredApplicationSet_NewChart_PrintAdded(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip integration test in short mode")
+	}
+
+	runner := runNewAnchoredAppSetChart(t, true)
+
+	assert.Contains(t, runner.log.String(), "does not exist in target branch main, assuming it is new")
+	assert.Equal(t, 2, runner.helm.callCount("RenderAppSource"), "source leg only, for each of the two Applications")
+
+	runner.assertTempDirsRemoved(t)
+}
+
+// TestAppRunAnchoredApplicationSet_NewChart_Default skips a comparison that has
+// no baseline, matching how a newly added Application manifest is handled.
+func TestAppRunAnchoredApplicationSet_NewChart_Default(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip integration test in short mode")
+	}
+
+	runner := runNewAnchoredAppSetChart(t, false)
+
+	output := runner.log.String()
+	assert.Contains(t, output, "does not exist in target branch main, assuming it is new")
+	assert.NotContains(t, output, "No diff was found")
+
+	runner.assertTempDirsRemoved(t)
+}
+
+// TestAppRunAnchoredApplicationSet_AddedSkippedByDefault proves an Application
+// only this branch generates is skipped, not rendered, without the print flag.
+func TestAppRunAnchoredApplicationSet_AddedSkippedByDefault(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip integration test in short mode")
+	}
+
+	tempDir := t.TempDir()
+	localOrigin := filepath.Join(tempDir, "origin.git")
+	appSetRepo := filepath.Join(tempDir, "appsets.git")
+	require.NoError(t, seedBareRepoWithApplication(t, appSetRepo, "main", "apps/addons.yaml", crossRepoAppSetYAML(localOrigin)))
+
+	anchorFile := map[string]string{
+		"clusters/.argo-compare.yml": "application:\n  repo: " + appSetRepo + "\n  path: apps/addons.yaml\n  branch: main\n",
+	}
+	mainFiles := mergeFileMaps(anchorFile, clusterChart("dev"))
+	seedLocalRepo(t, tempDir, localOrigin, mainFiles, mergeFileMaps(mainFiles, clusterChart("staging")))
+
+	runner := newAppSetRunner(t, Config{AnchorFileName: DefaultAnchorFileName}, nil)
+	require.NoError(t, runner.app.Run(context.Background()))
+
+	output := runner.log.String()
+	assert.Contains(t, output, "Skipping added Application [staging-addons]")
+	assert.Equal(t, 2, runner.helm.callCount("RenderAppSource"), "only dev-addons renders, on both legs")
+
+	runner.assertTempDirsRemoved(t)
+}
+
+// registryAnchoredAppSetYAML generates registry-chart Applications, which no
+// change to this repository's chart directories can affect.
+const registryAnchoredAppSetYAML = `apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: demo
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - list:
+        elements:
+          - cluster: dev
+  template:
+    metadata:
+      name: '{{ .cluster }}-demo'
+      namespace: argocd
+    spec:
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: demo
+      source:
+        repoURL: fake.repo/charts
+        chart: demo-chart
+        targetRevision: 1.0.0
+`
+
+// TestAppRunAnchoredApplicationSet_RegistryOnly proves an anchor whose
+// ApplicationSet renders nothing from this repository fails rather than pulling
+// two identical charts and reporting an empty diff.
+func TestAppRunAnchoredApplicationSet_RegistryOnly(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip integration test in short mode")
+	}
+
+	seedAppSetRepoState(t,
+		branchState{manifest: registryAnchoredAppSetYAML, files: anchoredChartFiles("1")},
+		branchState{manifest: registryAnchoredAppSetYAML, files: anchoredChartFiles("7")})
+
+	runner := newAppSetRunner(t, Config{AnchorFileName: DefaultAnchorFileName}, nil)
+	err := runner.app.Run(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "generates no Application rendering a chart from this repository")
+	assert.Contains(t, runner.log.String(), "its source is a registry chart")
+	assert.Zero(t, runner.helm.callCount("DownloadHelmChart"), "a chart outside this repository must not be pulled")
+}
+
+// foreignSourceAppSetYAML generates a path-based Application belonging to a
+// repository other than the one being compared.
+func foreignSourceAppSetYAML() string {
+	return strings.Replace(anchoredAppSetYAML,
+		"        repoURL: ORIGIN_URL\n",
+		"        repoURL: https://elsewhere.example.com/group/other.git\n", 1)
+}
+
+// TestAppRunAnchoredApplicationSet_ForeignSource proves a generated Application
+// whose source is another repository is not rendered from this repository's
+// tree, which would produce a confident diff of the wrong content.
+func TestAppRunAnchoredApplicationSet_ForeignSource(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip integration test in short mode")
+	}
+
+	manifest := foreignSourceAppSetYAML()
+	seedAppSetRepoState(t,
+		branchState{manifest: manifest, files: anchoredChartFiles("1")},
+		branchState{manifest: manifest, files: anchoredChartFiles("7")})
+
+	runner := newAppSetRunner(t, Config{AnchorFileName: DefaultAnchorFileName}, nil)
+	err := runner.app.Run(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "generates no Application rendering a chart from this repository")
+	assert.Contains(t, runner.log.String(), "is not this one, so this repository's tree cannot render it")
+	assert.Zero(t, runner.helm.callCount("RenderAppSource"))
+}

--- a/internal/app/anchor_appset_integration_test.go
+++ b/internal/app/anchor_appset_integration_test.go
@@ -722,3 +722,111 @@ spec:
 	assert.Contains(t, err.Error(), "apps/appset.yaml (local)")
 	assert.Contains(t, err.Error(), "for src leg")
 }
+
+// registryApp builds a single-source registry-chart Application.
+func registryApp(name string) *models.Application {
+	app := &models.Application{Kind: models.KindApplication}
+	app.Metadata.Name = name
+	app.Spec.Source = &models.Source{RepoURL: "https://charts.example.com", Chart: "demo"}
+
+	return app
+}
+
+// TestAnchoredPairsInScopeJudgesLegsIndependently covers an Application that
+// moves into or out of this repository on this branch: the leg that reads the
+// local repository must still be compared, not dropped with its counterpart.
+func TestAnchoredPairsInScopeJudgesLegsIndependently(t *testing.T) {
+	const origin = "https://git.example.com/group/repo.git"
+	ref := anchor.ApplicationRef{Path: "apps/appset.yaml"}
+
+	cases := []struct {
+		name     string
+		pair     generatedPair
+		wantKept bool
+		wantSrc  bool
+		wantDst  bool
+	}{
+		{
+			name:     "moving into this repository keeps the source leg",
+			pair:     generatedPair{name: "moving-in", src: pathApp("moving-in", origin), dst: registryApp("moving-in")},
+			wantKept: true, wantSrc: true, wantDst: false,
+		},
+		{
+			name:     "moving out of this repository keeps the destination leg",
+			pair:     generatedPair{name: "moving-out", src: registryApp("moving-out"), dst: pathApp("moving-out", origin)},
+			wantKept: true, wantSrc: false, wantDst: true,
+		},
+		{
+			name:     "a foreign source on one leg still keeps the local leg",
+			pair:     generatedPair{name: "foreign-dst", src: pathApp("foreign-dst", origin), dst: pathApp("foreign-dst", "https://other.example.com/g/o.git")},
+			wantKept: true, wantSrc: true, wantDst: false,
+		},
+		{
+			name:     "neither leg in this repository is skipped",
+			pair:     generatedPair{name: "never", src: registryApp("never"), dst: registryApp("never")},
+			wantKept: false,
+		},
+		{
+			name:     "a one-sided pair whose only leg is out of scope is skipped",
+			pair:     generatedPair{name: "added-registry", src: registryApp("added-registry")},
+			wantKept: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			app := &App{cfg: Config{TargetBranch: "main"}, logger: logger.New("leg-scope-test")}
+			// A second, always-comparable pair keeps the no-qualifying-Applications
+			// backstop from masking what this case is about.
+			filler := generatedPair{name: "filler", src: pathApp("filler", origin), dst: pathApp("filler", origin)}
+
+			inScope, err := app.anchoredPairsInScope(ref, []generatedPair{c.pair, filler}, origin)
+			require.NoError(t, err)
+
+			var got *generatedPair
+			for i := range inScope {
+				if inScope[i].name == c.pair.name {
+					got = &inScope[i]
+				}
+			}
+
+			if !c.wantKept {
+				assert.Nil(t, got, "pair must be skipped entirely")
+				return
+			}
+
+			require.NotNil(t, got, "pair must be kept")
+			assert.Equal(t, c.wantSrc, got.src != nil, "source leg presence")
+			assert.Equal(t, c.wantDst, got.dst != nil, "destination leg presence")
+		})
+	}
+}
+
+// TestDedupAnchorGroupsNormalizesRemoteIdentity proves two spellings of one
+// remote anchor collapse, so the same manifest is not compared twice.
+func TestDedupAnchorGroupsNormalizesRemoteIdentity(t *testing.T) {
+	groups := []AnchorGroup{
+		{Dir: "charts/a", Anchor: anchor.Anchor{Application: anchor.ApplicationRef{
+			Repo: "https://git.example.com/group/repo.git", Path: "apps/appset.yaml", Branch: "main"}}},
+		{Dir: "charts/b", Anchor: anchor.Anchor{Application: anchor.ApplicationRef{
+			Repo: "git@git.example.com:group/repo", Path: "./apps/appset.yaml", Branch: "main"}}},
+	}
+
+	deduped := dedupAnchorGroups(groups, nil)
+
+	require.Len(t, deduped, 1)
+	assert.Equal(t, "charts/a", deduped[0].Dir, "the first group wins")
+}
+
+// TestDedupAnchorGroupsKeepsDistinctBranches proves the same manifest at two
+// branch tips stays two comparisons.
+func TestDedupAnchorGroupsKeepsDistinctBranches(t *testing.T) {
+	groups := []AnchorGroup{
+		{Dir: "charts/a", Anchor: anchor.Anchor{Application: anchor.ApplicationRef{
+			Repo: "https://git.example.com/group/repo.git", Path: "apps/appset.yaml", Branch: "main"}}},
+		{Dir: "charts/b", Anchor: anchor.Anchor{Application: anchor.ApplicationRef{
+			Repo: "https://git.example.com/group/repo.git", Path: "apps/appset.yaml", Branch: "next"}}},
+	}
+
+	assert.Len(t, dedupAnchorGroups(groups, nil), 2)
+}

--- a/internal/app/anchor_appset_integration_test.go
+++ b/internal/app/anchor_appset_integration_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/shini4i/argo-compare/cmd/argo-compare/utils/logger"
+	"github.com/shini4i/argo-compare/internal/anchor"
 	"github.com/shini4i/argo-compare/internal/models"
 	"github.com/shini4i/argo-compare/internal/ports"
 	"github.com/stretchr/testify/assert"
@@ -574,4 +576,149 @@ func TestAppRunAnchoredApplicationSet_ForeignSource(t *testing.T) {
 	assert.Contains(t, err.Error(), "generates no Application rendering a chart from this repository")
 	assert.Contains(t, runner.log.String(), "is not this one, so this repository's tree cannot render it")
 	assert.Zero(t, runner.helm.callCount("RenderAppSource"))
+}
+
+// pathApp builds a single-source path-based Application for the scope tests.
+func pathApp(name, repoURL string) *models.Application {
+	app := &models.Application{Kind: models.KindApplication}
+	app.Metadata.Name = name
+	app.Spec.Source = &models.Source{RepoURL: repoURL, Path: "charts/demo"}
+
+	return app
+}
+
+func TestAnchoredPairsInScope(t *testing.T) {
+	const origin = "https://git.example.com/group/repo.git"
+	ref := anchor.ApplicationRef{Path: "apps/appset.yaml"}
+
+	mixed := &models.Application{Kind: models.KindApplication}
+	mixed.Metadata.Name = "mixed"
+	mixed.Spec.Sources = []*models.Source{
+		{RepoURL: origin, Path: "charts/demo"},
+		{RepoURL: "https://charts.example.com", Chart: "demo"},
+	}
+	mixed.Spec.MultiSource = true
+
+	registry := &models.Application{Kind: models.KindApplication}
+	registry.Metadata.Name = "registry"
+	registry.Spec.Source = &models.Source{RepoURL: "https://charts.example.com", Chart: "demo"}
+
+	cases := []struct {
+		name      string
+		originURL string
+		pairs     []generatedPair
+		wantNames []string
+		wantErr   string
+	}{
+		{
+			name:      "keeps a source in this repository",
+			originURL: origin,
+			pairs: []generatedPair{
+				{name: "keep", src: pathApp("keep", origin), dst: pathApp("keep", origin)},
+				{name: "registry", src: registry},
+			},
+			wantNames: []string{"keep"},
+		},
+		{
+			name:      "an ssh spelling of the same repository still matches",
+			originURL: origin,
+			pairs:     []generatedPair{{name: "keep", src: pathApp("keep", "ssh://git@git.example.com:1022/group/repo.git")}},
+			wantNames: []string{"keep"},
+		},
+		{
+			name:      "no origin is a hard error",
+			originURL: "",
+			pairs:     []generatedPair{{name: "keep", src: pathApp("keep", origin)}},
+			wantErr:   "no origin remote configured",
+		},
+		{
+			name:      "nothing in scope is a hard error",
+			originURL: origin,
+			pairs:     []generatedPair{{name: "elsewhere", src: pathApp("elsewhere", "https://other.example.com/group/other.git")}},
+			wantErr:   "generates no Application rendering a chart from this repository",
+		},
+		{
+			name:      "mixed multi-source sources are rejected, not skipped",
+			originURL: origin,
+			pairs:     []generatedPair{{name: "mixed", src: mixed}},
+			wantErr:   ErrMixedMultiSource.Error(),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			app := &App{cfg: Config{TargetBranch: "main"}, logger: logger.New("scope-test")}
+
+			inScope, err := app.anchoredPairsInScope(ref, c.pairs, c.originURL)
+			if c.wantErr != "" {
+				require.ErrorContains(t, err, c.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			names := make([]string, 0, len(inScope))
+			for _, pair := range inScope {
+				names = append(names, pair.name)
+			}
+			assert.Equal(t, c.wantNames, names)
+		})
+	}
+}
+
+// emptyManifestFetcher violates the AnchoredManifest contract by resolving to
+// neither kind, which a hand-written or generated test double can do.
+type emptyManifestFetcher struct{}
+
+func (emptyManifestFetcher) Fetch(_ context.Context, _ anchor.ApplicationRef, _ string) (ports.AnchoredManifest, error) {
+	return ports.AnchoredManifest{}, nil
+}
+
+func TestProcessAnchorGroupRejectsEmptyManifest(t *testing.T) {
+	app := &App{cfg: Config{TargetBranch: "main"}, logger: logger.New("empty-manifest-test")}
+	group := AnchorGroup{Dir: "charts/demo", Anchor: anchor.Anchor{Application: anchor.ApplicationRef{Path: "apps/appset.yaml"}}}
+
+	_, err := app.processAnchorGroup(context.Background(), nil, group, emptyManifestFetcher{}, "", "")
+
+	require.ErrorContains(t, err, "resolved apps/appset.yaml (local) to no manifest")
+}
+
+// TestExpandAnchoredApplicationSetNamesTheLeg covers an expansion failure the
+// manifest's own validation cannot catch: a template that names two generated
+// Applications identically. A list generator never reads the tree, so none is
+// needed here.
+func TestExpandAnchoredApplicationSetNamesTheLeg(t *testing.T) {
+	const duplicateNames = `apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: demo
+  namespace: argocd
+spec:
+  goTemplate: true
+  generators:
+    - list:
+        elements:
+          - cluster: dev
+          - cluster: prod
+  template:
+    metadata:
+      name: same-name
+      namespace: argocd
+    spec:
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: demo
+      source:
+        repoURL: https://git.example.com/group/repo.git
+        path: charts/demo
+        targetRevision: HEAD
+`
+
+	appSet, err := parseApplicationSetContent([]byte(duplicateNames))
+	require.NoError(t, err)
+
+	_, err = expandAnchoredApplicationSet(appSet, nil, anchor.ApplicationRef{Path: "apps/appset.yaml"}, TargetTypeSource)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "apps/appset.yaml (local)")
+	assert.Contains(t, err.Error(), "for src leg")
 }

--- a/internal/app/anchor_flow.go
+++ b/internal/app/anchor_flow.go
@@ -111,12 +111,20 @@ func (a *App) processAnchoredApplicationSet(ctx context.Context, repo *GitRepo, 
 		return false, fmt.Errorf("anchored ApplicationSet %s: %w", anchorRefDisplay(ref), err)
 	}
 
-	srcApps, err := a.expandAnchoredApplicationSet(repo, appSet, ref, TargetTypeSource)
+	headTree, err := repo.HeadTree()
+	if err != nil {
+		return false, err
+	}
+	srcApps, err := expandAnchoredApplicationSet(appSet, headTree, ref, TargetTypeSource)
 	if err != nil {
 		return false, err
 	}
 
-	dstApps, err := a.expandAnchoredApplicationSet(repo, appSet, ref, TargetTypeDestination)
+	baseTree, err := repo.MergeBaseTreeFor(a.cfg.TargetBranch)
+	if err != nil {
+		return false, err
+	}
+	dstApps, err := expandAnchoredApplicationSet(appSet, baseTree, ref, TargetTypeDestination)
 	if err != nil {
 		return false, err
 	}
@@ -205,26 +213,9 @@ func anchoredPairSkipReason(pair generatedPair, originURL string) (string, error
 	return "", nil
 }
 
-// expandAnchoredApplicationSet expands appSet against the tree one comparison
-// leg stands for: this branch's HEAD for the source leg, the merge-base with
-// the target branch for the destination leg.
-func (a *App) expandAnchoredApplicationSet(repo *GitRepo, appSet *models.ApplicationSet, ref anchor.ApplicationRef, leg string) ([]models.Application, error) {
-	var (
-		tree *object.Tree
-		err  error
-	)
-	switch leg {
-	case TargetTypeSource:
-		tree, err = repo.HeadTree()
-	case TargetTypeDestination:
-		tree, err = repo.MergeBaseTreeFor(a.cfg.TargetBranch)
-	default:
-		return nil, fmt.Errorf("unknown render leg %q", leg)
-	}
-	if err != nil {
-		return nil, err
-	}
-
+// expandAnchoredApplicationSet expands appSet against one comparison leg's
+// tree, naming the leg if expansion fails.
+func expandAnchoredApplicationSet(appSet *models.ApplicationSet, tree *object.Tree, ref anchor.ApplicationRef, leg string) ([]models.Application, error) {
 	apps, err := appset.Expand(appSet, gitTree{tree: tree})
 	if err != nil {
 		return nil, fmt.Errorf("expand anchored ApplicationSet %s for %s leg: %w", anchorRefDisplay(ref), leg, err)

--- a/internal/app/anchor_flow.go
+++ b/internal/app/anchor_flow.go
@@ -165,15 +165,13 @@ func (a *App) anchoredPairsInScope(ref anchor.ApplicationRef, pairs []generatedP
 
 	inScope := make([]generatedPair, 0, len(pairs))
 	for _, pair := range pairs {
-		reason, err := anchoredPairSkipReason(pair, originURL)
+		scoped, keep, err := a.scopeAnchoredPair(pair, originURL)
 		if err != nil {
 			return nil, fmt.Errorf("anchored ApplicationSet %s: %w", anchorRefDisplay(ref), err)
 		}
-		if reason != "" {
-			a.logger.Infof("Skipping generated Application [%s]: %s", ui.Cyan(pair.name), reason)
-			continue
+		if keep {
+			inScope = append(inScope, scoped)
 		}
-		inScope = append(inScope, pair)
 	}
 
 	if len(inScope) == 0 {
@@ -184,33 +182,73 @@ func (a *App) anchoredPairsInScope(ref anchor.ApplicationRef, pairs []generatedP
 	return inScope, nil
 }
 
-// anchoredPairSkipReason names why a generated Application is outside an
-// anchor's reach, or "" when it is comparable. A registry chart cannot be
-// affected by a change to this repository, and a path-based source belonging to
-// another repository would otherwise be rendered from the wrong tree.
-func anchoredPairSkipReason(pair generatedPair, originURL string) (string, error) {
-	for _, app := range []*models.Application{pair.src, pair.dst} {
-		if app == nil {
+// scopeAnchoredPair drops the comparison legs an anchor cannot report on,
+// judging each independently so an Application moving into or out of this
+// repository is still compared on the side that reads it. keep is false when
+// neither leg qualifies.
+func (a *App) scopeAnchoredPair(pair generatedPair, originURL string) (generatedPair, bool, error) {
+	srcReason, err := anchoredLegSkipReason(pair.src, originURL)
+	if err != nil {
+		return pair, false, err
+	}
+	dstReason, err := anchoredLegSkipReason(pair.dst, originURL)
+	if err != nil {
+		return pair, false, err
+	}
+
+	if srcReason != "" {
+		pair.src = nil
+	}
+	if dstReason != "" {
+		pair.dst = nil
+	}
+
+	reason := firstNonEmpty(srcReason, dstReason)
+	if pair.src == nil && pair.dst == nil {
+		a.logger.Infof("Skipping generated Application [%s]: %s", ui.Cyan(pair.name), reason)
+		return pair, false, nil
+	}
+	if reason != "" {
+		a.logger.Infof("Comparing generated Application [%s] on one branch only: %s", ui.Cyan(pair.name), reason)
+	}
+
+	return pair, true, nil
+}
+
+// anchoredLegSkipReason names why one comparison leg is outside an anchor's
+// reach, or "" when it is comparable — a leg with no Application included. A
+// registry chart cannot be affected by a change to this repository, and a
+// path-based source belonging to another repository would render from the wrong tree.
+func anchoredLegSkipReason(app *models.Application, originURL string) (string, error) {
+	if app == nil {
+		return "", nil
+	}
+
+	target := Target{App: *app}
+	if err := target.ClassifySources(); err != nil {
+		return "", err
+	}
+	if !target.PathBased() {
+		return "its source is a registry chart, which a change to this repository cannot affect", nil
+	}
+	for _, source := range target.pathSources() {
+		if source == nil || repoIdentityMatches(source.RepoURL, originURL) {
 			continue
 		}
-
-		target := Target{App: *app}
-		if err := target.ClassifySources(); err != nil {
-			return "", err
-		}
-		if !target.PathBased() {
-			return "its source is a registry chart, which a change to this repository cannot affect", nil
-		}
-		for _, source := range target.pathSources() {
-			if source == nil || repoIdentityMatches(source.RepoURL, originURL) {
-				continue
-			}
-			return fmt.Sprintf("its source repository %q is not this one, so this repository's tree cannot render it",
-				redactRepo(source.RepoURL)), nil
-		}
+		return fmt.Sprintf("its source repository %q is not this one, so this repository's tree cannot render it",
+			redactRepo(source.RepoURL)), nil
 	}
 
 	return "", nil
+}
+
+// firstNonEmpty returns the first non-empty string, or "" when both are empty.
+func firstNonEmpty(a, b string) string {
+	if a != "" {
+		return a
+	}
+
+	return b
 }
 
 // expandAnchoredApplicationSet expands appSet against one comparison leg's

--- a/internal/app/anchor_flow.go
+++ b/internal/app/anchor_flow.go
@@ -9,10 +9,12 @@ import (
 	"strings"
 
 	"github.com/shini4i/argo-compare/internal/anchor"
+	"github.com/shini4i/argo-compare/internal/appset"
 	"github.com/shini4i/argo-compare/internal/models"
 	"github.com/shini4i/argo-compare/internal/ports"
 	"github.com/shini4i/argo-compare/internal/ui"
 
+	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/spf13/afero"
 )
 
@@ -74,16 +76,166 @@ func (a *App) compareAnchorGroups(ctx context.Context, repo *GitRepo, groups []A
 	return anyFailed, nil
 }
 
-// processAnchorGroup renders, diffs, and validates the Application that the
-// anchor points to. tmpDir is created fresh per group and cleaned up at end.
-func (a *App) processAnchorGroup(ctx context.Context, repo *GitRepo, group AnchorGroup, fetcher ports.ApplicationFetcher, repoRoot, originURL string) (validationFailed bool, err error) {
+// processAnchorGroup compares whatever the anchor points at: a single
+// Application, or every Application an ApplicationSet generates.
+func (a *App) processAnchorGroup(ctx context.Context, repo *GitRepo, group AnchorGroup, fetcher ports.ApplicationFetcher, repoRoot, originURL string) (bool, error) {
 	a.logger.Infof("===> Processing anchored chart in [%s]", ui.Cyan(group.Dir))
 
-	app, err := fetcher.Fetch(ctx, group.Anchor.Application, repoRoot)
+	manifest, err := fetcher.Fetch(ctx, group.Anchor.Application, repoRoot)
 	if err != nil {
 		return false, err
 	}
 
+	if manifest.ApplicationSet != nil {
+		return a.processAnchoredApplicationSet(ctx, repo, group, manifest.ApplicationSet, originURL)
+	}
+	if manifest.Application == nil {
+		return false, fmt.Errorf("fetcher resolved %s to no manifest", anchorRefDisplay(group.Anchor.Application))
+	}
+
+	return a.processAnchoredApplication(ctx, repo, group, *manifest.Application, repoRoot, originURL)
+}
+
+// processAnchoredApplicationSet compares every Application an anchored
+// ApplicationSet generates. The manifest is read once — an anchor exists
+// because the chart changed, not the manifest — while each leg expands it
+// against its own tree, so a directory the change adds or drops is reported.
+func (a *App) processAnchoredApplicationSet(ctx context.Context, repo *GitRepo, group AnchorGroup, appSet *models.ApplicationSet, originURL string) (bool, error) {
+	ref := group.Anchor.Application
+
+	// Expansion reads the two local branch legs, so a generator naming another
+	// repository has no tree here to expand against. Unlike a manifest found by
+	// scanning the diff, an anchor is an explicit pointer: skipping it silently
+	// would leave the change it names uncompared with nothing said.
+	if err := assertGitGeneratorsComparable(appSet, originURL, a.cfg.TargetBranch); err != nil {
+		return false, fmt.Errorf("anchored ApplicationSet %s: %w", anchorRefDisplay(ref), err)
+	}
+
+	srcApps, err := a.expandAnchoredApplicationSet(repo, appSet, ref, TargetTypeSource)
+	if err != nil {
+		return false, err
+	}
+
+	dstApps, err := a.expandAnchoredApplicationSet(repo, appSet, ref, TargetTypeDestination)
+	if err != nil {
+		return false, err
+	}
+
+	pairs := pairGeneratedApplications(srcApps, dstApps)
+	inScope, err := a.anchoredPairsInScope(ref, pairs, originURL)
+	if err != nil {
+		return false, err
+	}
+
+	a.logger.Infof("Anchored ApplicationSet %s generates %d Application(s) on this branch and %d on %s; comparing %d",
+		ui.Cyan(anchorRefDisplay(ref)), len(srcApps), len(dstApps), a.cfg.TargetBranch, len(inScope))
+
+	anyFailed := false
+	for _, pair := range inScope {
+		failed, err := a.compareGeneratedApplication(ctx, repo, ref.Path, pair)
+		if err != nil {
+			return anyFailed, err
+		}
+		if failed {
+			anyFailed = true
+		}
+	}
+
+	return anyFailed, nil
+}
+
+// anchoredPairsInScope keeps the generated Applications that read chart content
+// from this repository — the only ones an anchor can be reporting on. It fails
+// when none qualify, because an anchor names a change that must not go
+// uncompared with nothing said.
+func (a *App) anchoredPairsInScope(ref anchor.ApplicationRef, pairs []generatedPair, originURL string) ([]generatedPair, error) {
+	// Every path-based render reads the local repo, so without an origin to
+	// compare against there is no way to tell which Applications belong to it.
+	if originURL == "" {
+		return nil, fmt.Errorf("anchored ApplicationSet %s: local repo has no origin remote configured", anchorRefDisplay(ref))
+	}
+
+	inScope := make([]generatedPair, 0, len(pairs))
+	for _, pair := range pairs {
+		reason, err := anchoredPairSkipReason(pair, originURL)
+		if err != nil {
+			return nil, fmt.Errorf("anchored ApplicationSet %s: %w", anchorRefDisplay(ref), err)
+		}
+		if reason != "" {
+			a.logger.Infof("Skipping generated Application [%s]: %s", ui.Cyan(pair.name), reason)
+			continue
+		}
+		inScope = append(inScope, pair)
+	}
+
+	if len(inScope) == 0 {
+		return nil, fmt.Errorf("anchored ApplicationSet %s generates no Application rendering a chart from this repository, so the change under the anchor is not covered by any comparison",
+			anchorRefDisplay(ref))
+	}
+
+	return inScope, nil
+}
+
+// anchoredPairSkipReason names why a generated Application is outside an
+// anchor's reach, or "" when it is comparable. A registry chart cannot be
+// affected by a change to this repository, and a path-based source belonging to
+// another repository would otherwise be rendered from the wrong tree.
+func anchoredPairSkipReason(pair generatedPair, originURL string) (string, error) {
+	for _, app := range []*models.Application{pair.src, pair.dst} {
+		if app == nil {
+			continue
+		}
+
+		target := Target{App: *app}
+		if err := target.ClassifySources(); err != nil {
+			return "", err
+		}
+		if !target.PathBased() {
+			return "its source is a registry chart, which a change to this repository cannot affect", nil
+		}
+		for _, source := range target.pathSources() {
+			if source == nil || repoIdentityMatches(source.RepoURL, originURL) {
+				continue
+			}
+			return fmt.Sprintf("its source repository %q is not this one, so this repository's tree cannot render it",
+				redactRepo(source.RepoURL)), nil
+		}
+	}
+
+	return "", nil
+}
+
+// expandAnchoredApplicationSet expands appSet against the tree one comparison
+// leg stands for: this branch's HEAD for the source leg, the merge-base with
+// the target branch for the destination leg.
+func (a *App) expandAnchoredApplicationSet(repo *GitRepo, appSet *models.ApplicationSet, ref anchor.ApplicationRef, leg string) ([]models.Application, error) {
+	var (
+		tree *object.Tree
+		err  error
+	)
+	switch leg {
+	case TargetTypeSource:
+		tree, err = repo.HeadTree()
+	case TargetTypeDestination:
+		tree, err = repo.MergeBaseTreeFor(a.cfg.TargetBranch)
+	default:
+		return nil, fmt.Errorf("unknown render leg %q", leg)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	apps, err := appset.Expand(appSet, gitTree{tree: tree})
+	if err != nil {
+		return nil, fmt.Errorf("expand anchored ApplicationSet %s for %s leg: %w", anchorRefDisplay(ref), leg, err)
+	}
+
+	return apps, nil
+}
+
+// processAnchoredApplication renders, diffs, and validates the Application that
+// the anchor points to. tmpDir is created fresh per group and cleaned up at end.
+func (a *App) processAnchoredApplication(ctx context.Context, repo *GitRepo, group AnchorGroup, app models.Application, repoRoot, originURL string) (validationFailed bool, err error) {
 	classifyTarget := Target{App: app}
 	if classifyErr := classifyTarget.ClassifySources(); classifyErr != nil {
 		return false, classifyErr
@@ -295,10 +447,7 @@ func (a *App) applicationFetcher() ports.ApplicationFetcher {
 		return a.fetcher
 	}
 	return &RealApplicationFetcher{
-		FS:          a.fs,
 		FileReader:  a.fileReader,
-		CmdRunner:   a.cmdRunner,
-		Log:         a.logger,
 		GitUsername: a.cfg.GitUsername,
 		GitToken:    a.cfg.GitToken,
 	}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -291,7 +291,9 @@ func dedupAnchorGroups(groups []AnchorGroup, changedApps []string) []AnchorGroup
 		}
 		// Two chart directories anchored to one manifest describe a single
 		// comparison. Rendering it per group would repeat the whole diff — and
-		// for an ApplicationSet, repeat it once per generated Application.
+		// for an ApplicationSet, repeat it once per generated Application. The
+		// repo is keyed by identity, so two spellings of one remote still match.
+		ref.Repo = normalizeRepoIdentity(ref.Repo)
 		if _, dup := seen[ref]; dup {
 			continue
 		}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/shini4i/argo-compare/cmd/argo-compare/utils"
 	"github.com/shini4i/argo-compare/cmd/argo-compare/utils/logger"
+	"github.com/shini4i/argo-compare/internal/anchor"
 	"github.com/shini4i/argo-compare/internal/comment"
 	"github.com/shini4i/argo-compare/internal/comment/gitlab"
 	"github.com/shini4i/argo-compare/internal/models"
@@ -269,20 +270,33 @@ func (a *App) runComparisons(ctx context.Context, repo *GitRepo, changedFiles []
 // Paths on both sides are normalized via filepath.Clean so that anchor entries
 // spelled "./apps/foo.yaml" still match a changedApps entry of "apps/foo.yaml".
 func dedupAnchorGroups(groups []AnchorGroup, changedApps []string) []AnchorGroup {
-	if len(groups) == 0 || len(changedApps) == 0 {
+	if len(groups) == 0 {
 		return groups
 	}
 	changed := make(map[string]struct{}, len(changedApps))
 	for _, f := range changedApps {
 		changed[filepath.Clean(f)] = struct{}{}
 	}
+
+	seen := make(map[anchor.ApplicationRef]struct{}, len(groups))
 	out := groups[:0]
 	for _, g := range groups {
-		if g.Anchor.Application.Repo == "" {
-			if _, dup := changed[filepath.Clean(g.Anchor.Application.Path)]; dup {
+		ref := g.Anchor.Application
+		ref.Path = filepath.Clean(ref.Path)
+
+		if ref.Repo == "" {
+			if _, dup := changed[ref.Path]; dup {
 				continue
 			}
 		}
+		// Two chart directories anchored to one manifest describe a single
+		// comparison. Rendering it per group would repeat the whole diff — and
+		// for an ApplicationSet, repeat it once per generated Application.
+		if _, dup := seen[ref]; dup {
+			continue
+		}
+		seen[ref] = struct{}{}
+
 		out = append(out, g)
 	}
 	return out

--- a/internal/app/application_fetcher.go
+++ b/internal/app/application_fetcher.go
@@ -2,12 +2,11 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 
-	"github.com/shini4i/argo-compare/cmd/argo-compare/utils/logger"
 	"github.com/shini4i/argo-compare/internal/anchor"
-	"github.com/shini4i/argo-compare/internal/helpers"
 	"github.com/shini4i/argo-compare/internal/models"
 	"github.com/shini4i/argo-compare/internal/ports"
 
@@ -16,7 +15,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/go-git/go-git/v5/storage/memory"
-	"github.com/spf13/afero"
+	"gopkg.in/yaml.v3"
 )
 
 // defaultGitUsername is the placeholder username paired with a token when no
@@ -40,104 +39,109 @@ const defaultGitUsername = "x-access-token"
 //     agent + default keys for ssh:// URLs, unauthenticated for https://.
 //     This preserves the pre-PAT behavior for local development.
 type RealApplicationFetcher struct {
-	FS          afero.Fs
 	FileReader  ports.FileReader
-	CmdRunner   ports.CmdRunner
-	Log         *logger.Logger
 	GitUsername string
 	GitToken    string
 }
 
-// Fetch resolves ref to a parsed Application.
-func (f *RealApplicationFetcher) Fetch(ctx context.Context, ref anchor.ApplicationRef, localRepoRoot string) (models.Application, error) {
+// Fetch resolves ref to the parsed Application or ApplicationSet it names.
+func (f *RealApplicationFetcher) Fetch(ctx context.Context, ref anchor.ApplicationRef, localRepoRoot string) (ports.AnchoredManifest, error) {
 	if ref.Repo == "" {
 		return f.fetchFromLocal(ref.Path, localRepoRoot)
 	}
 	return f.fetchFromRemote(ctx, ref)
 }
 
-// fetchFromLocal reads ref.Path under localRepoRoot through the same Target.parse
-// pipeline used for in-repo Application files. The path is constrained to stay
-// within localRepoRoot — a same-repo anchor pointing at `../../etc/passwd`
-// would otherwise resolve to a file outside the project. The threat is low
-// (the attacker already needs commit access to plant the anchor), but the
-// guard matches the symmetric defense in MaterializeTreeDir, and is shared
-// with MaterializeChartFromWorkingTree via resolveRepoPath.
-func (f *RealApplicationFetcher) fetchFromLocal(path, localRepoRoot string) (models.Application, error) {
+// parseAnchoredManifest decodes an anchored manifest as whichever kind it
+// declares. A kind neither flow can render, and an ApplicationSet argo-compare
+// cannot expand, both fail: an anchor is an explicit pointer, so honouring it
+// partially would hide a broken configuration behind a passing run.
+func parseAnchoredManifest(content []byte) (ports.AnchoredManifest, error) {
+	appSet, err := parseApplicationSetContent(content)
+	switch {
+	case err == nil:
+		return ports.AnchoredManifest{ApplicationSet: appSet}, nil
+	case !errors.Is(err, models.ErrNotApplicationSet):
+		return ports.AnchoredManifest{}, err
+	}
+
+	app := models.Application{}
+	if err := yaml.Unmarshal(content, &app); err != nil {
+		return ports.AnchoredManifest{}, err
+	}
+	if err := app.Validate(); err != nil {
+		return ports.AnchoredManifest{}, err
+	}
+
+	return ports.AnchoredManifest{Application: &app}, nil
+}
+
+// fetchFromLocal reads ref.Path under localRepoRoot. resolveRepoPath keeps the
+// path inside localRepoRoot, so a planted anchor naming `../../etc/passwd`
+// cannot reach outside the project — the same guard MaterializeTreeDir and
+// MaterializeChartFromWorkingTree apply to the paths they are handed.
+func (f *RealApplicationFetcher) fetchFromLocal(path, localRepoRoot string) (ports.AnchoredManifest, error) {
 	abs, err := resolveRepoPath(localRepoRoot, path)
 	if err != nil {
-		return models.Application{}, fmt.Errorf("anchor application.path %q: %w", path, err)
+		return ports.AnchoredManifest{}, fmt.Errorf("anchor application.path %q: %w", path, err)
 	}
-	target := Target{
-		CmdRunner:  f.CmdRunner,
-		FileReader: f.FileReader,
-		Log:        f.Log,
-		File:       abs,
+
+	content, err := f.FileReader.ReadFile(abs)
+	if err != nil {
+		return ports.AnchoredManifest{}, fmt.Errorf("read anchored manifest %q: %w", abs, err)
 	}
-	if err := target.parse(); err != nil {
-		return models.Application{}, fmt.Errorf("read local Application %q: %w", abs, err)
+
+	manifest, err := parseAnchoredManifest(content)
+	if err != nil {
+		return ports.AnchoredManifest{}, fmt.Errorf("read local manifest %q: %w", abs, err)
 	}
-	return target.App, nil
+
+	return manifest, nil
 }
 
 // fetchFromRemote clones ref.Repo into memory at Branch tip and reads ref.Path
-// from the resulting tree. The clone happens against memory storage and a
-// memfs worktree so nothing touches the local filesystem until the parsed
-// content is written to a temp file for Target.parse.
-func (f *RealApplicationFetcher) fetchFromRemote(ctx context.Context, ref anchor.ApplicationRef) (models.Application, error) {
+// from the resulting tree. Memory storage and a memfs worktree keep the local
+// filesystem untouched.
+func (f *RealApplicationFetcher) fetchFromRemote(ctx context.Context, ref anchor.ApplicationRef) (ports.AnchoredManifest, error) {
 	cloneOpts := f.buildCloneOptions(ref)
 
 	safeRepo := redactRepo(ref.Repo)
 	repo, err := git.CloneContext(ctx, memory.NewStorage(), memfs.New(), cloneOpts)
 	if err != nil {
-		return models.Application{}, fmt.Errorf("clone %s: %w", safeRepo, err)
+		return ports.AnchoredManifest{}, fmt.Errorf("clone %s: %w", safeRepo, err)
 	}
 
 	head, err := repo.Head()
 	if err != nil {
-		return models.Application{}, fmt.Errorf("resolve HEAD of %s: %w", safeRepo, err)
+		return ports.AnchoredManifest{}, fmt.Errorf("resolve HEAD of %s: %w", safeRepo, err)
 	}
 
 	commit, err := repo.CommitObject(head.Hash())
 	if err != nil {
-		return models.Application{}, fmt.Errorf("read HEAD commit of %s: %w", safeRepo, err)
+		return ports.AnchoredManifest{}, fmt.Errorf("read HEAD commit of %s: %w", safeRepo, err)
 	}
 
 	tree, err := commit.Tree()
 	if err != nil {
-		return models.Application{}, fmt.Errorf("read HEAD tree of %s: %w", safeRepo, err)
+		return ports.AnchoredManifest{}, fmt.Errorf("read HEAD tree of %s: %w", safeRepo, err)
 	}
 
 	file, err := tree.File(ref.Path)
 	if err != nil {
-		return models.Application{}, fmt.Errorf("read %s from %s: %w", ref.Path, safeRepo, err)
+		return ports.AnchoredManifest{}, fmt.Errorf("read %s from %s: %w", ref.Path, safeRepo, err)
 	}
 
 	content, err := file.Contents()
 	if err != nil {
-		return models.Application{}, fmt.Errorf("read contents of %s from %s: %w", ref.Path, safeRepo, err)
+		return ports.AnchoredManifest{}, fmt.Errorf("read contents of %s from %s: %w", ref.Path, safeRepo, err)
 	}
 
-	tmpFile, err := helpers.CreateTempFile(f.FS, content)
+	manifest, err := parseAnchoredManifest([]byte(content))
 	if err != nil {
-		return models.Application{}, fmt.Errorf("buffer fetched Application: %w", err)
+		return ports.AnchoredManifest{}, fmt.Errorf("parse manifest %s from %s: %w", ref.Path, safeRepo, err)
 	}
-	defer func() {
-		if removeErr := afero.Fs.Remove(f.FS, tmpFile.Name()); removeErr != nil {
-			f.Log.Errorf("Failed to remove temporary file [%s]: %s", tmpFile.Name(), removeErr)
-		}
-	}()
 
-	target := Target{
-		CmdRunner:  f.CmdRunner,
-		FileReader: f.FileReader,
-		Log:        f.Log,
-		File:       tmpFile.Name(),
-	}
-	if err := target.parse(); err != nil {
-		return models.Application{}, fmt.Errorf("parse Application %s from %s: %w", ref.Path, safeRepo, err)
-	}
-	return target.App, nil
+	return manifest, nil
 }
 
 // buildCloneOptions assembles the *git.CloneOptions used by fetchFromRemote.

--- a/internal/app/application_fetcher_test.go
+++ b/internal/app/application_fetcher_test.go
@@ -4,18 +4,17 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/shini4i/argo-compare/cmd/argo-compare/utils"
-	"github.com/shini4i/argo-compare/cmd/argo-compare/utils/logger"
 	"github.com/shini4i/argo-compare/internal/anchor"
-	"github.com/shini4i/argo-compare/internal/ports/portstest"
+	"github.com/shini4i/argo-compare/internal/models"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -41,12 +40,8 @@ spec:
 
 func newTestFetcher(t *testing.T) *RealApplicationFetcher {
 	t.Helper()
-	return &RealApplicationFetcher{
-		FS:         afero.NewOsFs(),
-		FileReader: utils.OsFileReader{},
-		CmdRunner:  portstest.NoopCmdRunner{},
-		Log:        logger.New("fetcher-test-" + t.Name()),
-	}
+	t.Helper()
+	return &RealApplicationFetcher{FileReader: utils.OsFileReader{}}
 }
 
 func TestFetcher_SameRepo_HappyPath(t *testing.T) {
@@ -55,11 +50,12 @@ func TestFetcher_SameRepo_HappyPath(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "apps", "example.yaml"), []byte(sampleApplicationYAML), 0o644))
 
 	f := newTestFetcher(t)
-	app, err := f.Fetch(context.Background(), anchor.ApplicationRef{Path: "apps/example.yaml"}, repoRoot)
+	manifest, err := f.Fetch(context.Background(), anchor.ApplicationRef{Path: "apps/example.yaml"}, repoRoot)
 	require.NoError(t, err)
-	assert.Equal(t, "Application", app.Kind)
-	assert.Equal(t, "example", app.Metadata.Name)
-	assert.Equal(t, "example-chart", app.Spec.Source.Chart)
+	require.NotNil(t, manifest.Application)
+	assert.Equal(t, "Application", manifest.Application.Kind)
+	assert.Equal(t, "example", manifest.Application.Metadata.Name)
+	assert.Equal(t, "example-chart", manifest.Application.Spec.Source.Chart)
 }
 
 func TestFetcher_SameRepo_FileMissing(t *testing.T) {
@@ -67,7 +63,10 @@ func TestFetcher_SameRepo_FileMissing(t *testing.T) {
 
 	f := newTestFetcher(t)
 	_, err := f.Fetch(context.Background(), anchor.ApplicationRef{Path: "apps/missing.yaml"}, repoRoot)
-	require.Error(t, err)
+	// OsFileReader maps a missing file to no content and no error, so the
+	// absence surfaces from validation rather than from the read.
+	require.ErrorIs(t, err, models.ErrEmptyFile)
+	assert.Contains(t, err.Error(), "read local manifest")
 }
 
 func TestFetcher_SameRepo_NotAnApplication(t *testing.T) {
@@ -100,14 +99,15 @@ func TestFetcher_CrossRepo_HappyPath(t *testing.T) {
 	require.NoError(t, seedBareRepoWithApplication(t, bareDir, "main", "apps/example.yaml", sampleApplicationYAML))
 
 	f := newTestFetcher(t)
-	app, err := f.Fetch(context.Background(), anchor.ApplicationRef{
+	manifest, err := f.Fetch(context.Background(), anchor.ApplicationRef{
 		Repo:   bareDir,
 		Path:   "apps/example.yaml",
 		Branch: "main",
 	}, "")
 	require.NoError(t, err)
-	assert.Equal(t, "example", app.Metadata.Name)
-	assert.Equal(t, "example-chart", app.Spec.Source.Chart)
+	require.NotNil(t, manifest.Application)
+	assert.Equal(t, "example", manifest.Application.Metadata.Name)
+	assert.Equal(t, "example-chart", manifest.Application.Spec.Source.Chart)
 }
 
 func TestFetcher_CrossRepo_FileMissing(t *testing.T) {
@@ -170,13 +170,14 @@ func TestFetcher_CrossRepo_BranchDefaultsToHEAD(t *testing.T) {
 	require.NoError(t, seedBareRepoWithApplication(t, bareDir, "main", "apps/example.yaml", sampleApplicationYAML))
 
 	f := newTestFetcher(t)
-	app, err := f.Fetch(context.Background(), anchor.ApplicationRef{
+	manifest, err := f.Fetch(context.Background(), anchor.ApplicationRef{
 		Repo: bareDir,
 		Path: "apps/example.yaml",
 		// Branch intentionally omitted.
 	}, "")
 	require.NoError(t, err)
-	assert.Equal(t, "example", app.Metadata.Name)
+	require.NotNil(t, manifest.Application)
+	assert.Equal(t, "example", manifest.Application.Metadata.Name)
 }
 
 func TestFetcher_buildCloneOptions_NoAuthWhenTokenEmpty(t *testing.T) {
@@ -257,7 +258,7 @@ func TestRedactRepo(t *testing.T) {
 	cases := []struct {
 		in, want string
 	}{
-		{"https://user:token@host.example.com/group/repo.git", "https://host.example.com/group/repo.git"},
+		{"https://user:token@host.example.com/group/repo.git", "https://host.example.com/group/repo.git"}, // trufflehog:ignore
 		{"https://host.example.com/group/repo.git", "https://host.example.com/group/repo.git"},
 		{"ssh://git@host.example.com/group/repo.git", "ssh://host.example.com/group/repo.git"},
 		{"git@host.example.com:group/repo.git", "git@host.example.com:group/repo.git"},
@@ -317,4 +318,74 @@ func seedBareRepoWithApplication(t *testing.T, bareDir, branch, filePath, conten
 		RemoteName: "origin",
 		RefSpecs:   []config.RefSpec{config.RefSpec("refs/heads/" + branch + ":refs/heads/" + branch)},
 	})
+}
+
+func TestParseAnchoredManifest(t *testing.T) {
+	const appSetYAML = `apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: demo
+  namespace: argocd
+spec:
+  goTemplate: true
+  generators:
+    - list:
+        elements:
+          - cluster: dev
+  template:
+    metadata:
+      name: '{{ .cluster }}-demo'
+`
+
+	cases := []struct {
+		name            string
+		content         string
+		wantKind        string
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{name: "Application", content: sampleApplicationYAML, wantKind: models.KindApplication},
+		{name: "ApplicationSet", content: appSetYAML, wantKind: models.KindApplicationSet},
+		{name: "another kind", content: "kind: ConfigMap\nmetadata:\n  name: cm\n", wantErrIs: models.ErrNotApplication},
+		{name: "empty", content: "", wantErrIs: models.ErrEmptyFile},
+		{
+			name:            "Application shape the decoder rejects",
+			content:         "kind: Application\nspec:\n  source: not-a-map\n",
+			wantErrContains: "cannot unmarshal",
+		},
+		{
+			name:      "ApplicationSet without goTemplate",
+			content:   strings.Replace(appSetYAML, "  goTemplate: true\n", "", 1),
+			wantErrIs: models.ErrUnsupportedAppConfiguration,
+		},
+		{
+			name:      "Application with both chart and path",
+			content:   strings.Replace(sampleApplicationYAML, "    chart: example-chart\n", "    chart: example-chart\n    path: charts/demo\n", 1),
+			wantErrIs: models.ErrUnsupportedAppConfiguration,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			manifest, err := parseAnchoredManifest([]byte(c.content))
+			if c.wantErrIs != nil {
+				require.ErrorIs(t, err, c.wantErrIs)
+				return
+			}
+			if c.wantErrContains != "" {
+				require.ErrorContains(t, err, c.wantErrContains)
+				return
+			}
+
+			require.NoError(t, err)
+			switch c.wantKind {
+			case models.KindApplication:
+				require.NotNil(t, manifest.Application)
+				assert.Nil(t, manifest.ApplicationSet)
+			case models.KindApplicationSet:
+				require.NotNil(t, manifest.ApplicationSet)
+				assert.Nil(t, manifest.Application)
+			}
+		})
+	}
 }

--- a/internal/app/appset_dirs.go
+++ b/internal/app/appset_dirs.go
@@ -21,7 +21,7 @@ func assertGitGeneratorsComparable(appSet *models.ApplicationSet, originURL, tar
 
 		if !repoIdentityMatches(generator.Git.RepoURL, originURL) {
 			return fmt.Errorf("%w: git generator repoURL %q is not this repository (%q); only same-repository generators are supported",
-				models.ErrUnsupportedAppConfiguration, generator.Git.RepoURL, originURL)
+				models.ErrUnsupportedAppConfiguration, redactRepo(generator.Git.RepoURL), redactRepo(originURL))
 		}
 
 		// A pinned revision keeps ArgoCD generating from a fixed tree, so a

--- a/internal/app/appset_flow.go
+++ b/internal/app/appset_flow.go
@@ -192,8 +192,12 @@ func (a *App) compareGeneratedApplication(ctx context.Context, repo *GitRepo, fi
 
 	validationResults := make(map[string]ports.ValidationResult)
 
-	if err = a.renderGeneratedLegs(ctx, repo, pair, tmpDir, validationResults); err != nil {
+	proceed, err := a.renderGeneratedLegs(ctx, repo, pair, tmpDir, validationResults)
+	if err != nil {
 		return false, err
+	}
+	if !proceed {
+		return false, nil
 	}
 
 	if err = a.runComparison(ctx, tmpDir, generatedLabel(file, pair.name), validationResults); err != nil {
@@ -227,21 +231,34 @@ func (a *App) skipOneSidedPair(pair generatedPair) bool {
 
 // renderGeneratedLegs renders whichever branches still generate the Application.
 // A leg with no Application renders nothing, so the comparison reports every
-// manifest on the other side as added or removed.
-func (a *App) renderGeneratedLegs(ctx context.Context, repo *GitRepo, pair generatedPair, tmpDir string, validationResults map[string]ports.ValidationResult) error {
+// manifest on the other side as added or removed. It returns false when the
+// comparison should be skipped for want of a baseline to diff against.
+func (a *App) renderGeneratedLegs(ctx context.Context, repo *GitRepo, pair generatedPair, tmpDir string, validationResults map[string]ports.ValidationResult) (bool, error) {
 	if pair.src != nil {
 		if err := a.renderGeneratedLeg(ctx, repo, *pair.src, TargetTypeSource, tmpDir, validationResults); err != nil {
-			return err
+			return false, err
 		}
 	}
 
-	if pair.dst != nil {
-		if err := a.renderGeneratedLeg(ctx, repo, *pair.dst, TargetTypeDestination, tmpDir, validationResults); err != nil {
-			return err
-		}
+	if pair.dst == nil {
+		return true, nil
 	}
 
-	return nil
+	// A path-based chart the branch adds for the first time is absent from the
+	// merge-base tree even though both branches generate the Application, so the
+	// baseline leg has nothing to render. That is a new chart, not a failure.
+	destErr := a.renderGeneratedLeg(ctx, repo, *pair.dst, TargetTypeDestination, tmpDir, validationResults)
+	switch {
+	case destErr == nil:
+		return true, nil
+	case errors.Is(destErr, ErrChartPathNotInTree):
+		a.logger.Warning(ui.Yellow(fmt.Sprintf(
+			"The chart for generated Application [%s] does not exist in target branch %s, assuming it is new",
+			pair.name, a.cfg.TargetBranch)))
+		return a.cfg.PrintAddedManifests, nil
+	default:
+		return false, destErr
+	}
 }
 
 // renderGeneratedLeg renders one leg of a generated Application. No File is set

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -175,15 +175,18 @@ type ManifestValidator interface {
 	Validate(ctx context.Context, target, manifestDir string) (ValidationResult, error)
 }
 
-// ApplicationFetcher resolves an anchor.ApplicationRef to a parsed
-// Application model.
-//
-// For same-repo refs (Repo == ""), implementations read from the working tree
-// at localRepoRoot. For cross-repo refs, implementations fetch the file from
-// the named remote at Branch tip without affecting the local working tree.
-//
-// Any failure (network, missing file, parse error) is returned as a hard
-// error so the caller can fail loudly; partial results are not supported.
+// AnchoredManifest is the manifest an anchor resolves to. Exactly one field is
+// non-nil: an anchor may name a single Application, or an ApplicationSet whose
+// generated Applications are then compared one by one.
+type AnchoredManifest struct {
+	Application    *models.Application
+	ApplicationSet *models.ApplicationSet
+}
+
+// ApplicationFetcher resolves an anchor.ApplicationRef to the manifest it names.
+// Same-repo refs (Repo == "") read from the working tree at localRepoRoot;
+// cross-repo refs read the file from the named remote at Branch tip. Any failure
+// is a hard error so the caller can fail loudly; partial results are unsupported.
 type ApplicationFetcher interface {
-	Fetch(ctx context.Context, ref anchor.ApplicationRef, localRepoRoot string) (models.Application, error)
+	Fetch(ctx context.Context, ref anchor.ApplicationRef, localRepoRoot string) (AnchoredManifest, error)
 }


### PR DESCRIPTION
A `.argo-compare.yml` anchor may point at an ApplicationSet, not only an Application. The manifest is read once at the anchor branch tip and expanded per comparison leg, so each generated Application is compared like a changed one.

Only generated Applications rendering a chart from this repository are compared — a registry chart or a source in another repository is skipped with the reason named, and none qualifying is an error rather than a silently empty run. This is the only way to reach an ApplicationSet stored in a different repository, which the local scan cannot see.

Two fixes came out of it, both wider than the anchor path so the two ApplicationSet flows do not diverge: a generated Application whose chart the branch adds for the first time is treated as new instead of failing the run, and anchor groups resolving to one manifest are deduplicated (previously a whole diff, and its MR comment, repeated per anchor).

The issue #158 valueFiles preflight still does not cover generated Applications — unchanged from the changed-manifest flow, left for its own change.

Stacked on #165.