### PR TITLE
fix(appset): stop warning about files that only mention the kind

### DIFF
--- a/internal/app/appset_discovery.go
+++ b/internal/app/appset_discovery.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io/fs"
 	"path"
@@ -215,9 +216,9 @@ func mergePaths(base, extra []string) []string {
 }
 
 // readApplicationSet returns the expandable ApplicationSet at fullPath, nil when
-// the file is not one, or an error when a file that looks like one cannot be
-// used. The caller reports that rather than failing, so a single broken
-// manifest does not stop a run it may have nothing to do with.
+// the file is not one, or an error when the file cannot be read or declares the
+// kind without being usable. The caller reports that rather than failing, so a
+// single broken manifest does not stop a run it may have nothing to do with.
 func readApplicationSet(fileReader ports.FileReader, fullPath, rel string) (*models.ApplicationSet, error) {
 	if ext := path.Ext(rel); ext != ".yaml" && ext != ".yml" {
 		return nil, nil
@@ -235,7 +236,12 @@ func readApplicationSet(fileReader ports.FileReader, fullPath, rel string) (*mod
 	}
 
 	appSet, err := parseApplicationSetContent(content)
-	if err != nil {
+	switch {
+	// The word appeared in prose or in another kind's manifest, so the file
+	// never claimed to be an ApplicationSet and warning about it is noise.
+	case errors.Is(err, models.ErrEmptyFile), errors.Is(err, models.ErrNotApplicationSet):
+		return nil, nil
+	case err != nil:
 		return nil, err
 	}
 

--- a/internal/app/appset_discovery_test.go
+++ b/internal/app/appset_discovery_test.go
@@ -66,7 +66,8 @@ spec:
 
 // seedDiscoveryTree writes the manifests a scan should find, alongside files it
 // must ignore: a list-generator ApplicationSet, a plain Application, an
-// unparseable manifest, and one inside a dot directory.
+// unparseable manifest, one in a dot directory, two that merely mention the
+// kind, and one that declares it but cannot be expanded.
 func seedDiscoveryTree(t *testing.T) (afero.Fs, string) {
 	t.Helper()
 
@@ -103,6 +104,31 @@ spec:
 	write("apps/broken.yaml", "kind: ApplicationSet\nmetadata:\n   bad: indent\n  worse\n")
 	write("apps/notes.txt", "kind: ApplicationSet\n")
 	write(".hidden/addons.yaml", discoverableAppSet)
+
+	// Files that merely mention the word: a chart description and another kind.
+	write("charts/demo/Chart.yaml", "apiVersion: v2\nname: demo\ndescription: An ApplicationSet example\nversion: 0.1.0\n")
+	write("apps/configmap.yaml", "kind: ConfigMap\nmetadata:\n  name: notes\ndata:\n  hint: ApplicationSet\n")
+
+	// Declares the kind and fails validation, so the scan must still report it.
+	write("apps/legacy.yaml", `apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: legacy
+  namespace: argocd
+spec:
+  generators:
+    - list:
+        elements:
+          - cluster: dev
+  template:
+    metadata:
+      name: '{{ cluster }}'
+    spec:
+      source:
+        repoURL: https://charts.example.com
+        chart: demo
+        targetRevision: 1.0.0
+`)
 
 	return filesystem, root
 }
@@ -193,9 +219,36 @@ func TestDiscoverApplicationSetsReportsUnparseableManifests(t *testing.T) {
 		root, discoveryOrigin, "main", []string{"clusters/dev/values.yaml"})
 
 	require.NoError(t, err)
-	require.Len(t, unusable, 1)
+	require.Len(t, unusable, 2)
 	assert.Contains(t, unusable[0], "apps/broken.yaml")
 	assert.Contains(t, unusable[0], "did not find expected key")
+
+	// The other half of the contract: a manifest that declares the kind and
+	// fails validation is still worth a word.
+	assert.Contains(t, unusable[1], "apps/legacy.yaml")
+	assert.Contains(t, unusable[1], "goTemplate: true")
+}
+
+// TestDiscoverApplicationSetsIgnoresIncidentalMentions keeps a file that merely
+// contains the word out of the unusable list: it never claimed to be a manifest.
+func TestDiscoverApplicationSetsIgnoresIncidentalMentions(t *testing.T) {
+	filesystem, root := seedDiscoveryTree(t)
+
+	matched, unusable, err := DiscoverApplicationSets(filesystem, utils.OsFileReader{},
+		root, discoveryOrigin, "main", []string{"clusters/dev/values.yaml"})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"apps/addons.yaml"}, matched)
+
+	// An exact set, so the assertion cannot pass on an empty scan.
+	require.Len(t, unusable, 2)
+	assert.Contains(t, unusable[0], "apps/broken.yaml")
+	assert.Contains(t, unusable[1], "apps/legacy.yaml")
+
+	// Named, so dropping either fixture fails here instead of passing quietly.
+	joined := strings.Join(unusable, "\n")
+	assert.NotContains(t, joined, "Chart.yaml")
+	assert.NotContains(t, joined, "configmap.yaml")
 }
 
 // discoverableFileAppSet reads parameters out of matched files, including one


### PR DESCRIPTION
Closes #175.

The discovery scan pre-filters candidates on the substring `ApplicationSet`, so a Chart.yaml description, a Taskfile or a values file reached the parser and produced a warning `--ignore` could not silence. `ErrEmptyFile` and `ErrNotApplicationSet` now skip the file silently, since it never claimed to be a manifest.

A file declaring `kind: ApplicationSet` that then fails to parse or validate still warns — the new `apps/legacy.yaml` fixture pins that half.

Multi-document YAML stays out of scope: only the first document is decoded, so a bundle hiding an ApplicationSet after a `---` now skips without a word. It was never expanded before either; handling it needs a `yaml.Decoder` loop.