### PR TITLE
feat(comment): publish one merge request note per run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- A run now posts a single merge request note covering every Application it compared, with a section each, instead of one note per Application. An ApplicationSet generating thirty Applications previously produced thirty notes. The note is split only when it would exceed GitLab's 1 MB limit, and each part names the Application whose diff it carries. A validation summary large enough to fill a note on its own is truncated, with the full detail left in the job log.
 - Manifests skipped for an unsupported configuration now log why they were skipped, instead of only naming the file.
 - Cross-repo anchored Applications now fail with a clear, actionable error when the pull request restructures a chart's values files (for example splitting one `values.yaml` into several) but the Application — read from the anchored repo's branch tip — still references the old layout. Previously this surfaced as an opaque `helm template` "no such file" error. See `docs/anchored-repositories.md` for the workaround.
 

--- a/docs/applicationsets.md
+++ b/docs/applicationsets.md
@@ -171,6 +171,11 @@ newlines and indentation inside it cannot change how the manifest parses, so
 `{{ toYaml .values }}` needs no `nindent` ceremony, and `nindent` means the
 column you wrote rather than one derived from anything internal.
 
+## Merge request comments
+
+Every generated Application appears as a section of a single merge request note,
+not one note each. See [GitLab integration](gitlab-integration.md).
+
 ## Added and removed Applications
 
 A change to an ApplicationSet can change *which* Applications exist, not only

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,8 +88,13 @@ contains:
    `tree_materialize.go`. The anchor schema itself is in
    `internal/anchor`.
 
-All three converge on the same comparison + comment publication path in
-`internal/app/compare.go` and `comment_strategy.go`.
+All three converge on the same comparison path in `internal/app/compare.go`.
+
+Comment publication is decoupled from it: a `commentCollector` appends each
+comparison to `App.commentSections`, and `Run` publishes the batch as one
+comment once every comparison has finished (`internal/app/app.go`). The
+`Comment publishing` side-effect below therefore fires once per run, not once
+per comparison, while the stdout and external-diff presenters still run inline.
 
 ## Side-effects and where they live
 

--- a/docs/gitlab-integration.md
+++ b/docs/gitlab-integration.md
@@ -31,3 +31,18 @@ When running inside GitLab CI, most settings are detected automatically:
 - `--gitlab-project-id` falls back to `CI_PROJECT_ID`.
 - `--gitlab-merge-request-iid` falls back to `CI_MERGE_REQUEST_IID`.
 - `--gitlab-token` falls back to `CI_JOB_TOKEN` if no explicit token is provided (ensure the token has the necessary scope to post notes).
+
+## One note per run
+
+A run publishes a single note covering every Application it compared, with a
+section each. An ApplicationSet generating thirty Applications therefore posts
+one note, not thirty. Applications with no differences are still listed, so the
+note accounts for everything that was compared.
+
+The note is split only when it would exceed GitLab's 1 MB limit. Each part is
+numbered, and a part that begins partway through an Application repeats its
+name, so no diff is ever shown without saying which Application it belongs to.
+
+An Application whose validation output alone would fill a note has that summary
+truncated, with a pointer to the job log for the rest — a note over the limit is
+rejected outright, which would cost every other Application its results too.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -192,10 +192,10 @@ func (a *App) Run(ctx context.Context) error {
 	// still what the reviewer needs. A cancelled context is the exception — the
 	// poster honours it, so an interrupted run publishes nothing.
 	if flushErr := a.flushComments(ctx); flushErr != nil {
-		if compareErr == nil {
-			return flushErr
-		}
 		a.logger.Errorf("Failed to publish the comparison comment: %s", flushErr)
+		// Both are reported: a caller that only sees the comparison error cannot
+		// tell the merge request went unpublished.
+		return errors.Join(compareErr, flushErr)
 	}
 	if compareErr != nil {
 		return compareErr

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -66,6 +66,8 @@ type App struct {
 	sensitiveDataMasker ports.SensitiveDataMasker // Applied to manifest content prior to diff generation.
 	validator           ports.ManifestValidator   // Optional validator for rendered manifests.
 	fetcher             ports.ApplicationFetcher  // Resolves anchored Applications. Optional; defaults to a real impl.
+	commentPoster       comment.Poster            // Built on first use and kept; nil until a comparison needs it.
+	commentSections     []commentSection          // One per comparison, published together at the end of the run.
 }
 
 // CommentPosterFactory builds a comment poster based on the active configuration.
@@ -184,9 +186,19 @@ func (a *App) Run(ctx context.Context) error {
 		return nil
 	}
 
-	validationFailed, err := a.runComparisons(ctx, repo, inputs.changed, inputs.groups)
-	if err != nil {
-		return err
+	validationFailed, compareErr := a.runComparisons(ctx, repo, inputs.changed, inputs.groups)
+
+	// Publish even when a later comparison failed: what was already compared is
+	// still what the reviewer needs. A cancelled context is the exception — the
+	// poster honours it, so an interrupted run publishes nothing.
+	if flushErr := a.flushComments(ctx); flushErr != nil {
+		if compareErr == nil {
+			return flushErr
+		}
+		a.logger.Errorf("Failed to publish the comparison comment: %s", flushErr)
+	}
+	if compareErr != nil {
+		return compareErr
 	}
 
 	if err := a.reportInvalidFiles(inputs.invalid); err != nil {
@@ -621,24 +633,67 @@ func (a *App) selectDiffStrategies(applicationFile string) ([]DiffPresenter, err
 	}
 
 	if a.cfg.Comment != nil && a.cfg.Comment.Provider != CommentProviderNone {
-		poster, err := a.commentFactory(a.cfg)
-		if err != nil {
+		if _, err := a.commentPosterForRun(); err != nil {
 			return nil, err
 		}
-		if poster == nil {
-			return nil, fmt.Errorf("comment poster factory returned nil for provider %q", a.cfg.Comment.Provider)
-		}
 
-		strategies = append(strategies, CommentStrategy{
-			Log:             a.logger,
-			Poster:          poster,
-			ShowAdded:       a.cfg.PrintAddedManifests,
-			ShowRemoved:     a.cfg.PrintRemovedManifests,
-			ApplicationPath: applicationFile,
-		})
+		strategies = append(strategies, commentCollector{app: a, label: applicationFile})
 	}
 
 	return strategies, nil
+}
+
+// commentCollector defers one comparison's result to the run's single comment,
+// so an ApplicationSet generating many Applications does not post a note each.
+type commentCollector struct {
+	app   *App
+	label string
+}
+
+// Present adds the comparison to the run's batch rather than publishing it;
+// flushComments publishes the batch once every comparison has finished.
+func (c commentCollector) Present(_ context.Context, result ComparisonResult) error {
+	c.app.commentSections = append(c.app.commentSections, commentSection{label: c.label, result: result})
+	return nil
+}
+
+// commentPosterForRun builds the poster on first use and reuses it, so one
+// client serves every comparison in the run.
+func (a *App) commentPosterForRun() (comment.Poster, error) {
+	if a.commentPoster != nil {
+		return a.commentPoster, nil
+	}
+
+	poster, err := a.commentFactory(a.cfg)
+	if err != nil {
+		return nil, err
+	}
+	if poster == nil {
+		return nil, fmt.Errorf("comment poster factory returned nil for provider %q", a.cfg.Comment.Provider)
+	}
+
+	a.commentPoster = poster
+
+	return poster, nil
+}
+
+// flushComments publishes every comparison collected during the run as one
+// comment, splitting only when the note limit demands it. The batch is cleared
+// as it is taken, so a second run publishes only its own comparisons.
+func (a *App) flushComments(ctx context.Context) error {
+	if len(a.commentSections) == 0 || a.commentPoster == nil {
+		return nil
+	}
+
+	sections := a.commentSections
+	a.commentSections = nil
+
+	return CommentStrategy{
+		Log:         a.logger,
+		Poster:      a.commentPoster,
+		ShowAdded:   a.cfg.PrintAddedManifests,
+		ShowRemoved: a.cfg.PrintRemovedManifests,
+	}.PresentSections(ctx, sections)
 }
 
 // collectRepoCredentials loads repository credentials from environment variables.

--- a/internal/app/app_integration_test.go
+++ b/internal/app/app_integration_test.go
@@ -180,6 +180,9 @@ type stubHelmProcessor struct {
 	mu      sync.Mutex
 	calls   map[string]int
 	tmpDirs map[string]struct{}
+	// renderErrFor fails RenderAppSource for a given release name, so a test can
+	// make one Application of a set fail while the rest render.
+	renderErrFor map[string]error
 }
 
 func newStubHelmProcessor(t *testing.T) *stubHelmProcessor {
@@ -235,6 +238,9 @@ func (s *stubHelmProcessor) ExtractHelmChart(_ context.Context, _ ports.HelmDeps
 
 func (s *stubHelmProcessor) RenderAppSource(_ context.Context, _ ports.CmdRunner, req ports.ChartRenderRequest) error {
 	s.record("RenderAppSource", req.TmpDir)
+	if err := s.renderErrFor[req.ReleaseName]; err != nil {
+		return err
+	}
 	dir := filepath.Join(req.TmpDir, "templates", req.TargetType, req.ChartName)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -87,8 +87,12 @@ func TestSelectDiffStrategiesIncludesCommentStrategy(t *testing.T) {
 
 	_, isStdout := strategies[0].(StdoutStrategy)
 	assert.True(t, isStdout)
-	_, isComment := strategies[1].(CommentStrategy)
-	assert.True(t, isComment)
+	// Comments are collected, not posted per comparison, so a run publishes one
+	// note covering every Application it compared.
+	collector, isCollector := strategies[1].(commentCollector)
+	require.True(t, isCollector)
+	assert.Equal(t, "apps/foo.yaml", collector.label)
+	assert.NotNil(t, appInstance.commentPoster, "the poster is built once, up front")
 }
 
 func TestSelectDiffStrategiesErrorFromFactory(t *testing.T) {

--- a/internal/app/appset_integration_test.go
+++ b/internal/app/appset_integration_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/shini4i/argo-compare/cmd/argo-compare/utils"
 	"github.com/shini4i/argo-compare/cmd/argo-compare/utils/logger"
+	"github.com/shini4i/argo-compare/internal/comment"
 	"github.com/shini4i/argo-compare/internal/models"
 	"github.com/shini4i/argo-compare/internal/ports"
 	"github.com/shini4i/argo-compare/internal/ports/portstest"
@@ -183,6 +184,14 @@ type appSetRunner struct {
 func newAppSetRunner(t *testing.T, cfg Config, validator *stubValidator) *appSetRunner {
 	t.Helper()
 
+	return newAppSetRunnerWith(t, cfg, validator, nil)
+}
+
+// newAppSetRunnerWith is newAppSetRunner with an optional comment poster. Both
+// share one wiring so a dependency added here reaches every caller.
+func newAppSetRunnerWith(t *testing.T, cfg Config, validator *stubValidator, poster comment.Poster) *appSetRunner {
+	t.Helper()
+
 	tempDir := t.TempDir()
 	cfg.TargetBranch = "main"
 	cfg.CacheDir = filepath.Join(tempDir, "cache")
@@ -204,6 +213,9 @@ func newAppSetRunner(t *testing.T, cfg Config, validator *stubValidator) *appSet
 	}
 	if validator != nil {
 		deps.ManifestValidator = validator
+	}
+	if poster != nil {
+		deps.CommentPosterFactory = func(Config) (comment.Poster, error) { return poster, nil }
 	}
 
 	appInstance, err := New(cfg, deps)

--- a/internal/app/comment_batch_test.go
+++ b/internal/app/comment_batch_test.go
@@ -1,0 +1,290 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/shini4i/argo-compare/internal/ports"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// changedSection is one Application's result carrying a single changed file.
+func changedSection(label, file string) commentSection {
+	return commentSection{
+		label: label,
+		result: ComparisonResult{
+			Changed: []DiffOutput{{File: File{Name: file}, Diff: "--- a\n+++ b\n@@ diff\n- old\n+ new"}},
+		},
+	}
+}
+
+// TestCommentStrategyBatchesSections is the reason batching exists: an
+// ApplicationSet generating many Applications must produce one note, not one
+// per Application.
+func TestCommentStrategyBatchesSections(t *testing.T) {
+	poster := &stubPoster{}
+	strategy := CommentStrategy{Log: setupSilentLogger("comment-batch", t), Poster: poster}
+
+	sections := []commentSection{
+		changedSection("apps/appset.yaml [dev-guestbook]", "dev.yaml"),
+		changedSection("apps/appset.yaml [prod-guestbook]", "prod.yaml"),
+	}
+
+	require.NoError(t, strategy.PresentSections(context.Background(), sections))
+
+	require.Len(t, poster.bodies, 1, "every generated Application belongs to one note")
+	body := poster.bodies[0]
+	assert.Equal(t, 1, strings.Count(body, "## Argo Compare Results"), "the run header appears once")
+	assert.Contains(t, body, "**Application:** `apps/appset.yaml [dev-guestbook]`")
+	assert.Contains(t, body, "**Application:** `apps/appset.yaml [prod-guestbook]`")
+	assert.NotContains(t, body, "Part 1 of")
+
+	// Each Application's diffs must sit between its own heading and the next,
+	// or the note would attribute one Application's change to another.
+	for _, want := range []string{"<summary>Changed • dev.yaml</summary>", "<summary>Changed • prod.yaml</summary>"} {
+		require.Contains(t, body, want)
+	}
+	assert.Less(t, strings.Index(body, "[dev-guestbook]"), strings.Index(body, "dev.yaml"))
+	assert.Less(t, strings.Index(body, "dev.yaml"), strings.Index(body, "[prod-guestbook]"))
+	assert.Less(t, strings.Index(body, "[prod-guestbook]"), strings.Index(body, "prod.yaml"))
+}
+
+// TestCommentStrategyBatchKeepsSectionOrder pins the order to the order the
+// comparisons ran, so the note reads the same way as the log.
+func TestCommentStrategyBatchKeepsSectionOrder(t *testing.T) {
+	poster := &stubPoster{}
+	strategy := CommentStrategy{Log: setupSilentLogger("comment-batch-order", t), Poster: poster}
+
+	sections := []commentSection{
+		changedSection("b-app", "b.yaml"),
+		changedSection("a-app", "a.yaml"),
+	}
+
+	require.NoError(t, strategy.PresentSections(context.Background(), sections))
+
+	body := poster.bodies[0]
+	require.Contains(t, body, "`b-app`")
+	require.Contains(t, body, "`a-app`")
+	assert.Less(t, strings.Index(body, "`b-app`"), strings.Index(body, "`a-app`"))
+}
+
+// TestCommentStrategyBatchReportsEmptySections proves an Application with no
+// differences is still named, rather than silently missing from the note.
+func TestCommentStrategyBatchReportsEmptySections(t *testing.T) {
+	poster := &stubPoster{}
+	strategy := CommentStrategy{Log: setupSilentLogger("comment-batch-empty", t), Poster: poster}
+
+	sections := []commentSection{
+		{label: "quiet-app"},
+		changedSection("busy-app", "busy.yaml"),
+	}
+
+	require.NoError(t, strategy.PresentSections(context.Background(), sections))
+
+	require.Len(t, poster.bodies, 1)
+	body := poster.bodies[0]
+	assert.Contains(t, body, "**Application:** `quiet-app`")
+	assert.Contains(t, body, "No manifest differences detected")
+	assert.Contains(t, body, "<summary>Changed • busy.yaml</summary>")
+}
+
+func TestCommentStrategyBatchAllSectionsEmpty(t *testing.T) {
+	poster := &stubPoster{}
+	strategy := CommentStrategy{Log: setupSilentLogger("comment-batch-all-empty", t), Poster: poster}
+
+	sections := []commentSection{{label: "one"}, {label: "two"}}
+
+	require.NoError(t, strategy.PresentSections(context.Background(), sections))
+
+	require.Len(t, poster.bodies, 1)
+	assert.Equal(t, 2, strings.Count(poster.bodies[0], "No manifest differences detected"))
+}
+
+// TestCommentStrategyBatchSplitsAcrossNotes proves batching still respects the
+// note size limit, and that each part carries the run header.
+func TestCommentStrategyBatchSplitsAcrossNotes(t *testing.T) {
+	poster := &stubPoster{}
+	strategy := CommentStrategy{Log: setupSilentLogger("comment-batch-large", t), Poster: poster, ShowAdded: true}
+
+	largeDiff := strings.Repeat("+ oversized line\n", 160000)
+	sections := []commentSection{
+		{label: "big-one", result: ComparisonResult{Added: []DiffOutput{{File: File{Name: "a.yaml"}, Diff: largeDiff}}}},
+		{label: "big-two", result: ComparisonResult{Added: []DiffOutput{{File: File{Name: "b.yaml"}, Diff: largeDiff}}}},
+	}
+
+	require.NoError(t, strategy.PresentSections(context.Background(), sections))
+
+	require.Greater(t, len(poster.bodies), 1)
+	total := len(poster.bodies)
+	for idx, body := range poster.bodies {
+		assert.Contains(t, body, "## Argo Compare Results", "part %d must carry the run header", idx+1)
+		assert.LessOrEqual(t, len(body), gitlabNoteLengthLimit, "part %d must fit GitLab's note limit", idx+1)
+	}
+	assert.Contains(t, poster.bodies[0], "Part 1 of "+fmt.Sprint(total))
+	assert.Contains(t, poster.bodies[total-1], fmt.Sprintf("Part %d of %d", total, total))
+}
+
+// TestCommentStrategyBatchCarriesValidationPerSection proves each Application's
+// validation result stays attached to its own section.
+func TestCommentStrategyBatchCarriesValidationPerSection(t *testing.T) {
+	poster := &stubPoster{}
+	strategy := CommentStrategy{Log: setupSilentLogger("comment-batch-validation", t), Poster: poster}
+
+	failing := changedSection("bad-app", "bad.yaml")
+	failing.result.ValidationResults = map[string]ports.ValidationResult{
+		"src": {Target: "src", Valid: false, ResourceCount: 2, ErrorCount: 1},
+	}
+	passing := changedSection("good-app", "good.yaml")
+	passing.result.ValidationResults = map[string]ports.ValidationResult{
+		"src": {Target: "src", Valid: true, ResourceCount: 3},
+	}
+
+	require.NoError(t, strategy.PresentSections(context.Background(), []commentSection{failing, passing}))
+
+	body := poster.bodies[0]
+	require.Contains(t, body, "1/2 valid")
+	require.Contains(t, body, "3/3 valid")
+	require.Contains(t, body, "`good-app`")
+	assert.Less(t, strings.Index(body, "1/2 valid"), strings.Index(body, "`good-app`"))
+}
+
+func TestCommentStrategyPresentSectionsWithoutPoster(t *testing.T) {
+	strategy := CommentStrategy{Log: setupSilentLogger("comment-batch-nil", t)}
+
+	require.Error(t, strategy.PresentSections(context.Background(), []commentSection{{label: "x"}}))
+}
+
+// TestCommentStrategyPresentSectionsNoSections proves an empty batch posts
+// nothing at all, so a run with no comparisons stays silent.
+func TestCommentStrategyPresentSectionsNoSections(t *testing.T) {
+	poster := &stubPoster{}
+	strategy := CommentStrategy{Log: setupSilentLogger("comment-batch-none", t), Poster: poster}
+
+	require.NoError(t, strategy.PresentSections(context.Background(), nil))
+	assert.Empty(t, poster.bodies)
+}
+
+// commentCfg enables GitLab comments with throwaway connection details; the
+// poster is stubbed, so none of them are used.
+func commentCfg() *CommentConfig {
+	return &CommentConfig{
+		Provider: CommentProviderGitLab,
+		GitLab: GitLabCommentConfig{
+			BaseURL:         "https://gitlab.example.com",
+			Token:           "token",
+			ProjectID:       "1",
+			MergeRequestIID: 101,
+		},
+	}
+}
+
+// TestAppRunPostsOneCommentForAnApplicationSet is the problem this batching
+// solves: a 30-element ApplicationSet used to post 30 merge request notes.
+func TestAppRunPostsOneCommentForAnApplicationSet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip integration test in short mode")
+	}
+
+	elements := make([][2]string, 0, 6)
+	for i := range 6 {
+		elements = append(elements, [2]string{fmt.Sprintf("cluster%d", i), "1.0.0"})
+	}
+	bumped := make([][2]string, len(elements))
+	copy(bumped, elements)
+	for i := range bumped {
+		bumped[i][1] = "1.1.0"
+	}
+
+	seedAppSetRepo(t, applicationSetYAML(elements), applicationSetYAML(bumped))
+
+	poster := &stubPoster{}
+	runner := newAppSetRunnerWith(t, Config{Comment: commentCfg()}, nil, poster)
+	require.NoError(t, runner.app.Run(context.Background()))
+
+	require.Len(t, poster.bodies, 1, "six generated Applications must produce one note")
+	body := poster.bodies[0]
+	assert.Equal(t, 6, strings.Count(body, "**Application:**"), "one heading per generated Application")
+	for i := range 6 {
+		assert.Contains(t, body, fmt.Sprintf("**Application:** `%s`",
+			generatedLabel(appSetPath, fmt.Sprintf("cluster%d-guestbook", i))))
+	}
+	assert.Equal(t, 1, strings.Count(body, "## Argo Compare Results"))
+}
+
+// TestAppRunPostsOneCommentForAnAnchoredApplicationSet covers the other way a
+// run fans out to many Applications: an anchor naming an ApplicationSet.
+func TestAppRunPostsOneCommentForAnAnchoredApplicationSet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip integration test in short mode")
+	}
+
+	seedAppSetRepoState(t,
+		branchState{manifest: anchoredAppSetYAML, files: anchoredChartFiles("1")},
+		branchState{manifest: anchoredAppSetYAML, files: anchoredChartFiles("7")})
+
+	poster := &stubPoster{}
+	runner := newAppSetRunnerWith(t, Config{AnchorFileName: DefaultAnchorFileName, Comment: commentCfg()}, nil, poster)
+	require.NoError(t, runner.app.Run(context.Background()))
+
+	require.Len(t, poster.bodies, 1, "both generated Applications belong to one note")
+	body := poster.bodies[0]
+	assert.Equal(t, 2, strings.Count(body, "**Application:**"))
+	assert.Contains(t, body, "**Application:** `"+generatedLabel(appSetPath, "dev-demo")+"`")
+	assert.Contains(t, body, "**Application:** `"+generatedLabel(appSetPath, "prod-demo")+"`")
+}
+
+// commentLabels returns the Application headings a comment body carries.
+func commentLabels(body string) []string {
+	var labels []string
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(line, "**Application:**") {
+			labels = append(labels, strings.TrimSpace(line))
+		}
+	}
+
+	return labels
+}
+
+// TestCommentStrategyBatchAttributesEverySplitNote guards the shape batching
+// makes routine: many Applications share one note budget, so a comment starting
+// partway through one must still name it, and must never open with one
+// Application's diff under another's heading.
+func TestCommentStrategyBatchAttributesEverySplitNote(t *testing.T) {
+	poster := &stubPoster{}
+	strategy := CommentStrategy{Log: setupSilentLogger("comment-batch-attribution", t), Poster: poster, ShowAdded: true}
+
+	largeDiff := strings.Repeat("+ oversized line\n", 160000)
+	sections := []commentSection{
+		{label: "first-app", result: ComparisonResult{Added: []DiffOutput{{File: File{Name: "a.yaml"}, Diff: largeDiff}}}},
+		{label: "second-app", result: ComparisonResult{Added: []DiffOutput{{File: File{Name: "b.yaml"}, Diff: largeDiff}}}},
+	}
+
+	require.NoError(t, strategy.PresentSections(context.Background(), sections))
+	require.Greater(t, len(poster.bodies), len(sections), "the batch must actually split for this to mean anything")
+
+	var order []string
+	for idx, body := range poster.bodies {
+		labels := commentLabels(body)
+		require.Len(t, labels, 1, "note %d must name exactly one Application", idx+1)
+		assert.Contains(t, body, "oversized line", "note %d must carry diff content, not a heading alone", idx+1)
+
+		label := labels[0]
+		switch {
+		case strings.Contains(label, "first-app"):
+			order = append(order, "first")
+		case strings.Contains(label, "second-app"):
+			order = append(order, "second")
+		default:
+			t.Fatalf("note %d names an unexpected Application: %s", idx+1, label)
+		}
+	}
+
+	// Each Application's notes stay together, so a reader never has to stitch
+	// one Application's diff back together across another's notes.
+	assert.Equal(t, "first", order[0])
+	assert.Equal(t, "second", order[len(order)-1])
+	assert.Equal(t, 1, strings.Count(strings.Join(order, ","), "first,second"), "notes must not interleave")
+}

--- a/internal/app/comment_failure_test.go
+++ b/internal/app/comment_failure_test.go
@@ -58,9 +58,10 @@ func TestAppRunPublishesWhatItComparedBeforeAFailure(t *testing.T) {
 	assert.NotContains(t, body, "**Application:** `"+generatedLabel(appSetPath, "gamma-guestbook")+"`")
 }
 
-// TestAppRunPrefersTheComparisonErrorOverTheCommentError proves the root cause
-// wins when both fail, with the publishing failure still surfaced in the log.
-func TestAppRunPrefersTheComparisonErrorOverTheCommentError(t *testing.T) {
+// TestAppRunReportsBothTheComparisonAndCommentErrors proves neither failure is
+// swallowed: a caller seeing only the comparison error could not tell the merge
+// request went unpublished.
+func TestAppRunReportsBothTheComparisonAndCommentErrors(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skip integration test in short mode")
 	}
@@ -76,8 +77,8 @@ func TestAppRunPrefersTheComparisonErrorOverTheCommentError(t *testing.T) {
 
 	err := runner.app.Run(context.Background())
 
-	require.ErrorIs(t, err, assert.AnError, "the comparison error is the root cause")
-	assert.NotErrorIs(t, err, postErr)
+	require.ErrorIs(t, err, assert.AnError, "the comparison failure is reported")
+	require.ErrorIs(t, err, postErr, "the publishing failure is reported too")
 	assert.Contains(t, runner.log.String(), "Failed to publish the comparison comment")
 }
 

--- a/internal/app/comment_failure_test.go
+++ b/internal/app/comment_failure_test.go
@@ -1,0 +1,134 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAppRunFailsWhenTheCommentCannotBePosted proves a rejected note fails the
+// run instead of reporting success over an empty merge request.
+func TestAppRunFailsWhenTheCommentCannotBePosted(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip integration test in short mode")
+	}
+
+	seedAppSetRepo(t,
+		applicationSetYAML([][2]string{{"dev", "1.0.0"}}),
+		applicationSetYAML([][2]string{{"dev", "1.1.0"}}))
+
+	poster := &stubPoster{err: assert.AnError}
+	runner := newAppSetRunnerWith(t, Config{Comment: commentCfg()}, nil, poster)
+
+	err := runner.app.Run(context.Background())
+
+	require.ErrorIs(t, err, assert.AnError)
+	assert.Contains(t, err.Error(), "post diff comment")
+	assert.Len(t, poster.bodies, 1, "the note is attempted once, not retried")
+}
+
+// TestAppRunPublishesWhatItComparedBeforeAFailure is the reordering this change
+// hinges on: comparisons no longer publish as they go, so a later failure must
+// not cost the reviewer the results already gathered.
+func TestAppRunPublishesWhatItComparedBeforeAFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip integration test in short mode")
+	}
+
+	elements := [][2]string{{"alpha", "1.0.0"}, {"beta", "1.0.0"}, {"gamma", "1.0.0"}}
+	bumped := [][2]string{{"alpha", "1.1.0"}, {"beta", "1.1.0"}, {"gamma", "1.1.0"}}
+	seedAppSetRepo(t, applicationSetYAML(elements), applicationSetYAML(bumped))
+
+	poster := &stubPoster{}
+	runner := newAppSetRunnerWith(t, Config{Comment: commentCfg()}, nil, poster)
+	runner.helm.renderErrFor = map[string]error{"gamma-guestbook": assert.AnError}
+
+	err := runner.app.Run(context.Background())
+
+	require.ErrorIs(t, err, assert.AnError, "the comparison failure is still reported")
+	require.Len(t, poster.bodies, 1, "the partial batch is published")
+
+	body := poster.bodies[0]
+	assert.Contains(t, body, "alpha-guestbook")
+	assert.Contains(t, body, "beta-guestbook")
+	assert.NotContains(t, body, "**Application:** `"+generatedLabel(appSetPath, "gamma-guestbook")+"`")
+}
+
+// TestAppRunPrefersTheComparisonErrorOverTheCommentError proves the root cause
+// wins when both fail, with the publishing failure still surfaced in the log.
+func TestAppRunPrefersTheComparisonErrorOverTheCommentError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip integration test in short mode")
+	}
+
+	seedAppSetRepo(t,
+		applicationSetYAML([][2]string{{"alpha", "1.0.0"}, {"beta", "1.0.0"}}),
+		applicationSetYAML([][2]string{{"alpha", "1.1.0"}, {"beta", "1.1.0"}}))
+
+	postErr := fmt.Errorf("gitlab rejected the note")
+	poster := &stubPoster{err: postErr}
+	runner := newAppSetRunnerWith(t, Config{Comment: commentCfg()}, nil, poster)
+	runner.helm.renderErrFor = map[string]error{"beta-guestbook": assert.AnError}
+
+	err := runner.app.Run(context.Background())
+
+	require.ErrorIs(t, err, assert.AnError, "the comparison error is the root cause")
+	assert.NotErrorIs(t, err, postErr)
+	assert.Contains(t, runner.log.String(), "Failed to publish the comparison comment")
+}
+
+// TestAppRunPostsNothingWithoutComparisons proves a run that compares nothing
+// stays silent rather than posting an empty note. The branches differ only in a
+// non-manifest file, so there is a diff but no Application to compare.
+func TestAppRunPostsNothingWithoutComparisons(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip integration test in short mode")
+	}
+
+	manifest := applicationSetYAML([][2]string{{"dev", "1.0.0"}})
+	seedAppSetRepoState(t,
+		branchState{manifest: manifest, files: map[string]string{"docs/notes.md": "before\n"}},
+		branchState{manifest: manifest, files: map[string]string{"docs/notes.md": "after\n"}})
+
+	poster := &stubPoster{}
+	runner := newAppSetRunnerWith(t, Config{Comment: commentCfg()}, nil, poster)
+
+	require.NoError(t, runner.app.Run(context.Background()))
+	assert.Empty(t, poster.bodies)
+}
+
+// TestCommentStrategyAbandonsRemainingPartsAfterAFailure proves a failed part
+// stops the batch, so a half-published note does not keep growing.
+func TestCommentStrategyAbandonsRemainingPartsAfterAFailure(t *testing.T) {
+	poster := &stubPoster{err: assert.AnError, failOnCall: 2}
+	strategy := CommentStrategy{Log: setupSilentLogger("comment-part-failure", t), Poster: poster, ShowAdded: true}
+
+	largeDiff := strings.Repeat("+ oversized line\n", 160000)
+	sections := []commentSection{
+		{label: "big-one", result: ComparisonResult{Added: []DiffOutput{{File: File{Name: "a.yaml"}, Diff: largeDiff}}}},
+		{label: "big-two", result: ComparisonResult{Added: []DiffOutput{{File: File{Name: "b.yaml"}, Diff: largeDiff}}}},
+	}
+
+	err := strategy.PresentSections(context.Background(), sections)
+
+	require.ErrorIs(t, err, assert.AnError)
+	assert.Contains(t, err.Error(), "part 2/")
+	assert.Len(t, poster.bodies, 2, "parts after the failure are not attempted")
+}
+
+// TestCommentStrategySingleBodyFailureNamesNoPart proves a lone note's error
+// carries no part numbering, which would be meaningless.
+func TestCommentStrategySingleBodyFailureNamesNoPart(t *testing.T) {
+	poster := &stubPoster{err: assert.AnError}
+	strategy := CommentStrategy{Log: setupSilentLogger("comment-single-failure", t), Poster: poster}
+
+	err := strategy.PresentSections(context.Background(), []commentSection{changedSection("app", "a.yaml")})
+
+	require.ErrorIs(t, err, assert.AnError)
+	assert.Contains(t, err.Error(), "post diff comment:")
+	assert.NotContains(t, err.Error(), "part")
+}

--- a/internal/app/comment_oversized_test.go
+++ b/internal/app/comment_oversized_test.go
@@ -72,6 +72,67 @@ func TestCommentStrategyOversizedSectionKeepsOthersPublishable(t *testing.T) {
 	assert.Contains(t, joined, "<summary>Changed • quiet.yaml</summary>")
 }
 
+// TestCommentStrategySplitsManyCRDNotices proves an Application omitting
+// thousands of CRDs cannot produce a comment over the limit, which would
+// discard the Applications queued behind it.
+func TestCommentStrategySplitsManyCRDNotices(t *testing.T) {
+	poster := &stubPoster{}
+	strategy := CommentStrategy{Log: setupSilentLogger("comment-crd-volume", t), Poster: poster}
+
+	changed := make([]DiffOutput, 0, 6000)
+	for i := range 6000 {
+		changed = append(changed, DiffOutput{
+			File: File{Name: fmt.Sprintf("charts/demo/crds/resource-%d.crd.yaml", i)},
+			Diff: "--- a\n+++ b\n@@ diff\n+ kind: CustomResourceDefinition",
+		})
+	}
+
+	sections := []commentSection{
+		{label: "crd-heavy", result: ComparisonResult{Changed: changed}},
+		changedSection("queued-app", "queued.yaml"),
+	}
+
+	require.NoError(t, strategy.PresentSections(context.Background(), sections))
+
+	for idx, body := range poster.bodies {
+		require.LessOrEqual(t, len(body), gitlabNoteLengthLimit, "comment %d must fit the limit", idx+1)
+	}
+
+	joined := strings.Join(poster.bodies, "")
+	assert.Contains(t, joined, "**Application:** `queued-app`", "the queued Application still publishes")
+	assert.Greater(t, strings.Count(joined, "**CRD Notes**"), 1, "the notices span several chunks")
+}
+
+func TestBuildCRDNotes(t *testing.T) {
+	t.Run("keeps a small set in one chunk", func(t *testing.T) {
+		chunks := buildCRDNotes([]string{"> first\n", "> second\n"}, 1000)
+
+		require.Len(t, chunks, 1)
+		assert.Contains(t, chunks[0], "**CRD Notes**")
+		assert.Contains(t, chunks[0], "> first")
+		assert.Contains(t, chunks[0], "> second")
+	})
+
+	t.Run("splits past the limit, heading each chunk", func(t *testing.T) {
+		notices := make([]string, 40)
+		for i := range notices {
+			notices[i] = fmt.Sprintf("> notice %d\n", i)
+		}
+
+		chunks := buildCRDNotes(notices, 100)
+
+		require.Greater(t, len(chunks), 1)
+		for idx, chunk := range chunks {
+			assert.Contains(t, chunk, "**CRD Notes**", "chunk %d must be self-describing", idx+1)
+		}
+		assert.Contains(t, strings.Join(chunks, ""), "> notice 39", "no notice is dropped")
+	})
+
+	t.Run("returns nothing without notices", func(t *testing.T) {
+		assert.Empty(t, buildCRDNotes(nil, 1000))
+	})
+}
+
 func TestTruncatePreamble(t *testing.T) {
 	t.Run("leaves a preamble that fits untouched", func(t *testing.T) {
 		preamble := "**Application:** `app`\n\n**Summary**\n- Changed: 1\n\n"

--- a/internal/app/comment_oversized_test.go
+++ b/internal/app/comment_oversized_test.go
@@ -1,0 +1,98 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/shini4i/argo-compare/internal/ports"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// hugeValidationResult builds a validation summary far larger than a single
+// comment can hold, as a chart with thousands of schema failures would.
+func hugeValidationResult(entries int) map[string]ports.ValidationResult {
+	errs := make([]ports.ValidationError, 0, entries)
+	for i := range entries {
+		errs = append(errs, ports.ValidationError{
+			Kind:     "Deployment",
+			Name:     fmt.Sprintf("workload-%d", i),
+			Filename: fmt.Sprintf("templates/deployment-%d.yaml", i),
+			Message:  strings.Repeat("field is invalid; ", 20),
+		})
+	}
+
+	return map[string]ports.ValidationResult{
+		"src": {Target: "src", Valid: false, ResourceCount: entries, ErrorCount: entries, Errors: errs},
+	}
+}
+
+// TestCommentStrategyTruncatesAnOversizedPreamble proves one Application's
+// runaway validation output cannot produce a comment GitLab would reject.
+func TestCommentStrategyTruncatesAnOversizedPreamble(t *testing.T) {
+	poster := &stubPoster{}
+	strategy := CommentStrategy{Log: setupSilentLogger("comment-oversized", t), Poster: poster}
+
+	oversized := changedSection("noisy-app", "noisy.yaml")
+	oversized.result.ValidationResults = hugeValidationResult(20000)
+
+	require.NoError(t, strategy.PresentSections(context.Background(), []commentSection{oversized}))
+
+	require.NotEmpty(t, poster.bodies)
+	for idx, body := range poster.bodies {
+		assert.LessOrEqual(t, len(body), gitlabNoteLengthLimit, "comment %d must fit the limit", idx+1)
+	}
+
+	joined := strings.Join(poster.bodies, "")
+	assert.Contains(t, joined, "**Application:** `noisy-app`")
+	assert.Contains(t, joined, "Review the job logs for full details")
+}
+
+// TestCommentStrategyOversizedSectionKeepsOthersPublishable is why the bound
+// matters under batching: a rejected comment abandons the ones behind it, so an
+// oversized Application must not take its neighbours down.
+func TestCommentStrategyOversizedSectionKeepsOthersPublishable(t *testing.T) {
+	poster := &stubPoster{}
+	strategy := CommentStrategy{Log: setupSilentLogger("comment-oversized-batch", t), Poster: poster}
+
+	oversized := changedSection("noisy-app", "noisy.yaml")
+	oversized.result.ValidationResults = hugeValidationResult(20000)
+
+	sections := []commentSection{oversized, changedSection("quiet-app", "quiet.yaml")}
+	require.NoError(t, strategy.PresentSections(context.Background(), sections))
+
+	for idx, body := range poster.bodies {
+		require.LessOrEqual(t, len(body), gitlabNoteLengthLimit, "comment %d must fit the limit", idx+1)
+	}
+
+	joined := strings.Join(poster.bodies, "")
+	assert.Contains(t, joined, "**Application:** `quiet-app`", "the neighbour is still reported")
+	assert.Contains(t, joined, "<summary>Changed • quiet.yaml</summary>")
+}
+
+func TestTruncatePreamble(t *testing.T) {
+	t.Run("leaves a preamble that fits untouched", func(t *testing.T) {
+		preamble := "**Application:** `app`\n\n**Summary**\n- Changed: 1\n\n"
+
+		assert.Equal(t, preamble, truncatePreamble(preamble, len(preamble)))
+	})
+
+	t.Run("cuts on a line boundary and names the omission", func(t *testing.T) {
+		preamble := "**Application:** `app`\n\n" + strings.Repeat("- a failing resource\n", 200)
+
+		got := truncatePreamble(preamble, len(preambleTruncationNotice)+200)
+
+		assert.LessOrEqual(t, len(got), len(preambleTruncationNotice)+200)
+		assert.True(t, strings.HasSuffix(got, preambleTruncationNotice))
+		assert.Contains(t, got, "**Application:** `app`", "the Application must survive truncation")
+		assert.NotContains(t, strings.TrimSuffix(got, preambleTruncationNotice), "resource-")
+	})
+
+	t.Run("still names the omission when nothing fits", func(t *testing.T) {
+		got := truncatePreamble(strings.Repeat("x\n", 500), 10)
+
+		assert.Contains(t, got, "Review the job logs")
+	})
+}

--- a/internal/app/comment_shapes_test.go
+++ b/internal/app/comment_shapes_test.go
@@ -1,0 +1,146 @@
+package app
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// crdSection is one Application whose only change is a CRD, which the comment
+// reports as a notice instead of a diff.
+func crdSection(label, file string) commentSection {
+	return commentSection{
+		label: label,
+		result: ComparisonResult{
+			Changed: []DiffOutput{{
+				File: File{Name: file},
+				Diff: "--- a\n+++ b\n@@ diff\n+ kind: CustomResourceDefinition",
+			}},
+		},
+	}
+}
+
+// TestCommentStrategyBatchKeepsCRDNotesPerSection proves each Application's CRD
+// notices stay with that Application rather than merging into one block, which
+// would leave the reader unable to tell which Application omitted what.
+func TestCommentStrategyBatchKeepsCRDNotesPerSection(t *testing.T) {
+	poster := &stubPoster{}
+	strategy := CommentStrategy{Log: setupSilentLogger("comment-batch-crd", t), Poster: poster}
+
+	sections := []commentSection{
+		crdSection("first-app", "first-crd.yaml"),
+		crdSection("second-app", "second-crd.yaml"),
+	}
+
+	require.NoError(t, strategy.PresentSections(context.Background(), sections))
+	require.Len(t, poster.bodies, 1)
+
+	body := poster.bodies[0]
+	assert.Equal(t, 2, strings.Count(body, "**CRD Notes**"), "one block per Application")
+	assert.Contains(t, body, "first-crd.yaml")
+	assert.Contains(t, body, "second-crd.yaml")
+
+	// The first Application's notice belongs before the second's heading.
+	assert.Less(t, strings.Index(body, "first-crd.yaml"), strings.Index(body, "`second-app`"))
+}
+
+// TestCommentStrategyBatchNotesHiddenSectionsPerApplication proves the
+// "not shown" accounting is per Application, so a reader can see which one is
+// hiding manifests.
+func TestCommentStrategyBatchNotesHiddenSectionsPerApplication(t *testing.T) {
+	poster := &stubPoster{}
+	strategy := CommentStrategy{Log: setupSilentLogger("comment-batch-hidden", t), Poster: poster}
+
+	hidden := func(label string) commentSection {
+		return commentSection{
+			label: label,
+			result: ComparisonResult{
+				Added:   []DiffOutput{{File: File{Name: "added.yaml"}, Diff: "+ added"}},
+				Removed: []DiffOutput{{File: File{Name: "removed.yaml"}, Diff: "- removed"}},
+			},
+		}
+	}
+
+	sections := []commentSection{hidden("first-app"), hidden("second-app")}
+
+	require.NoError(t, strategy.PresentSections(context.Background(), sections))
+
+	body := poster.bodies[0]
+	assert.Equal(t, 4, strings.Count(body, "are present but not shown"), "added and removed, per Application")
+	assert.Equal(t, 4, strings.Count(body, "(not shown)"))
+	assert.NotContains(t, body, "+ added", "a hidden diff must not leak into the note")
+	assert.NotContains(t, body, "- removed")
+}
+
+// TestCommentStrategyBatchRendersAllThreeSectionsInOneApplication proves added,
+// removed and changed diffs for one Application all land inside its own span.
+func TestCommentStrategyBatchRendersAllThreeSectionsInOneApplication(t *testing.T) {
+	poster := &stubPoster{}
+	strategy := CommentStrategy{
+		Log:         setupSilentLogger("comment-batch-mixed", t),
+		Poster:      poster,
+		ShowAdded:   true,
+		ShowRemoved: true,
+	}
+
+	mixed := commentSection{
+		label: "mixed-app",
+		result: ComparisonResult{
+			Added:   []DiffOutput{{File: File{Name: "added.yaml"}, Diff: "+ added"}},
+			Removed: []DiffOutput{{File: File{Name: "removed.yaml"}, Diff: "- removed"}},
+			Changed: []DiffOutput{{File: File{Name: "changed.yaml"}, Diff: "@@ diff\n- old\n+ new"}},
+		},
+	}
+
+	require.NoError(t, strategy.PresentSections(context.Background(),
+		[]commentSection{mixed, changedSection("later-app", "later.yaml")}))
+
+	body := poster.bodies[0]
+	for _, want := range []string{
+		"<summary>Added • added.yaml</summary>",
+		"<summary>Removed • removed.yaml</summary>",
+		"<summary>Changed • changed.yaml</summary>",
+	} {
+		require.Contains(t, body, want)
+		assert.Less(t, strings.Index(body, want), strings.Index(body, "`later-app`"),
+			"%s belongs to mixed-app, before the next Application", want)
+	}
+}
+
+// TestCommentStrategyNamesAnUnlabelledApplication covers the fallback for a
+// comparison that had no path to report.
+func TestCommentStrategyNamesAnUnlabelledApplication(t *testing.T) {
+	poster := &stubPoster{}
+	strategy := CommentStrategy{Log: setupSilentLogger("comment-unknown", t), Poster: poster}
+
+	require.NoError(t, strategy.Present(context.Background(), ComparisonResult{}))
+
+	assert.Contains(t, poster.bodies[0], "**Application:** `unknown`")
+}
+
+// TestAppRunDoesNotRepublishAnEarlierRun proves a second Run publishes only its
+// own comparisons, so a reused App cannot double-report.
+func TestAppRunDoesNotRepublishAnEarlierRun(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip integration test in short mode")
+	}
+
+	seedAppSetRepo(t,
+		applicationSetYAML([][2]string{{"dev", "1.0.0"}, {"prod", "1.0.0"}}),
+		applicationSetYAML([][2]string{{"dev", "1.1.0"}, {"prod", "1.1.0"}}))
+
+	poster := &stubPoster{}
+	runner := newAppSetRunnerWith(t, Config{Comment: commentCfg()}, nil, poster)
+
+	require.NoError(t, runner.app.Run(context.Background()))
+	require.NoError(t, runner.app.Run(context.Background()))
+
+	require.Len(t, poster.bodies, 2, "one note per run")
+	assert.Equal(t,
+		strings.Count(poster.bodies[0], "**Application:**"),
+		strings.Count(poster.bodies[1], "**Application:**"),
+		"the second run must not carry the first run's sections")
+}

--- a/internal/app/comment_strategy.go
+++ b/internal/app/comment_strategy.go
@@ -27,22 +27,45 @@ const (
 	gitlabNoteLengthLimit = 1_000_000
 	// commentPartReserve keeps room for part numbering suffixes when chunking comments.
 	commentPartReserve = 32
+	// crowdedNoteDivisor halves a note's budget: once to cap a preamble that would
+	// fill a comment on its own, and again as the diff budget if that preamble or a
+	// continuation line would still consume the whole chunk.
+	crowdedNoteDivisor = 2
 	crdNoticeTemplate  = "> CRD manifest `%s` detected in the %s section. Diff omitted to keep merge request comments concise. Review the job logs for full details.\n"
 )
 
-// Present formats comparison results and pushes them as one or more comments depending on size.
+// commentSection is one Application's contribution to a run's comment. A run
+// comparing several Applications — an ApplicationSet generating them, or several
+// changed manifests — collects one section each and publishes them together.
+type commentSection struct {
+	label  string
+	result ComparisonResult
+}
+
+// Present formats one Application's comparison and pushes it as one or more
+// comments depending on size.
 // The context is used for cancellation and timeout control when posting comments.
 func (s CommentStrategy) Present(ctx context.Context, result ComparisonResult) error {
+	return s.PresentSections(ctx, []commentSection{{label: s.ApplicationPath, result: result}})
+}
+
+// PresentSections publishes every collected section as a single comment,
+// splitting into further comments only when GitLab's note limit demands it. An
+// empty batch posts nothing.
+func (s CommentStrategy) PresentSections(ctx context.Context, sections []commentSection) error {
 	if err := s.validate(); err != nil {
 		return err
 	}
+	if len(sections) == 0 {
+		return nil
+	}
 
-	bodies := buildCommentBodies(result, s.ShowAdded, s.ShowRemoved, s.ApplicationPath)
+	bodies := buildCommentBodies(sections, s.ShowAdded, s.ShowRemoved)
 	if err := s.postBodies(ctx, bodies); err != nil {
 		return err
 	}
 
-	s.logResult(result, len(bodies))
+	s.logSections(sections, len(bodies))
 	return nil
 }
 
@@ -72,68 +95,171 @@ func (s CommentStrategy) postBodies(ctx context.Context, bodies []string) error 
 	return nil
 }
 
-func (s CommentStrategy) logResult(result ComparisonResult, commentCount int) {
-	app := strings.TrimSpace(s.ApplicationPath)
-	if app == "" {
-		app = "unknown application"
+func (s CommentStrategy) logSections(sections []commentSection, commentCount int) {
+	subject := sectionLabel(sections[0].label)
+	if len(sections) > 1 {
+		subject = fmt.Sprintf("%d Applications", len(sections))
 	}
 
 	switch {
-	case result.IsEmpty():
-		s.Log.Infof("Posted comment summarizing absence of manifest changes for %s", app)
+	case allSectionsEmpty(sections):
+		s.Log.Infof("Posted comment summarizing absence of manifest changes for %s", subject)
 	case commentCount > 1:
-		s.Log.Infof("Posted %d comments with manifest diff summary for %s", commentCount, app)
+		s.Log.Infof("Posted %d comments with manifest diff summary for %s", commentCount, subject)
 	default:
-		s.Log.Infof("Posted comment with manifest diff summary for %s", app)
+		s.Log.Infof("Posted comment with manifest diff summary for %s", subject)
 	}
 }
 
-func buildCommentBodies(result ComparisonResult, showAdded, showRemoved bool, applicationPath string) []string {
-	appLabel := strings.TrimSpace(applicationPath)
-	if appLabel == "" {
-		appLabel = "unknown"
-	}
-	appDisplay := strings.ReplaceAll(appLabel, "`", "\\`")
-
-	var headerBuilder strings.Builder
-	headerBuilder.WriteString("## Argo Compare Results\n\n")
-	headerBuilder.WriteString(fmt.Sprintf("**Application:** `%s`\n\n", appDisplay))
-
-	if validationSummary := buildValidationSummary(result.ValidationResults); validationSummary != "" {
-		headerBuilder.WriteString(validationSummary)
-	}
-
-	if summary := buildSummaryLines(result, showAdded, showRemoved); summary != "" {
-		headerBuilder.WriteString(summary)
-	}
-
-	header := headerBuilder.String()
-	if result.IsEmpty() {
-		return []string{ensureTrailingNewline(header + "No manifest differences detected :white_check_mark:\n")}
-	}
-
-	maxPerComment := computeMaxPerComment(len(header))
-
-	maxChunkLen := maxPerComment - len(header)
-	if maxChunkLen <= 0 {
-		maxChunkLen = maxPerComment / 2
-	}
-
-	chunks, notices := collectDiffChunks(result, showAdded, showRemoved, maxChunkLen)
-	if len(notices) > 0 {
-		var noticeBuilder strings.Builder
-		noticeBuilder.WriteString("**CRD Notes**\n")
-		for _, notice := range notices {
-			noticeBuilder.WriteString(notice)
-			if !strings.HasSuffix(notice, "\n") {
-				noticeBuilder.WriteString("\n")
-			}
+func allSectionsEmpty(sections []commentSection) bool {
+	for _, section := range sections {
+		if !section.result.IsEmpty() {
+			return false
 		}
-		noticeBuilder.WriteString("\n")
-		chunks = append(chunks, noticeBuilder.String())
 	}
 
-	return assembleCommentBodies(header, chunks)
+	return true
+}
+
+// sectionLabel names an Application for a comment, falling back when the
+// caller had no path to give.
+func sectionLabel(label string) string {
+	if trimmed := strings.TrimSpace(label); trimmed != "" {
+		return trimmed
+	}
+
+	return "unknown"
+}
+
+// buildCommentBodies renders every section under one run header, then packs the
+// result into as few comments as GitLab's note limit allows.
+func buildCommentBodies(sections []commentSection, showAdded, showRemoved bool) []string {
+	const runHeader = "## Argo Compare Results\n\n"
+
+	// computeMaxPerComment guarantees room beyond the fixed run header.
+	maxChunkLen := computeMaxPerComment(len(runHeader)) - len(runHeader)
+
+	chunks := make([]commentChunk, 0, len(sections))
+	for _, section := range sections {
+		chunks = append(chunks, sectionChunks(section, showAdded, showRemoved, maxChunkLen)...)
+	}
+
+	return assembleCommentBodies(runHeader, chunks)
+}
+
+// commentChunk is one renderable piece of a comment together with the
+// Application it belongs to, so a comment starting partway through that
+// Application can still name it. opensSection marks the piece that already
+// carries the Application's own heading.
+type commentChunk struct {
+	label        string
+	text         string
+	opensSection bool
+}
+
+// continuationLine re-states an Application when its diffs spill into a
+// further comment.
+func continuationLine(label string) string {
+	return fmt.Sprintf("**Application:** `%s` _(continued)_\n\n", escapeCommentLabel(label))
+}
+
+func escapeCommentLabel(label string) string {
+	return strings.ReplaceAll(sectionLabel(label), "`", "\\`")
+}
+
+// preambleTruncationNotice replaces the tail of a validation summary too large
+// to publish, pointing at the job log for the rest.
+const preambleTruncationNotice = "> The rest of this summary was omitted to keep the comment within GitLab's size limit. Review the job logs for full details.\n\n"
+
+// truncatePreamble bounds a section's opening at limit, cutting on a line
+// boundary. A validation summary has one entry per failing resource and no cap,
+// and a comment that exceeds GitLab's limit is rejected outright — which with
+// batching would discard every other Application's comment too.
+func truncatePreamble(preamble string, limit int) string {
+	if len(preamble) <= limit {
+		return preamble
+	}
+
+	keep := max(limit-len(preambleTruncationNotice), 0)
+	if cut := strings.LastIndex(preamble[:keep], "\n"); cut > 0 {
+		keep = cut
+	}
+
+	return strings.TrimRight(preamble[:keep], "\n") + "\n\n" + preambleTruncationNotice
+}
+
+// sectionChunks renders one Application: its preamble (label, validation,
+// summary) followed by its diffs, or the no-differences note when it has none.
+// The preamble rides along with the first diff so the two never land in
+// separate comments.
+func sectionChunks(section commentSection, showAdded, showRemoved bool, maxChunkLen int) []commentChunk {
+	label := sectionLabel(section.label)
+
+	var preamble strings.Builder
+	fmt.Fprintf(&preamble, "**Application:** `%s`\n\n", escapeCommentLabel(label))
+
+	if validationSummary := buildValidationSummary(section.result.ValidationResults); validationSummary != "" {
+		preamble.WriteString(validationSummary)
+	}
+	if summary := buildSummaryLines(section.result, showAdded, showRemoved); summary != "" {
+		preamble.WriteString(summary)
+	}
+
+	// A validation summary grows with the number of failing resources, so an
+	// unbounded preamble could produce a comment GitLab rejects — abandoning
+	// every other Application's comment queued behind it.
+	preambleText := truncatePreamble(preamble.String(), maxChunkLen/crowdedNoteDivisor)
+
+	if section.result.IsEmpty() {
+		return []commentChunk{{
+			label:        label,
+			text:         preambleText + "No manifest differences detected :white_check_mark:\n\n",
+			opensSection: true,
+		}}
+	}
+
+	// Whichever opening is longer bounds the diffs, since a later comment
+	// re-states the Application in place of the full preamble.
+	reserved := max(len(preambleText), len(continuationLine(label)))
+	available := maxChunkLen - reserved
+	if available <= 0 {
+		available = maxChunkLen / crowdedNoteDivisor
+	}
+
+	diffs, notices := collectDiffChunks(section.result, showAdded, showRemoved, available)
+	if len(notices) > 0 {
+		diffs = append(diffs, buildCRDNotes(notices))
+	}
+
+	chunks := make([]commentChunk, 0, len(diffs))
+	for idx, diff := range diffs {
+		if idx == 0 {
+			chunks = append(chunks, commentChunk{label: label, text: preambleText + diff, opensSection: true})
+			continue
+		}
+		chunks = append(chunks, commentChunk{label: label, text: diff})
+	}
+
+	if len(chunks) == 0 {
+		chunks = append(chunks, commentChunk{label: label, text: preambleText, opensSection: true})
+	}
+
+	return chunks
+}
+
+// buildCRDNotes gathers the notices for diffs omitted from a section.
+func buildCRDNotes(notices []string) string {
+	var builder strings.Builder
+	builder.WriteString("**CRD Notes**\n")
+	for _, notice := range notices {
+		builder.WriteString(notice)
+		if !strings.HasSuffix(notice, "\n") {
+			builder.WriteString("\n")
+		}
+	}
+	builder.WriteString("\n")
+
+	return builder.String()
 }
 
 // escapeInlineMarkdown sanitizes a string for safe interpolation into Markdown.
@@ -379,23 +505,31 @@ func splitDiffContent(content string, limit int) (string, string) {
 	return chunk, strings.TrimPrefix(remaining, "\n")
 }
 
-func assembleCommentBodies(header string, chunks []string) []string {
+// assembleCommentBodies packs chunks into as few comments as the note limit
+// allows. A comment that starts partway through an Application repeats that
+// Application's name, so no diff is ever shown without saying whose it is.
+func assembleCommentBodies(header string, chunks []commentChunk) []string {
 	maxPerComment := computeMaxPerComment(len(header))
 
 	var bodies []string
 	var builder strings.Builder
 	builder.WriteString(header)
+	atCommentStart := true
 
 	for _, chunk := range includeNonEmptyChunks(chunks) {
-		if builder.Len()+len(chunk) > maxPerComment {
-			if builder.Len() > len(header) {
-				bodies = append(bodies, ensureTrailingNewline(builder.String()))
-				builder.Reset()
-				builder.WriteString(header)
-			}
+		if builder.Len()+len(chunk.text) > maxPerComment && builder.Len() > len(header) {
+			bodies = append(bodies, ensureTrailingNewline(builder.String()))
+			builder.Reset()
+			builder.WriteString(header)
+			atCommentStart = true
 		}
 
-		builder.WriteString(chunk)
+		if atCommentStart && !chunk.opensSection {
+			builder.WriteString(continuationLine(chunk.label))
+		}
+
+		builder.WriteString(chunk.text)
+		atCommentStart = false
 	}
 
 	if builder.Len() > len(header) {
@@ -409,10 +543,10 @@ func assembleCommentBodies(header string, chunks []string) []string {
 	return bodies
 }
 
-func includeNonEmptyChunks(chunks []string) []string {
-	result := make([]string, 0, len(chunks))
+func includeNonEmptyChunks(chunks []commentChunk) []commentChunk {
+	result := make([]commentChunk, 0, len(chunks))
 	for _, chunk := range chunks {
-		if strings.TrimSpace(chunk) == "" {
+		if strings.TrimSpace(chunk.text) == "" {
 			continue
 		}
 		result = append(result, chunk)

--- a/internal/app/comment_strategy.go
+++ b/internal/app/comment_strategy.go
@@ -227,9 +227,7 @@ func sectionChunks(section commentSection, showAdded, showRemoved bool, maxChunk
 	}
 
 	diffs, notices := collectDiffChunks(section.result, showAdded, showRemoved, available)
-	if len(notices) > 0 {
-		diffs = append(diffs, buildCRDNotes(notices))
-	}
+	diffs = append(diffs, buildCRDNotes(notices, available)...)
 
 	chunks := make([]commentChunk, 0, len(diffs))
 	for idx, diff := range diffs {
@@ -247,19 +245,34 @@ func sectionChunks(section commentSection, showAdded, showRemoved bool, maxChunk
 	return chunks
 }
 
-// buildCRDNotes gathers the notices for diffs omitted from a section.
-func buildCRDNotes(notices []string) string {
-	var builder strings.Builder
-	builder.WriteString("**CRD Notes**\n")
-	for _, notice := range notices {
-		builder.WriteString(notice)
-		if !strings.HasSuffix(notice, "\n") {
-			builder.WriteString("\n")
-		}
-	}
-	builder.WriteString("\n")
+// buildCRDNotes packs the notices for omitted diffs into chunks that fit a
+// comment. One Application can omit arbitrarily many CRDs, and a chunk is never
+// split further, so gathering them all into one would produce a comment GitLab
+// rejects — discarding every Application queued behind it.
+func buildCRDNotes(notices []string, limit int) []string {
+	const heading = "**CRD Notes**\n"
 
-	return builder.String()
+	var (
+		chunks  []string
+		builder strings.Builder
+	)
+	builder.WriteString(heading)
+
+	for _, notice := range notices {
+		line := ensureTrailingNewline(notice)
+		if builder.Len()+len(line) > limit && builder.Len() > len(heading) {
+			chunks = append(chunks, builder.String()+"\n")
+			builder.Reset()
+			builder.WriteString(heading)
+		}
+		builder.WriteString(line)
+	}
+
+	if builder.Len() > len(heading) {
+		chunks = append(chunks, builder.String()+"\n")
+	}
+
+	return chunks
 }
 
 // escapeInlineMarkdown sanitizes a string for safe interpolation into Markdown.

--- a/internal/app/comment_strategy_test.go
+++ b/internal/app/comment_strategy_test.go
@@ -15,10 +15,20 @@ import (
 type stubPoster struct {
 	bodies []string
 	err    error
+	// failOnCall, when positive, fails only that 1-based Post call, so a test can
+	// fail one part of a multi-part note and see the rest abandoned.
+	failOnCall int
 }
 
 func (s *stubPoster) Post(_ context.Context, body string) error {
 	s.bodies = append(s.bodies, body)
+	if s.failOnCall > 0 {
+		if len(s.bodies) == s.failOnCall {
+			return s.err
+		}
+		return nil
+	}
+
 	return s.err
 }
 


### PR DESCRIPTION
Each comparison now contributes a section to a single merge request note, published once the last one finishes. An ApplicationSet generating thirty Applications posted thirty notes before this.

The change is wider than ApplicationSets on purpose: a run with several changed Application manifests batches the same way, which avoids maintaining two posting paths. Single-section output is unchanged, so the existing comment tests cover it as before.

The note splits only at GitLab's size limit, and a part beginning partway through an Application repeats its name so no diff appears unattributed. A validation summary big enough to fill a note on its own is truncated toward the job log — an oversized note is rejected outright, which would cost every other Application its results.

Stdout and external-diff output stay inline per comparison. A failed comparison still publishes what was already compared, and reports its own error.