### PR TITLE
test(e2e): validate a generated Application's diff against ArgoCD

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -27,6 +27,7 @@ Each is one bats test in `phases.bats`, in this order:
 | `smoke` | The real binary, over a real Gitea clone, renders a real chart with real helm and reports the diff. The assertion is the rendered `replicas` value on both sides — a stub cannot produce it. |
 | `appset-parity` | argo-compare's expansion matches what the real ArgoCD ApplicationSet controller generated from the same manifest at the same commit, across all three supported generators. |
 | `render-parity` | argo-compare's reported **diff** matches what ArgoCD itself renders, in both directions: every change ArgoCD sees appears in the diff, and the diff invents none. |
+| `generated-parity` | the same, for each Application an **ApplicationSet** generates, reached through an anchor. Covers the ApplicationSet flow's own output, which `render-parity` does not. |
 
 `appset-parity` runs its comparison as a Go test
 (`internal/app/e2e_parity_test.go`, behind `//go:build e2e`) rather than a shell
@@ -57,6 +58,13 @@ That is why the fixture has two Applications:
 `charts/addon/` carries a `.argo-compare.yml`, because a chart-only change with
 no anchor and no manifest change is invisible to argo-compare by design. So this
 phase also happens to be the strictest test of the anchor flow.
+
+`generated-parity` applies the same reasoning one level further: `charts/generated`
+is anchored to an **ApplicationSet**, so a change to that chart reaches
+argo-compare through the anchor and is compared per generated Application. Each
+element renders a banner carrying its own name, so the two diffs are distinct and
+attributing one Application's diff to the other fails rather than passing on an
+identical change.
 
 The two renderers format YAML differently: ArgoCD parses rendered manifests into
 its object model and re-serialises them, so helm's `message: "hello"` comes back
@@ -106,6 +114,7 @@ task phases              # re-run every phase against a lab already up
 task smoke               # one phase directly
 task appset-parity
 task render-parity
+task generated-parity
 task lint                # shellcheck, no cluster needed
 task down                # destroy the cluster
 bats --filter parity phases.bats          # one phase by name

--- a/test/e2e/Taskfile.yml
+++ b/test/e2e/Taskfile.yml
@@ -90,6 +90,11 @@ tasks:
     cmds:
       - ./scripts/render-parity.sh
 
+  generated-parity:
+    desc: "Assert a generated Application's diff matches what ArgoCD renders"
+    cmds:
+      - ./scripts/generated-parity.sh
+
   lint:
     desc: "shellcheck plus the offline bats suite (no cluster needed)"
     cmds:

--- a/test/e2e/fixtures/appset-generated.yaml
+++ b/test/e2e/fixtures/appset-generated.yaml
@@ -1,0 +1,34 @@
+# An ANCHORED ApplicationSet: the manifest is identical on both branches, and
+# charts/generated carries a .argo-compare.yml pointing here, so a change to the
+# chart reaches argo-compare through the anchor and is compared per generated
+# Application. Each element renders a different value, so mixing two up shows.
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: e2e-generated
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - list:
+        elements:
+          - env: dev
+          - env: prod
+  template:
+    metadata:
+      name: 'gen-{{ .env }}'
+      namespace: argocd
+    spec:
+      project: default
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: 'gen-{{ .env }}'
+      source:
+        repoURL: REPO_URL
+        path: charts/generated
+        targetRevision: main
+        helm:
+          releaseName: 'gen-{{ .env }}'
+          values: |
+            env: {{ .env }}

--- a/test/e2e/fixtures/gitops/charts/generated/.argo-compare.yml
+++ b/test/e2e/fixtures/gitops/charts/generated/.argo-compare.yml
@@ -1,0 +1,2 @@
+application:
+  path: apps/generated-appset.yaml

--- a/test/e2e/fixtures/gitops/charts/generated/Chart.yaml
+++ b/test/e2e/fixtures/gitops/charts/generated/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: generated
+version: 0.1.0

--- a/test/e2e/fixtures/gitops/charts/generated/templates/configmap.yaml
+++ b/test/e2e/fixtures/gitops/charts/generated/templates/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-banner
+  namespace: {{ .Release.Namespace }}
+data:
+  banner: {{ printf "%s-%s" .Values.banner .Values.env }}

--- a/test/e2e/fixtures/gitops/charts/generated/values.yaml
+++ b/test/e2e/fixtures/gitops/charts/generated/values.yaml
@@ -1,0 +1,2 @@
+banner: first
+env: unset

--- a/test/e2e/phases.bats
+++ b/test/e2e/phases.bats
@@ -40,3 +40,11 @@ teardown() {
   echo "$output"
   [ "$status" -eq 0 ]
 }
+
+# generated-parity last: it needs everything the others prove, and covers the
+# ApplicationSet flow's own output through an anchored manifest.
+@test "generated-parity: a generated Application's diff matches what ArgoCD renders" {
+  run ./scripts/generated-parity.sh
+  echo "$output"
+  [ "$status" -eq 0 ]
+}

--- a/test/e2e/scripts/apply-appsets.sh
+++ b/test/e2e/scripts/apply-appsets.sh
@@ -15,6 +15,7 @@ declare -A want=(
   [e2e-list]=2
   [e2e-git-dir]=2
   [e2e-git-file]=2
+  [e2e-generated]=2
 )
 
 for name in "${!want[@]}"; do

--- a/test/e2e/scripts/generated-parity.sh
+++ b/test/e2e/scripts/generated-parity.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# The diff for a GENERATED Application, checked against ArgoCD's own rendering.
+# render-parity covers a plain Application; this covers the ApplicationSet flow's
+# output, reached through charts/generated's anchor, per generated Application.
+set -uo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib.sh
+. "${here}/lib.sh"
+
+command -v argocd >/dev/null || die "argocd is required on PATH (nix develop provides it)"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+build_compare "$work"
+clone_gitops "${work}/gitops"
+
+main_sha="$(git -C "${work}/gitops" rev-parse "origin/${TARGET_BRANCH}")"
+feature_sha="$(git -C "${work}/gitops" rev-parse "origin/${FEATURE_BRANCH}")"
+
+argocd_login || die "could not log in to the lab's ArgoCD"
+
+out="${work}/out.txt"
+git -C "${work}/gitops" checkout -q "$FEATURE_BRANCH"
+(cd "${work}/gitops" && "$COMPARE_BIN" branch "$TARGET_BRANCH") >"$out" 2>&1
+
+echo "--- argo-compare output"
+cat "$out"
+echo "--- end"
+
+assert_grep "$out" 'Anchored ApplicationSet' "reached the ApplicationSet through its anchor"
+
+# Each generated Application is compared on its own, so one of them agreeing
+# cannot cover for the other — and their renders differ by design.
+for app in gen-dev gen-prod; do
+  argocd_manifests "$app" "$main_sha" >"${work}/${app}-main.yaml" ||
+    die "argocd could not render ${app} at ${main_sha}"
+  argocd_manifests "$app" "$feature_sha" >"${work}/${app}-feature.yaml" ||
+    die "argocd could not render ${app} at ${feature_sha}"
+
+  if diff -q "${work}/${app}-main.yaml" "${work}/${app}-feature.yaml" >/dev/null; then
+    die "ArgoCD renders ${app} identically at both commits, so this asserts nothing"
+  fi
+
+  argo_diff="${work}/${app}-argo.diff"
+  diff_body "${work}/${app}-main.yaml" "${work}/${app}-feature.yaml" >"$argo_diff"
+
+  compare_diff="${work}/${app}-compare.diff"
+  section_diff "$out" "$app" >"$compare_diff"
+
+  if [[ ! -s "$compare_diff" ]]; then
+    bad "argo-compare reported no diff for ${app}"
+    continue
+  fi
+
+  while read -r line; do
+    [[ -n "$line" ]] || continue
+    if grep -qxF -e "$line" "$compare_diff"; then
+      ok "${app}: argo-compare reports ${line}"
+    else
+      bad "${app}: argo-compare is missing ArgoCD's change: ${line}"
+    fi
+  done <"$argo_diff"
+
+  while read -r line; do
+    [[ -n "$line" ]] || continue
+    if grep -qxF -e "$line" "$argo_diff"; then
+      ok "${app}: ArgoCD confirms ${line}"
+    else
+      bad "${app}: argo-compare reports a change ArgoCD does not: ${line}"
+    fi
+  done <"$compare_diff"
+done
+
+# Each element's banner carries its own name, so the two diffs are distinct and
+# a run that attributed one Application's diff to the other fails above rather
+# than passing on an identical change.
+assert_grep "${work}/gen-dev-feature.yaml" 'banner: second-dev' "gen-dev renders its own element"
+assert_grep "${work}/gen-prod-feature.yaml" 'banner: second-prod' "gen-prod renders its own element"
+
+phase_end generated-parity

--- a/test/e2e/scripts/seed-gitea.sh
+++ b/test/e2e/scripts/seed-gitea.sh
@@ -31,6 +31,12 @@ for app in demo addon; do
     >"${work}/apps/${app}.yaml"
 done
 
+# The anchored ApplicationSet has to live in the repo as well as in the cluster:
+# charts/generated's anchor resolves it by repo path, and a missing file there
+# surfaces as the confusing "file is empty".
+sed "s|REPO_URL|${ORIGIN_URL}|g" "${E2E_DIR}/fixtures/appset-generated.yaml" \
+  >"${work}/apps/generated-appset.yaml"
+
 git -C "$work" add -A
 git -C "$work" commit -qm "seed gitops fixtures"
 
@@ -50,6 +56,12 @@ grep -qE '^[[:space:]]*replicaCount: 3$' "${work}/apps/demo.yaml" ||
 sed -i -E 's/^message: hello$/message: world/' "${work}/charts/addon/values.yaml"
 grep -qx 'message: world' "${work}/charts/addon/values.yaml" ||
   die "the feature-branch addon chart change did not apply"
+
+# The anchored ApplicationSet's chart changes while its manifest stays put, so
+# the change reaches argo-compare only through charts/generated's anchor.
+sed -i -E 's/^banner: first$/banner: second/' "${work}/charts/generated/values.yaml"
+grep -qx 'banner: second' "${work}/charts/generated/values.yaml" ||
+  die "the feature-branch generated chart change did not apply"
 
 mkdir -p "${work}/clusters/prod"
 printf 'cluster: prod\nreplicas: 4\n' >"${work}/clusters/prod/config.yaml"


### PR DESCRIPTION
`render-parity` covers a plain Application, which left the ApplicationSet flow's own output — the largest feature in this codebase — with nothing checking it end to end. This closes that.

`charts/generated` is anchored to an **ApplicationSet**, so a change to that chart reaches argo-compare through the anchor and is compared per generated Application, each against ArgoCD's own rendering at both commits, in both directions. That exercises the whole #166 path: anchor → expansion → per-Application render → diff.

Each element renders a banner carrying its own name. Without that the two generated Applications produced an *identical* diff, so a run attributing one's change to the other would have passed; a mutation confirms it now fails with 4 errors.

Also fixed: the anchored ApplicationSet manifest is seeded into the repo as well as applied to the cluster. The anchor resolves it by repo path, and a missing file there surfaces only as `file is empty` — which is how I found it.

Verified by a clean-room `task e2e` from a deleted cluster: all four phases green, plus `task lint` (shellcheck + the offline `lib.bats`).

Stacked on #169.