### PR TITLE
test(e2e): check the template functions against ArgoCD's own

### DIFF
--- a/internal/app/e2e_parity_test.go
+++ b/internal/app/e2e_parity_test.go
@@ -4,6 +4,7 @@ package app
 
 import (
 	"encoding/json"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -47,7 +48,7 @@ func TestE2EApplicationSetParity(t *testing.T) {
 
 	tree := branchTree(t, repoDir, branch)
 
-	for _, name := range []string{"e2e-list", "e2e-git-dir", "e2e-git-file", "e2e-lifecycle"} {
+	for _, name := range []string{"e2e-list", "e2e-git-dir", "e2e-git-file", "e2e-lifecycle", "e2e-funcs", "e2e-git-values"} {
 		t.Run(name, func(t *testing.T) {
 			manifest := filepath.Join(fixturesDir, strings.Replace(name, "e2e-", "appset-", 1)+".yaml")
 			raw, err := os.ReadFile(manifest) // #nosec G304 -- a lab fixture path
@@ -161,7 +162,8 @@ func normalizeGenerated(t *testing.T, apps []models.Application) []generatedApp 
 }
 
 // canonicalYAML re-marshals a values block so the comparison is about content
-// rather than the indentation each side's templating happened to emit.
+// rather than the indentation each side's templating happened to emit. It fails
+// the test if the block is not exactly one YAML document.
 func canonicalYAML(t *testing.T, values string) string {
 	t.Helper()
 
@@ -169,8 +171,15 @@ func canonicalYAML(t *testing.T, values string) string {
 		return ""
 	}
 
+	// A decoder rather than Unmarshal: a values block whose indentation breaks
+	// mid-way parses as two documents, and Unmarshal returns the first without
+	// complaint, so half the block would silently drop out of the comparison.
+	decoder := yaml.NewDecoder(strings.NewReader(values))
+
 	var parsed any
-	require.NoError(t, yaml.Unmarshal([]byte(values), &parsed), "values is not YAML: %q", values)
+	require.NoError(t, decoder.Decode(&parsed), "values is not YAML: %q", values)
+	require.ErrorIs(t, decoder.Decode(new(any)), io.EOF, "values is more than one YAML document: %q", values)
+
 	out, err := yaml.Marshal(parsed)
 	require.NoError(t, err)
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -39,6 +39,23 @@ Compiling that package's tests needs the generated mocks, which are gitignored,
 so `phases` and `appset-parity` depend on the root Taskfile's `mocks` task. A
 checkout that has never run `task test` has none, which is the state CI starts in.
 
+Two of its fixtures exist for the parts of expansion that are pure
+reimplementation, where a self-consistent unit test proves nothing:
+
+- `appset-funcs.yaml` drives the template functions argo-compare copies from
+  ArgoCD's own map — `slugify`, `normalize`, `toYaml`, `fromYaml` and
+  `fromYamlArray`. Each result lands in a compared field: `slugify` in the name
+  and release name, the rest in the values block. Its three `slugify` call sites
+  pin all of the argument forms: a length short enough to truncate, the same
+  length with the smart-truncate flag off, and one with no arguments at all
+  against a name long enough that the default 50-character cap shows. `nindent`
+  is plumbing only — the comparison re-marshals the values block, so indent
+  cannot diverge.
+- `appset-git-values.yaml` drives the git generator's `values:` block, which
+  ArgoCD renders against the generator's parameters and hands back under a
+  `.values` prefix. Both entries reach compared fields, so dropping the block or
+  the prefix fails rather than producing a quietly different name.
+
 It compares a projection of each generated Application — name, source
 repoURL/path/chart/targetRevision, and the rendered `helm.releaseName` and
 `helm.values` — because ArgoCD also stamps ownership, finalizers and status that

--- a/test/e2e/fixtures/appset-funcs.yaml
+++ b/test/e2e/fixtures/appset-funcs.yaml
@@ -1,0 +1,51 @@
+# The template functions argo-compare reimplements from ArgoCD's own map, each
+# landing in a field appset-parity compares: slugify in the name and release
+# name, and normalize, toYaml, fromYaml and fromYamlArray in the values block.
+# nindent is plumbing here — canonicalYAML re-marshals, so indent cannot differ.
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: e2e-funcs
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - list:
+        elements:
+          - team: "Platform Engineering & Site Reliability Enablement Guild"
+            config: |
+              replicaCount: 2
+              image:
+                tag: "1.0.0"
+            extras: '["alpha", "beta"]'
+          - team: "Data / ML Crew"
+            config: |
+              replicaCount: 4
+              image:
+                tag: "1.0.0"
+            extras: '["gamma"]'
+  template:
+    metadata:
+      name: 'fn-{{ slugify 12 .team }}'
+      namespace: argocd
+    spec:
+      project: default
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: 'fn-{{ slugify 12 .team }}'
+      source:
+        repoURL: REPO_URL
+        path: charts/demo
+        targetRevision: main
+        helm:
+          releaseName: 'fn-{{ slugify 12 false .team }}'
+          # Built as one map and emitted once: interleaving nindent output with
+          # literal lines puts them at different indents, and the result parses
+          # as two documents whose second half is silently dropped.
+          values: |
+            {{- $v := fromYaml .config -}}
+            {{- $_ := set $v "team" (normalize .team) -}}
+            {{- $_ := set $v "extras" (fromYamlArray .extras) -}}
+            {{- $_ := set $v "defaultSlug" (slugify .team) -}}
+            {{- toYaml $v | nindent 12 }}

--- a/test/e2e/fixtures/appset-git-values.yaml
+++ b/test/e2e/fixtures/appset-git-values.yaml
@@ -1,0 +1,38 @@
+# The git generator's own `values:` block, which ArgoCD renders against the
+# generator's parameters and exposes back under a `.values` prefix. Both entries
+# reach compared fields, so a generator that skipped the block or dropped the
+# prefix would fail the phase rather than quietly producing a different name.
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: e2e-git-values
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - git:
+        repoURL: REPO_URL
+        revision: main
+        directories:
+          - path: clusters/*
+        values:
+          cluster: '{{ .path.basename }}'
+          release: 'gv-{{ .path.basenameNormalized }}'
+  template:
+    metadata:
+      name: '{{ .values.release }}'
+      namespace: argocd
+    spec:
+      project: default
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: '{{ .values.cluster }}'
+      source:
+        repoURL: REPO_URL
+        path: charts/demo
+        targetRevision: main
+        helm:
+          releaseName: '{{ .values.release }}'
+          values: |
+            cluster: "{{ .values.cluster }}"

--- a/test/e2e/scripts/apply-appsets.sh
+++ b/test/e2e/scripts/apply-appsets.sh
@@ -18,6 +18,8 @@ declare -A want=(
   [e2e-generated]=2
   # Applied so the controller vouches for the baseline the lifecycle phase uses.
   [e2e-lifecycle]=2
+  [e2e-funcs]=2
+  [e2e-git-values]=2
 )
 
 for name in "${!want[@]}"; do

--- a/test/e2e/scripts/appset-parity.sh
+++ b/test/e2e/scripts/appset-parity.sh
@@ -27,7 +27,7 @@ assert_grep "$out" '^ok[[:space:]]' "expansion matches the ArgoCD controller"
 
 # Each ApplicationSet is asserted separately, so one passing subtest cannot stand
 # in for the others.
-fixtures=(e2e-list e2e-git-dir e2e-git-file e2e-lifecycle)
+fixtures=(e2e-list e2e-git-dir e2e-git-file e2e-lifecycle e2e-funcs e2e-git-values)
 for name in "${fixtures[@]}"; do
   assert_grep "$out" "^[[:space:]]+--- PASS: TestE2EApplicationSetParity/${name}" \
     "${name} parity"


### PR DESCRIPTION
Two fixtures join `appset-parity`, both covering parts of expansion that are pure reimplementation and so cannot be established by any amount of self-consistent unit testing.

`appset-funcs.yaml` drives `slugify`, `normalize`, `toYaml`, `fromYaml` and `fromYamlArray`, each landing in a field the phase compares. Its three `slugify` call sites cover every argument form: an explicit length, the same length with smart truncation off, and no arguments at all against a name long enough for the default 50-character cap to show — so the defaults in `slugify.go`, which are a claim about ArgoCD's behaviour, are checked rather than assumed.

`appset-git-values.yaml` drives the git generator's `values:` block and the `.values` prefix ArgoCD exposes the results under.

`canonicalYAML` now requires the values block to be exactly one YAML document. This was found the hard way: the first version of `appset-funcs.yaml` interleaved `nindent` output with literal lines, producing a block that parses as two documents. `yaml.Unmarshal` returns the first without complaint, so `normalize` and `fromYamlArray` were silently dropped from the comparison and the fixture passed while proving nothing.

`nindent` is deliberately not claimed as covered — the comparison re-marshals, so indentation cannot diverge.

Stacked on #172 (stack #170).