### PR TITLE
test(e2e): validate the reported diff against ArgoCD's own rendering

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,7 @@
         # (kind, kubectl, helm) are deliberately absent: they are heavy, and the
         # lab is a per-release gate rather than part of the everyday shell.
         e2eTools = with pkgs; [
+          argocd
           bats
           shellcheck
           yq-go

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -26,6 +26,7 @@ Each is one bats test in `phases.bats`, in this order:
 |---|---|
 | `smoke` | The real binary, over a real Gitea clone, renders a real chart with real helm and reports the diff. The assertion is the rendered `replicas` value on both sides — a stub cannot produce it. |
 | `appset-parity` | argo-compare's expansion matches what the real ArgoCD ApplicationSet controller generated from the same manifest at the same commit, across all three supported generators. |
+| `render-parity` | argo-compare's reported **diff** matches what ArgoCD itself renders, in both directions: every change ArgoCD sees appears in the diff, and the diff invents none. |
 
 `appset-parity` runs its comparison as a Go test
 (`internal/app/e2e_parity_test.go`, behind `//go:build e2e`) rather than a shell
@@ -37,6 +38,30 @@ repoURL/path/chart/targetRevision, and the rendered `helm.releaseName` and
 `helm.values` — because ArgoCD also stamps ownership, finalizers and status that
 argo-compare never produces. Values are re-marshalled before comparison so the
 result is about content, not the indentation each side's templating emitted.
+
+## What render-parity can and cannot compare
+
+`argocd app manifests <app> --revision <sha>` renders the chart **at that
+revision using the Application spec stored in the cluster**. It therefore cannot
+model a change to the Application manifest itself — asked for two revisions that
+differ only in the manifest's inline values, ArgoCD returns identical output.
+
+That is why the fixture has two Applications:
+
+- `demo` changes its own manifest between branches. The `smoke` phase covers it,
+  and ArgoCD cannot be used as an oracle for it.
+- `addon` has an **identical manifest on both branches** and no inline values, so
+  the only thing that can change its render is chart content — which is exactly
+  what `--revision` varies. That makes the comparison two-directional.
+
+`charts/addon/` carries a `.argo-compare.yml`, because a chart-only change with
+no anchor and no manifest change is invisible to argo-compare by design. So this
+phase also happens to be the strictest test of the anchor flow.
+
+The two renderers format YAML differently: ArgoCD parses rendered manifests into
+its object model and re-serialises them, so helm's `message: "hello"` comes back
+as `message: hello`. `normalize_diff` in `lib.sh` strips that quoting before the
+sets are compared — the quoting differs without the meaning differing.
 
 ## The two repo URLs
 
@@ -57,7 +82,7 @@ remote never has to be fetchable.
 ## Prerequisites
 
 `kind`, `kubectl` and `helm` on `PATH`, with **podman or docker** as the kind
-provider. `go`, `bats`, `shellcheck`, `jq` and `task` come from the devshell
+provider. `go`, `bats`, `shellcheck`, `jq`, `argocd` and `task` come from the devshell
 (`nix develop`); the cluster tools deliberately do not, since the lab is a
 per-release gate rather than part of the everyday shell.
 
@@ -80,6 +105,7 @@ task up                  # boot the lab only (idempotent)
 task phases              # re-run every phase against a lab already up
 task smoke               # one phase directly
 task appset-parity
+task render-parity
 task lint                # shellcheck, no cluster needed
 task down                # destroy the cluster
 bats --filter parity phases.bats          # one phase by name

--- a/test/e2e/Taskfile.yml
+++ b/test/e2e/Taskfile.yml
@@ -46,6 +46,8 @@ tasks:
         --version {{.ARGOCD_CHART_VERSION}} -n argocd -f values/argocd.yaml
       - kubectl --context {{.KCTX}} -n argocd rollout status deploy/argocd-applicationset-controller --timeout=300s
       - kubectl --context {{.KCTX}} -n argocd rollout status deploy/argocd-repo-server --timeout=300s
+      # render-parity talks to the API, so the server has to be up before phases.
+      - kubectl --context {{.KCTX}} -n argocd rollout status deploy/argocd-server --timeout=300s
 
   gitea:
     desc: "Install Gitea, the git remote both sides read"
@@ -89,9 +91,10 @@ tasks:
       - ./scripts/render-parity.sh
 
   lint:
-    desc: "shellcheck the phase scripts (no cluster needed)"
+    desc: "shellcheck plus the offline bats suite (no cluster needed)"
     cmds:
       - shellcheck scripts/*.sh
+      - bats lib.bats
 
   down:
     desc: "Destroy the cluster"

--- a/test/e2e/Taskfile.yml
+++ b/test/e2e/Taskfile.yml
@@ -83,6 +83,11 @@ tasks:
     cmds:
       - ./scripts/appset-parity.sh
 
+  render-parity:
+    desc: "Assert argo-compare's diff matches what ArgoCD itself renders"
+    cmds:
+      - ./scripts/render-parity.sh
+
   lint:
     desc: "shellcheck the phase scripts (no cluster needed)"
     cmds:

--- a/test/e2e/fixtures/app-addon.yaml
+++ b/test/e2e/fixtures/app-addon.yaml
@@ -1,0 +1,20 @@
+# The render-parity fixture. Its manifest is IDENTICAL on both branches and
+# carries no inline values, so the only thing that can change what it renders is
+# the chart content. That makes ArgoCD's own render at each revision directly
+# comparable with argo-compare's diff, in both directions.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: addon
+  namespace: argocd
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: addon
+  source:
+    repoURL: REPO_URL
+    path: charts/addon
+    targetRevision: main
+    helm:
+      releaseName: addon

--- a/test/e2e/fixtures/gitops/charts/addon/.argo-compare.yml
+++ b/test/e2e/fixtures/gitops/charts/addon/.argo-compare.yml
@@ -1,0 +1,2 @@
+application:
+  path: apps/addon.yaml

--- a/test/e2e/fixtures/gitops/charts/addon/Chart.yaml
+++ b/test/e2e/fixtures/gitops/charts/addon/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: addon
+version: 0.1.0

--- a/test/e2e/fixtures/gitops/charts/addon/templates/configmap.yaml
+++ b/test/e2e/fixtures/gitops/charts/addon/templates/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-config
+  namespace: {{ .Release.Namespace }}
+data:
+  message: {{ .Values.message | quote }}

--- a/test/e2e/fixtures/gitops/charts/addon/values.yaml
+++ b/test/e2e/fixtures/gitops/charts/addon/values.yaml
@@ -1,0 +1,2 @@
+message: hello
+replicas: 1

--- a/test/e2e/kind-config.yaml
+++ b/test/e2e/kind-config.yaml
@@ -13,3 +13,8 @@ nodes:
         # Loopback keeps Gitea's throwaway admin credentials off the network.
         listenAddress: "127.0.0.1"
         protocol: TCP
+      # ArgoCD API: the render-parity phase asks it what it renders.
+      - containerPort: 30081
+        hostPort: 30081
+        listenAddress: "127.0.0.1"
+        protocol: TCP

--- a/test/e2e/lib.bats
+++ b/test/e2e/lib.bats
@@ -1,0 +1,119 @@
+#!/usr/bin/env bats
+# Offline unit tests for the text helpers in scripts/lib.sh. No cluster: these
+# are pure functions, and the phase that uses them is a per-release gate, so a
+# boundary bug in them would otherwise only surface there.
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  cd "${BATS_TEST_DIRNAME}" || return 1
+  # shellcheck source=./scripts/lib.sh
+  . ./scripts/lib.sh
+}
+
+# normalize_diff is a filter, so each case pipes into it through this helper
+# rather than `run bash -c`: a function sourced by setup() does not cross into a
+# new shell, and the tests then pass on a command-not-found message instead.
+normalized() {
+  printf -- "$1" | normalize_diff
+  return
+}
+
+@test "normalize_diff strips leading whitespace and sorts" {
+  run normalized "+  b: 2\n-  a: 1\n"
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -eq 2 ]
+  [ "${lines[0]}" = "-a: 1" ]
+  [ "${lines[1]}" = "+b: 2" ]
+}
+
+# ArgoCD re-serialises through its object model, so the same value arrives
+# quoted from helm and unquoted from ArgoCD.
+@test "normalize_diff unquotes scalar values" {
+  run normalized "+  message: \"world\"\n"
+  [ "$status" -eq 0 ]
+  [ "$output" = "+message: world" ]
+}
+
+@test "normalize_diff leaves an unquoted value alone" {
+  run normalized "+message: world\n"
+  [ "$status" -eq 0 ]
+  [ "$output" = "+message: world" ]
+}
+
+@test "normalize_diff deduplicates identical lines" {
+  run normalized "+a: 1\n+a: 1\n"
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -eq 1 ]
+  [ "$output" = "+a: 1" ]
+}
+
+@test "section_diff takes only the named section" {
+  cat >"${BATS_TEST_TMPDIR}/out.txt" <<'EOF'
+===> Processing changed application: [apps/demo.yaml]
+-  replicas: 1
++  replicas: 3
+===> Processing anchored chart in [/tmp/x/charts/addon]
+-  message: "hello"
++  message: "world"
+EOF
+  run section_diff "${BATS_TEST_TMPDIR}/out.txt" addon
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -eq 2 ]
+  [ "${lines[0]}" = "-message: hello" ]
+  [ "${lines[1]}" = "+message: world" ]
+}
+
+# The bug a mutation found: an unbounded section swallowed its successors.
+@test "section_diff stops at the next section" {
+  cat >"${BATS_TEST_TMPDIR}/out.txt" <<'EOF'
+===> Processing anchored chart in [/tmp/x/charts/addon]
+-  message: "hello"
+===> Processing changed application: [apps/demo.yaml]
+-  replicas: 1
+EOF
+  run section_diff "${BATS_TEST_TMPDIR}/out.txt" addon
+  [ "${#lines[@]}" -eq 1 ]
+  [ "${lines[0]}" = "-message: hello" ]
+}
+
+@test "section_diff returns nothing for a section that is absent" {
+  cat >"${BATS_TEST_TMPDIR}/out.txt" <<'EOF'
+===> Processing changed application: [apps/demo.yaml]
+-  replicas: 1
+EOF
+  run section_diff "${BATS_TEST_TMPDIR}/out.txt" addon
+  [ "$output" = "" ]
+}
+
+@test "section_diff ignores diff context and file headers" {
+  cat >"${BATS_TEST_TMPDIR}/out.txt" <<'EOF'
+===> Processing anchored chart in [/tmp/x/charts/addon]
+--- /tmp/src/configmap.yaml
++++ /tmp/dst/configmap.yaml
+@@ -6,4 +6,4 @@
+   name: addon-config
+-  message: "hello"
+EOF
+  run section_diff "${BATS_TEST_TMPDIR}/out.txt" addon
+  [ "${#lines[@]}" -eq 1 ]
+  [ "${lines[0]}" = "-message: hello" ]
+}
+
+@test "diff_body reports only what differs between two files" {
+  printf 'a: 1\nb: 2\n' >"${BATS_TEST_TMPDIR}/one.yaml"
+  printf 'a: 1\nb: 3\n' >"${BATS_TEST_TMPDIR}/two.yaml"
+
+  run diff_body "${BATS_TEST_TMPDIR}/one.yaml" "${BATS_TEST_TMPDIR}/two.yaml"
+  [ "${#lines[@]}" -eq 2 ]
+  [ "${lines[0]}" = "-b: 2" ]
+  [ "${lines[1]}" = "+b: 3" ]
+}
+
+@test "diff_body reports nothing for identical files" {
+  printf 'a: 1\n' >"${BATS_TEST_TMPDIR}/one.yaml"
+  printf 'a: 1\n' >"${BATS_TEST_TMPDIR}/two.yaml"
+
+  run diff_body "${BATS_TEST_TMPDIR}/one.yaml" "${BATS_TEST_TMPDIR}/two.yaml"
+  [ "$output" = "" ]
+}

--- a/test/e2e/phases.bats
+++ b/test/e2e/phases.bats
@@ -32,3 +32,11 @@ teardown() {
   echo "$output"
   [ "$status" -eq 0 ]
 }
+
+# render-parity last: it is the strictest, and reaching it means expansion and
+# rendering are already known good.
+@test "render-parity: the reported diff matches what ArgoCD renders" {
+  run ./scripts/render-parity.sh
+  echo "$output"
+  [ "$status" -eq 0 ]
+}

--- a/test/e2e/scripts/apply-appsets.sh
+++ b/test/e2e/scripts/apply-appsets.sh
@@ -23,6 +23,13 @@ for name in "${!want[@]}"; do
   sed "s|REPO_URL|${ORIGIN_URL}|g" "$fixture" | kc apply -f - >/dev/null
 done
 
+# The plain Applications too: render-parity asks ArgoCD what `addon` renders, so
+# ArgoCD has to know about it.
+for app in demo addon; do
+  sed "s|REPO_URL|${ORIGIN_URL}|g" "${E2E_DIR}/fixtures/app-${app}.yaml" |
+    kc apply -f - >/dev/null
+done
+
 for name in "${!want[@]}"; do
   wait_appset "$name" "${want[$name]}" 60 ||
     die "${name} generated $(appset_count "$name") Application(s), expected ${want[$name]}"

--- a/test/e2e/scripts/lib.sh
+++ b/test/e2e/scripts/lib.sh
@@ -123,22 +123,41 @@ ARGOCD_URL="${ARGOCD_URL:-localhost:30081}"
 
 # argocd_login: authenticate the CLI against the lab's ArgoCD. Plaintext because
 # the lab server runs with server.insecure and is published on loopback only.
+# Retried: on a freshly booted lab the API answers before it serves sessions,
+# and a one-shot login would fail the phase for startup timing.
 argocd_login() {
   local pw
   pw="$(kc -n "$NS_ARGOCD" get secret argocd-initial-admin-secret \
     -o jsonpath='{.data.password}' | base64 -d)"
   [[ -n "$pw" ]] || return 1
-  argocd login "$ARGOCD_URL" --username admin --password "$pw" \
-    --plaintext --grpc-web >/dev/null 2>&1
+  retry 30 2 argocd login "$ARGOCD_URL" --username admin --password "$pw" \
+    --plaintext --grpc-web
   return
 }
 
 # argocd_manifests <app> <revision>: what ArgoCD itself renders for <app> at
 # <revision>. This varies chart content only — the Application spec comes from
-# the cluster — so it cannot model a change to the manifest itself.
+# the cluster — so it cannot model a change to the manifest itself. Retried
+# because the server may not have observed a just-applied Application yet.
 argocd_manifests() {
-  local app="$1" revision="$2"
-  argocd app manifests "$app" --revision "$revision" --plaintext --grpc-web 2>/dev/null
+  local app="$1" revision="$2" out
+  out="$(mktemp)"
+  if retry 30 2 argocd_manifests_once "$app" "$revision" "$out"; then
+    cat "$out"
+    rm -f "$out"
+    return 0
+  fi
+  rm -f "$out"
+  return 1
+}
+
+# argocd_manifests_once: one render attempt, written to <file> so a partial
+# failure never reaches the caller as if it were the full output.
+argocd_manifests_once() {
+  local app="$1" revision="$2" file="$3"
+  argocd app manifests "$app" --revision "$revision" \
+    --plaintext --grpc-web >"$file" 2>/dev/null || return 1
+  [[ -s "$file" ]]
   return
 }
 

--- a/test/e2e/scripts/lib.sh
+++ b/test/e2e/scripts/lib.sh
@@ -119,6 +119,58 @@ build_compare() {
   return
 }
 
+ARGOCD_URL="${ARGOCD_URL:-localhost:30081}"
+
+# argocd_login: authenticate the CLI against the lab's ArgoCD. Plaintext because
+# the lab server runs with server.insecure and is published on loopback only.
+argocd_login() {
+  local pw
+  pw="$(kc -n "$NS_ARGOCD" get secret argocd-initial-admin-secret \
+    -o jsonpath='{.data.password}' | base64 -d)"
+  [[ -n "$pw" ]] || return 1
+  argocd login "$ARGOCD_URL" --username admin --password "$pw" \
+    --plaintext --grpc-web >/dev/null 2>&1
+  return
+}
+
+# argocd_manifests <app> <revision>: what ArgoCD itself renders for <app> at
+# <revision>. This varies chart content only — the Application spec comes from
+# the cluster — so it cannot model a change to the manifest itself.
+argocd_manifests() {
+  local app="$1" revision="$2"
+  argocd app manifests "$app" --revision "$revision" --plaintext --grpc-web 2>/dev/null
+  return
+}
+
+# normalize_diff: read changed diff lines, emit them comparable across the two
+# renderers. ArgoCD parses rendered manifests into its object model and
+# re-serialises them, so `message: "hello"` from helm comes back as
+# `message: hello`; the quoting differs without the meaning differing.
+normalize_diff() {
+  sed -E 's/^([+-])[[:space:]]*/\1/; s/^([+-][^:]*): "(.*)"$/\1: \2/' | sort -u
+  return
+}
+
+# diff_body <a> <b>: the changed lines of a unified diff, as a comparable set.
+diff_body() {
+  local a="$1" b="$2"
+  diff -u "$a" "$b" | grep -E '^[+-][^+-]' | normalize_diff
+  return
+}
+
+# section_diff <output> <marker>: the changed lines of one Application's section
+# of an argo-compare run, which reports every Application in one stream. Bounded
+# by the next `===>` heading, so a section that is not the last one does not
+# collect its successors' diffs.
+section_diff() {
+  local output="$1" marker="$2"
+  awk -v m="$marker" '
+    /^===>/ { inside = index($0, m) ? 1 : 0; next }
+    inside && /^[+-][^+-]/ { print }
+  ' "$output" | normalize_diff
+  return
+}
+
 # appset_apps <appset>: names of the Applications the real controller generated.
 # Selected by ownerReference, not by a label: the controller stamps no
 # application-set-name label on what it generates, so a label selector silently

--- a/test/e2e/scripts/render-parity.sh
+++ b/test/e2e/scripts/render-parity.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Validate the comparison RESULT: ArgoCD renders the addon chart at each branch's
+# commit, those renders are diffed here, and argo-compare's reported diff must
+# agree with it in both directions. The addon manifest is identical on both
+# branches, so only chart content can differ. See README.md.
+set -uo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib.sh
+. "${here}/lib.sh"
+
+command -v argocd >/dev/null || die "argocd is required on PATH (nix develop provides it)"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+build_compare "$work"
+clone_gitops "${work}/gitops"
+
+main_sha="$(git -C "${work}/gitops" rev-parse "origin/${TARGET_BRANCH}")"
+feature_sha="$(git -C "${work}/gitops" rev-parse "origin/${FEATURE_BRANCH}")"
+[[ "$main_sha" != "$feature_sha" ]] || die "both branches point at the same commit"
+
+argocd_login || die "could not log in to the lab's ArgoCD"
+
+argocd_manifests addon "$main_sha" >"${work}/argo-main.yaml" ||
+  die "argocd could not render addon at ${main_sha}"
+argocd_manifests addon "$feature_sha" >"${work}/argo-feature.yaml" ||
+  die "argocd could not render addon at ${feature_sha}"
+
+# Without this the phase would assert nothing, which is how a parity test rots.
+if diff -q "${work}/argo-main.yaml" "${work}/argo-feature.yaml" >/dev/null; then
+  die "ArgoCD renders both commits identically, so this phase would assert nothing"
+fi
+
+argo_diff="${work}/argo.diff"
+diff_body "${work}/argo-main.yaml" "${work}/argo-feature.yaml" >"$argo_diff"
+
+echo "--- ArgoCD's change set"
+cat "$argo_diff"
+
+out="${work}/out.txt"
+git -C "${work}/gitops" checkout -q "$FEATURE_BRANCH"
+(cd "${work}/gitops" && "$COMPARE_BIN" branch "$TARGET_BRANCH") >"$out" 2>&1
+
+echo "--- argo-compare output"
+cat "$out"
+echo "--- end"
+
+# argo-compare reports every Application in one stream, so the addon section is
+# taken alone: the demo Application legitimately changes too.
+compare_diff="${work}/compare.diff"
+section_diff "$out" addon >"$compare_diff"
+
+while read -r line; do
+  [[ -n "$line" ]] || continue
+  if grep -qxF -e "$line" "$compare_diff"; then
+    ok "argo-compare reports ${line}"
+  else
+    bad "argo-compare is missing ArgoCD's change: ${line}"
+  fi
+done <"$argo_diff"
+
+# The reverse direction, so argo-compare cannot invent a change either.
+while read -r line; do
+  [[ -n "$line" ]] || continue
+  if grep -qxF -e "$line" "$argo_diff"; then
+    ok "ArgoCD confirms ${line}"
+  else
+    bad "argo-compare reports a change ArgoCD does not: ${line}"
+  fi
+done <"$compare_diff"
+
+phase_end render-parity

--- a/test/e2e/scripts/seed-gitea.sh
+++ b/test/e2e/scripts/seed-gitea.sh
@@ -26,7 +26,10 @@ cp -r "${E2E_DIR}/fixtures/gitops/." "${work}/"
 # The Application manifests name the in-cluster repo URL, which is what ArgoCD
 # resolves and what the clone's origin is rewritten to.
 mkdir -p "${work}/apps"
-sed "s|REPO_URL|${ORIGIN_URL}|g" "${E2E_DIR}/fixtures/app-demo.yaml" >"${work}/apps/demo.yaml"
+for app in demo addon; do
+  sed "s|REPO_URL|${ORIGIN_URL}|g" "${E2E_DIR}/fixtures/app-${app}.yaml" \
+    >"${work}/apps/${app}.yaml"
+done
 
 git -C "$work" add -A
 git -C "$work" commit -qm "seed gitops fixtures"
@@ -41,6 +44,13 @@ git -C "$work" checkout -q -b "$FEATURE_BRANCH"
 sed -i -E 's/^([[:space:]]*)replicaCount: 1$/\1replicaCount: 3/' "${work}/apps/demo.yaml"
 grep -qE '^[[:space:]]*replicaCount: 3$' "${work}/apps/demo.yaml" ||
   die "the feature-branch replica bump did not apply to apps/demo.yaml"
+
+# The addon chart's own content changes while apps/addon.yaml stays identical,
+# which is what makes the render-parity comparison two-directional.
+sed -i -E 's/^message: hello$/message: world/' "${work}/charts/addon/values.yaml"
+grep -qx 'message: world' "${work}/charts/addon/values.yaml" ||
+  die "the feature-branch addon chart change did not apply"
+
 mkdir -p "${work}/clusters/prod"
 printf 'cluster: prod\nreplicas: 4\n' >"${work}/clusters/prod/config.yaml"
 git -C "$work" add -A

--- a/test/e2e/values/argocd.yaml
+++ b/test/e2e/values/argocd.yaml
@@ -1,12 +1,21 @@
 # ArgoCD values for the argo-compare e2e lab. The ApplicationSet controller is
-# the point of this install: it is the oracle the parity phase compares
-# argo-compare's own expansion against. The repo-server and redis stay enabled
-# because a git generator cannot resolve without them.
+# the point of this install: it is the oracle the parity phases compare
+# argo-compare against. The repo-server and redis stay enabled because a git
+# generator cannot resolve without them.
 dex:
   enabled: false
 notifications:
   enabled: false
+
+configs:
+  params:
+    # Plaintext so the argocd CLI can reach the API without a trusted cert; the
+    # server is only published on loopback via the NodePort below.
+    server.insecure: true
+
 server:
-  # Nothing in the lab talks to the ArgoCD API, so no ingress or host port.
+  # Fixed NodePort so the render-parity phase can ask ArgoCD what it renders.
+  # The number must match the containerPort in kind-config.yaml.
   service:
-    type: ClusterIP
+    type: NodePort
+    nodePortHttp: 30081


### PR DESCRIPTION
The lab proved expansion parity but never checked the comparison result — `smoke` asserts the diff agrees with a hand-written expectation, not with ArgoCD. This closes that: ArgoCD renders the addon chart at each branch's commit, those renders are diffed, and argo-compare's reported diff must match in both directions. Every change ArgoCD sees must appear in the diff, and the diff must invent none.

Two findings shaped the design, both worth knowing:

`argocd app manifests --revision` renders chart content at a revision using the Application spec **held in the cluster**, so it cannot model a change to the manifest itself — asked for two revisions differing only in inline values, ArgoCD returns identical output. The addon Application therefore keeps an identical manifest on both branches with no inline values, leaving chart content as the only thing that can move its render.

Its chart also needed a `.argo-compare.yml`: a chart-only change with no manifest change reaches argo-compare no other way. That is correct behaviour and the reason anchors exist, and it makes this phase the strictest test of the anchor flow.

ArgoCD re-serialises manifests through its object model, so helm's `message: "hello"` comes back as `message: hello`; `normalize_diff` strips that quoting before the sets are compared. `section_diff` is now bounded by the next `===>` heading — a mutation revealed it had been collecting later Applications' diffs.

Verified by a clean-room `task e2e` from a deleted cluster, all three phases green. Mutation-checked: pointed at the wrong Application's section, both directions fail.

Stacked on #168.